### PR TITLE
Fix async event loop error in system prompt loading

### DIFF
--- a/openspec/changes/archive/2026-04-28-fix-system-prompt-async/.openspec.yaml
+++ b/openspec/changes/archive/2026-04-28-fix-system-prompt-async/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-28

--- a/openspec/changes/archive/2026-04-28-fix-system-prompt-async/design.md
+++ b/openspec/changes/archive/2026-04-28-fix-system-prompt-async/design.md
@@ -1,0 +1,34 @@
+## Context
+
+问题代码在 `runner.py` 第 156 行：
+```python
+self._system_prompt_cache = asyncio.get_event_loop().run_until_complete(
+    load_system_prompt(self.config.workspace_path())
+)
+```
+
+这在一个已经运行的 async 上下文中调用了 `run_until_complete()`，这是不允许的。
+
+## Goals / Non-Goals
+
+**Goals:**
+- 修复 async event loop 错误
+- 正确加载 system prompt
+
+**Non-Goals:**
+- 改变 system prompt 加载的时机或行为
+
+## Decisions
+
+### 在 `__aenter__` 中预加载 system prompt
+
+**方案：** 将 system prompt 加载移到 `__aenter__` 中，直接 `await` 协程。
+
+**原因：**
+- `__aenter__` 是 async 上下文，可以直接 await
+- 启动时加载一次，后续请求直接使用缓存
+- 避免在请求处理中调用 `run_until_complete`
+
+## Risks / Trade-offs
+
+- 无风险，这是正确的 async 编程模式

--- a/openspec/changes/archive/2026-04-28-fix-system-prompt-async/proposal.md
+++ b/openspec/changes/archive/2026-04-28-fix-system-prompt-async/proposal.md
@@ -1,0 +1,22 @@
+## Why
+
+`_get_cached_system_prompt` 方法在已运行的 event loop 中调用 `run_until_complete()`，导致 `RuntimeError: This event loop is already running`。
+
+## What Changes
+
+- 修复 `runner.py` 中的 system prompt 加载逻辑
+- 在 `__aenter__` 中预加载 system prompt，而不是在请求处理时同步加载
+
+## Capabilities
+
+### New Capabilities
+
+<!-- No new capabilities -->
+
+### Modified Capabilities
+
+<!-- No spec-level requirement changes - this is a bug fix -->
+
+## Impact
+
+- `src/psi_agent/session/runner.py`: 修改 `_get_cached_system_prompt` 和 `__aenter__`

--- a/openspec/changes/archive/2026-04-28-fix-system-prompt-async/specs/no-spec-changes/spec.md
+++ b/openspec/changes/archive/2026-04-28-fix-system-prompt-async/specs/no-spec-changes/spec.md
@@ -1,0 +1,3 @@
+## ADDED Requirements
+
+<!-- No spec-level requirements - this is a bug fix only -->

--- a/openspec/changes/archive/2026-04-28-fix-system-prompt-async/tasks.md
+++ b/openspec/changes/archive/2026-04-28-fix-system-prompt-async/tasks.md
@@ -1,0 +1,5 @@
+## 1. Fix
+
+- [x] 1.1 Move system prompt loading to `__aenter__` in runner.py
+- [x] 1.2 Remove `_get_cached_system_prompt` method or make it sync
+- [x] 1.3 Update `_build_messages` to use the cached value directly

--- a/src/psi_agent/session/runner.py
+++ b/src/psi_agent/session/runner.py
@@ -68,6 +68,7 @@ class SessionRunner:
         self.registry = ToolRegistry()
         self.history: History | None = None
         self.client: aiohttp.ClientSession | None = None
+        self._system_prompt_cache: str | None = None
 
     async def __aenter__(self) -> SessionRunner:
         """Initialize session resources."""
@@ -78,6 +79,9 @@ class SessionRunner:
         tools_dir = self.config.tools_dir()
         load_all_tools(tools_dir, self.registry)
         logger.info(f"Loaded {len(self.registry.tools)} tools")
+
+        # Load system prompt
+        self._system_prompt_cache = await load_system_prompt(self.config.workspace_path())
 
         # Initialize HTTP client for psi-ai
         connector = aiohttp.UnixConnector(path=str(self.config.ai_socket_path()))
@@ -133,30 +137,13 @@ class SessionRunner:
         messages = []
 
         # Add system prompt if available
-        system_prompt = self._get_cached_system_prompt()
-        if system_prompt:
-            messages.append({"role": "system", "content": system_prompt})
+        if self._system_prompt_cache:
+            messages.append({"role": "system", "content": self._system_prompt_cache})
 
         # Add history
         messages.extend(self.history.messages)
 
         return messages
-
-    _system_prompt_cache: str | None = None
-
-    def _get_cached_system_prompt(self) -> str | None:
-        """Get cached system prompt or load it.
-
-        Returns:
-            System prompt string or None.
-        """
-        if self._system_prompt_cache is None:
-            import asyncio
-
-            self._system_prompt_cache = asyncio.get_event_loop().run_until_complete(
-                load_system_prompt(self.config.workspace_path())
-            )
-        return self._system_prompt_cache
 
     async def _run_conversation(self, messages: list[dict[str, Any]]) -> dict[str, Any]:
         """Run conversation with LLM, handling tool calls.


### PR DESCRIPTION
## Summary
- Fix `RuntimeError: This event loop is already running` when processing requests in psi-session
- Move system prompt loading to `__aenter__` where it can be properly awaited
- Remove the problematic `_get_cached_system_prompt()` method that called `run_until_complete()` inside an already-running event loop

## Test plan
- [x] All 38 tests pass
- [x] Manual testing with psi-session and psi-channel-cli works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)