### PR TITLE
Add psi-ai-anthropic-messages component for Anthropic Messages API

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -184,10 +184,102 @@ Task instructions here...
 **规范：**
 - 文件：`systems/system.py`
 - 必要函数：
-  - `build_system_prompt()` — 构造系统 prompt
-  - `compact_history()` — 对过长上下文进行压缩
+  - `async def build_system_prompt() -> str` — 构造系统 prompt，自动扫描 skills/ 目录
+  - `async def compact_history(history: list[dict[str, str]], max_tokens: int = 4000) -> list[dict[str, str]]` — 压缩过长对话历史
 
-**注意：具体接口待定，未来有新信息时需在此更新。**
+**build_system_prompt() 行为：**
+- 扫描 `workspace/skills/` 目录下的所有 SKILL.md 文件
+- 解析 YAML frontmatter 提取 description 字段
+- 将所有 skill description 组合成 system prompt 返回
+- 使用异步 IO 进行文件读取
+
+**compact_history() 行为：**
+- 接收对话历史和最大 token 限制
+- 当历史超过限制时，使用 LLM 摘要压缩旧消息
+- 返回压缩后的消息列表，保留近期上下文
+
+**示例：**
+
+```python
+# systems/system.py
+import re
+from pathlib import Path
+
+
+async def build_system_prompt() -> str:
+    """Build system prompt by scanning skills directory asynchronously.
+
+    Returns:
+        System prompt string containing skill descriptions and guidelines.
+    """
+    skills_dir = Path(__file__).parent.parent / "skills"
+    skill_descriptions: list[str] = []
+
+    if skills_dir.exists():
+        for skill_path in skills_dir.iterdir():
+            if skill_path.is_dir():
+                skill_md = skill_path / "SKILL.md"
+                if skill_md.exists():
+                    description = await _parse_skill_description(skill_md)
+                    if description:
+                        skill_descriptions.append(f"- {skill_path.name}: {description}")
+
+    system_prompt = """You are a helpful assistant with access to tools and skills.
+
+## Available Skills
+
+"""
+    if skill_descriptions:
+        system_prompt += "\n".join(skill_descriptions)
+    else:
+        system_prompt += "No skills configured."
+
+    system_prompt += """
+
+## Guidelines
+
+- Use tools when appropriate to accomplish tasks
+- When you need a skill's detailed instructions, read the SKILL.md file
+"""
+
+    return system_prompt
+
+
+async def _parse_skill_description(skill_md_path: Path) -> str | None:
+    """Parse SKILL.md to extract description from YAML frontmatter."""
+    content = skill_md_path.read_text()
+
+    frontmatter_match = re.match(r"^---\n(.*?)\n---", content, re.DOTALL)
+    if not frontmatter_match:
+        return None
+
+    frontmatter = frontmatter_match.group(1)
+    description_match = re.search(r"^description:\s*(.+)$", frontmatter, re.MULTILINE)
+    if description_match:
+        return description_match.group(1).strip()
+
+    return None
+
+
+async def compact_history(
+    history: list[dict[str, str]], max_tokens: int = 4000
+) -> list[dict[str, str]]:
+    """Compact conversation history using LLM summarization.
+
+    Args:
+        history: List of conversation messages with role and content.
+        max_tokens: Maximum tokens to keep in history.
+
+    Returns:
+        Compacted history list.
+    """
+    # Framework implementation - replace with LLM summarization
+    max_messages = 20
+    if len(history) > max_messages:
+        return history[-max_messages:]
+
+    return history
+```
 
 ## 编码规范
 

--- a/openspec/changes/archive/2026-04-28-add-psi-ai-anthropic-messages/.openspec.yaml
+++ b/openspec/changes/archive/2026-04-28-add-psi-ai-anthropic-messages/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-28

--- a/openspec/changes/archive/2026-04-28-add-psi-ai-anthropic-messages/design.md
+++ b/openspec/changes/archive/2026-04-28-add-psi-ai-anthropic-messages/design.md
@@ -1,0 +1,67 @@
+## Context
+
+psi-agent uses a component architecture where `psi-ai-*` components handle LLM provider communication. The existing `psi-ai-openai-completions` component serves as the reference implementation, using:
+- HTTP over Unix socket for IPC with psi-session
+- aiohttp for async HTTP server/client
+- OpenAI chat completion format for request/response
+
+Anthropic's Messages API differs from OpenAI's chat completions:
+- System prompt is a top-level `system` parameter, not a message in the array
+- Content is an array of blocks (text, image) rather than a string
+- Tool use is native with structured `tool_use` and `tool_result` content blocks
+- Streaming uses SSE with typed events (`message_start`, `content_block_delta`, etc.)
+
+## Goals / Non-Goals
+
+**Goals:**
+- Implement `psi-ai-anthropic-messages` following the same architecture as `psi-ai-openai-completions`
+- Support Anthropic Messages API with streaming
+- Enable native tool use and multimodal content
+- Maintain async-first design with proper error handling
+
+**Non-Goals:**
+- Converting between OpenAI and Anthropic formats (psi-session handles format adaptation)
+- Supporting legacy Anthropic APIs (only Messages API v1)
+- Caching or rate limiting (handled by upstream or future middleware)
+
+## Decisions
+
+### Use Official Anthropic SDK
+
+**Decision**: Use the `anthropic` Python SDK for API communication.
+
+**Rationale**:
+- Official SDK handles authentication, retries, and error parsing
+- Type hints for all request/response structures
+- Built-in streaming support with async iterators
+- Simpler than maintaining raw HTTP implementation
+
+**Alternative considered**: Direct aiohttp calls (like `psi-ai-openai-completions`). Rejected because Anthropic's streaming protocol is more complex, and the SDK provides better ergonomics.
+
+### Server Accepts Anthropic Format Directly
+
+**Decision**: The server endpoint accepts Anthropic Messages API format directly at `/v1/messages`.
+
+**Rationale**:
+- No format conversion overhead
+- psi-session can send Anthropic-native requests
+- Simpler implementation with fewer transformation bugs
+
+**Alternative considered**: Accept OpenAI format and convert. Rejected because:
+- Conversion loses Anthropic-specific features (content blocks, tool_result)
+- psi-session should handle format selection based on provider
+
+### Config Mirrors OpenAI Component
+
+**Decision**: Use same config structure: `session_socket`, `model`, `api_key`, `base_url`.
+
+**Rationale**:
+- Consistent CLI interface across psi-ai-* components
+- Easy to swap components without changing invocation
+- `base_url` enables custom endpoints (Bedrock, Vertex AI)
+
+## Risks / Trade-offs
+
+- **SDK dependency**: Adds `anthropic` package (~10MB). Acceptable for native support.
+- **Format mismatch**: psi-session must know to send Anthropic format. Documentation will clarify.
+- **Streaming complexity**: Anthropic streaming has more event types. SDK handles parsing, but server must forward correctly.

--- a/openspec/changes/archive/2026-04-28-add-psi-ai-anthropic-messages/proposal.md
+++ b/openspec/changes/archive/2026-04-28-add-psi-ai-anthropic-messages/proposal.md
@@ -1,0 +1,33 @@
+## Why
+
+psi-agent currently only supports OpenAI-compatible chat completion APIs through `psi-ai-openai-completions`. Anthropic's Claude API uses a different message format (Messages API) with distinct features like system prompts as a separate field, content blocks for multimodal input, and native tool use. Adding `psi-ai-anthropic-messages` enables native Anthropic API support, unlocking Claude-specific capabilities while maintaining the component architecture.
+
+## What Changes
+
+- Add new `psi-ai-anthropic-messages` component under `src/psi_agent/ai/anthropic_messages/`
+- Implement HTTP server over Unix socket (same pattern as `psi-ai-openai-completions`)
+- Implement Anthropic Messages API client with streaming support
+- Add CLI entry point `psi-ai-anthropic-messages`
+- Support Anthropic-specific features:
+  - System prompt as separate parameter
+  - Content blocks (text, image) for multimodal input
+  - Native tool use with `tools` parameter
+  - Streaming with `stream: true`
+
+## Capabilities
+
+### New Capabilities
+
+- `anthropic-messages-server`: HTTP server for Anthropic Messages API over Unix socket, following the same architecture pattern as `psi-ai-openai-completions`
+- `anthropic-messages-client`: Async client for Anthropic Messages API with streaming support, content blocks, and tool use
+
+### Modified Capabilities
+
+None. This is a new component with no changes to existing specs.
+
+## Impact
+
+- **New code**: `src/psi_agent/ai/anthropic_messages/` module with `__init__.py`, `config.py`, `client.py`, `server.py`, `cli.py`
+- **Dependencies**: Add `anthropic` SDK to project dependencies
+- **Entry points**: Add `psi-ai-anthropic-messages` CLI command to `pyproject.toml`
+- **No breaking changes**: Existing components remain unchanged

--- a/openspec/changes/archive/2026-04-28-add-psi-ai-anthropic-messages/specs/anthropic-messages-client/spec.md
+++ b/openspec/changes/archive/2026-04-28-add-psi-ai-anthropic-messages/specs/anthropic-messages-client/spec.md
@@ -1,0 +1,73 @@
+## ADDED Requirements
+
+### Requirement: Client sends messages to Anthropic API
+
+The client SHALL send message requests to Anthropic Messages API endpoint.
+
+#### Scenario: Non-streaming request
+- **WHEN** client sends request with `stream: false`
+- **THEN** client SHALL return complete response as dict
+
+#### Scenario: Streaming request
+- **WHEN** client sends request with `stream: true`
+- **THEN** client SHALL return async generator yielding SSE chunks
+
+### Requirement: Client handles authentication
+
+The client SHALL include API key in request headers for authentication.
+
+#### Scenario: Valid API key
+- **WHEN** client has valid API key configured
+- **THEN** client SHALL include `x-api-key` header with all requests
+
+#### Scenario: Invalid API key
+- **WHEN** API key is invalid or expired
+- **THEN** client SHALL return error dict with status_code 401
+
+### Requirement: Client supports content blocks
+
+The client SHALL support Anthropic content block format in messages.
+
+#### Scenario: Text content block
+- **WHEN** message contains text content block
+- **THEN** client SHALL send content block to API unchanged
+
+#### Scenario: Image content block
+- **WHEN** message contains image content block (base64 or URL)
+- **THEN** client SHALL send content block to API unchanged
+
+### Requirement: Client supports tool use
+
+The client SHALL support Anthropic tool definitions and tool result content blocks.
+
+#### Scenario: Tool definition provided
+- **WHEN** request includes `tools` parameter
+- **THEN** client SHALL include tools in API request
+
+#### Scenario: Tool result in message
+- **WHEN** message contains `tool_result` content block
+- **THEN** client SHALL send tool result to API unchanged
+
+### Requirement: Client handles connection errors
+
+The client SHALL handle network errors gracefully.
+
+#### Scenario: Connection failure
+- **WHEN** network connection to API fails
+- **THEN** client SHALL return error dict with status_code 500 and error message
+
+#### Scenario: Request timeout
+- **WHEN** API request exceeds timeout
+- **THEN** client SHALL return error dict with status_code 500 and timeout message
+
+### Requirement: Client uses async context manager
+
+The client SHALL implement async context manager protocol for resource management.
+
+#### Scenario: Enter context
+- **WHEN** client enters async context
+- **THEN** client SHALL initialize HTTP session
+
+#### Scenario: Exit context
+- **WHEN** client exits async context
+- **THEN** client SHALL close HTTP session and clean up resources

--- a/openspec/changes/archive/2026-04-28-add-psi-ai-anthropic-messages/specs/anthropic-messages-server/spec.md
+++ b/openspec/changes/archive/2026-04-28-add-psi-ai-anthropic-messages/specs/anthropic-messages-server/spec.md
@@ -1,0 +1,57 @@
+## ADDED Requirements
+
+### Requirement: Server listens on Unix socket
+
+The server SHALL listen for HTTP requests on a Unix socket path specified in configuration.
+
+#### Scenario: Server starts successfully
+- **WHEN** server is started with valid socket path
+- **THEN** server SHALL create socket file and listen for connections
+
+#### Scenario: Socket file already exists
+- **WHEN** socket file already exists at configured path
+- **THEN** server SHALL remove existing file before creating new socket
+
+### Requirement: Server handles POST /v1/messages
+
+The server SHALL accept POST requests to `/v1/messages` endpoint with Anthropic Messages API format.
+
+#### Scenario: Valid request received
+- **WHEN** POST /v1/messages is received with valid Anthropic request body
+- **THEN** server SHALL forward request to Anthropic API and return response
+
+#### Scenario: Invalid JSON body
+- **WHEN** POST /v1/messages is received with malformed JSON
+- **THEN** server SHALL return HTTP 400 with error message
+
+### Requirement: Server supports streaming responses
+
+The server SHALL support streaming responses when `stream: true` is in request body.
+
+#### Scenario: Streaming request
+- **WHEN** request includes `stream: true`
+- **THEN** server SHALL return SSE stream with Anthropic streaming events
+
+#### Scenario: Non-streaming request
+- **WHEN** request does not include `stream` or `stream: false`
+- **THEN** server SHALL return complete JSON response
+
+### Requirement: Server forwards errors appropriately
+
+The server SHALL map Anthropic API errors to appropriate HTTP status codes.
+
+#### Scenario: Authentication failure
+- **WHEN** Anthropic API returns 401 authentication error
+- **THEN** server SHALL return HTTP 401 to client
+
+#### Scenario: Rate limit exceeded
+- **WHEN** Anthropic API returns 429 rate limit error
+- **THEN** server SHALL return HTTP 429 with retry information
+
+### Requirement: Server provides CLI entry point
+
+The server SHALL provide a CLI command `psi-ai-anthropic-messages` for starting the server.
+
+#### Scenario: CLI starts server
+- **WHEN** `psi-ai-anthropic-messages` is invoked with required arguments
+- **THEN** server SHALL start and log connection information

--- a/openspec/changes/archive/2026-04-28-add-psi-ai-anthropic-messages/tasks.md
+++ b/openspec/changes/archive/2026-04-28-add-psi-ai-anthropic-messages/tasks.md
@@ -1,0 +1,41 @@
+## 1. Setup
+
+- [x] 1.1 Add `anthropic` dependency to pyproject.toml
+- [x] 1.2 Create `src/psi_agent/ai/anthropic_messages/` module directory
+- [x] 1.3 Create `config.py` with `AnthropicMessagesConfig` dataclass
+
+## 2. Client Implementation
+
+- [x] 2.1 Create `client.py` with `AnthropicMessagesClient` class
+- [x] 2.2 Implement async context manager protocol (`__aenter__`, `__aexit__`)
+- [x] 2.3 Implement `messages()` method for non-streaming requests
+- [x] 2.4 Implement streaming support with async generator
+- [x] 2.5 Add error handling for authentication, connection, and timeout errors
+
+## 3. Server Implementation
+
+- [x] 3.1 Create `server.py` with `AnthropicMessagesServer` class
+- [x] 3.2 Implement Unix socket server setup with aiohttp
+- [x] 3.3 Implement POST `/v1/messages` endpoint handler
+- [x] 3.4 Implement streaming response handling (SSE)
+- [x] 3.5 Implement error response mapping (401, 429, 500)
+- [x] 3.6 Implement `start()` and `stop()` lifecycle methods
+
+## 4. CLI and Package
+
+- [x] 4.1 Create `cli.py` with tyro CLI entry point
+- [x] 4.2 Create `__init__.py` with public exports
+- [x] 4.3 Add `psi-ai-anthropic-messages` script entry to pyproject.toml
+
+## 5. Testing
+
+- [x] 5.1 Write unit tests for `AnthropicMessagesConfig`
+- [x] 5.2 Write unit tests for `AnthropicMessagesClient` (mocked API)
+- [x] 5.3 Write unit tests for `AnthropicMessagesServer` (mocked client)
+- [x] 5.4 Run full test suite and verify all tests pass
+
+## 6. Quality Checks
+
+- [x] 6.1 Run `ruff check` and fix all lint errors
+- [x] 6.2 Run `ruff format` and ensure code is formatted
+- [x] 6.3 Run `ty check` and fix all type errors

--- a/openspec/changes/archive/2026-04-28-update-systems-in-claude-md/.openspec.yaml
+++ b/openspec/changes/archive/2026-04-28-update-systems-in-claude-md/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-28

--- a/openspec/changes/archive/2026-04-28-update-systems-in-claude-md/design.md
+++ b/openspec/changes/archive/2026-04-28-update-systems-in-claude-md/design.md
@@ -1,0 +1,40 @@
+## Context
+
+The systems/ directory documentation in CLAUDE.md was left incomplete with a "具体接口待定" (interface pending) placeholder. The actual implementation was completed in commit bc5f484507fd0350d9a4853bc5ab4229ffaa31b0, which added:
+
+1. A complete `build_system_prompt()` async function that scans skills/ directory
+2. A `compact_history()` async function framework for LLM-based history compression
+3. An example implementation in `examples/a-simple-bash-only-workspace/systems/system.py`
+
+The documentation needs to be updated to reflect these actual interfaces.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Update CLAUDE.md with the complete systems/ directory specification
+- Document the async interface signatures and their behavior
+- Provide code examples matching the actual implementation patterns
+- Maintain consistency with existing documentation style
+
+**Non-Goals:**
+- Changing the actual implementation code
+- Adding new features to the systems/ interface
+- Modifying the existing workspace-systems spec
+
+## Decisions
+
+### Decision 1: Document actual implementation from bc5f484
+
+**Rationale:** The commit bc5f484507fd0350d9a4853bc5ab4229ffaa31b0 contains a working implementation that should be documented as-is. This provides developers with accurate reference material.
+
+**Alternatives considered:**
+- Creating new theoretical interfaces - rejected because implementation already exists
+- Waiting for further changes - rejected because current implementation is complete
+
+### Decision 2: Include code examples from the example workspace
+
+**Rationale:** The `examples/a-simple-bash-only-workspace/systems/system.py` provides a concrete reference implementation that developers can copy and adapt.
+
+## Risks / Trade-offs
+
+- **Documentation drift**: Future changes to system.py may not be reflected in CLAUDE.md → Mitigation: Keep examples minimal and focus on interface contracts

--- a/openspec/changes/archive/2026-04-28-update-systems-in-claude-md/proposal.md
+++ b/openspec/changes/archive/2026-04-28-update-systems-in-claude-md/proposal.md
@@ -1,0 +1,26 @@
+## Why
+
+The systems/ directory design was marked as "待定" (pending) in CLAUDE.md, but it has since been fully designed and implemented in commit bc5f484507fd0350d9a4853bc5ab4229ffaa31b0. The documentation needs to be updated to reflect the actual async interfaces and implementation patterns.
+
+## What Changes
+
+- Update the systems/ directory section in CLAUDE.md with complete interface specifications
+- Document the `build_system_prompt()` async function with its skill scanning behavior
+- Document the `compact_history()` async function with its LLM summarization framework
+- Add code examples showing the actual implementation patterns
+- Remove the "具体接口待定" placeholder note
+
+## Capabilities
+
+### New Capabilities
+
+None - this is a documentation update only.
+
+### Modified Capabilities
+
+- `workspace-systems`: Update spec to reflect the completed async interface design (already exists from bc5f484)
+
+## Impact
+
+- CLAUDE.md documentation file
+- Developers referencing the workspace systems/ directory structure

--- a/openspec/changes/archive/2026-04-28-update-systems-in-claude-md/specs/workspace-systems/spec.md
+++ b/openspec/changes/archive/2026-04-28-update-systems-in-claude-md/specs/workspace-systems/spec.md
@@ -1,4 +1,4 @@
-## Requirements
+## MODIFIED Requirements
 
 ### Requirement: systems/ 目录规范
 systems/system.py SHALL 提供两个 async 函数：`build_system_prompt()` 和 `compact_history()`。
@@ -20,25 +20,3 @@ systems/system.py SHALL 提供两个 async 函数：`build_system_prompt()` 和 
 - **THEN** SHALL 使用以下签名：
   - `async def build_system_prompt() -> str`
   - `async def compact_history(history: list[dict[str, str]], max_tokens: int = 4000) -> list[dict[str, str]]`
-
-### Requirement: async bash tool 接口
-tools/bash.py SHALL 提供 async `tool()` 函数，执行 shell 命令。
-
-#### Scenario: 执行命令
-- **WHEN** psi-session 调用 `await tool(command="ls -la")`
-- **THEN** 函数 SHALL 使用 asyncio.create_subprocess_exec 执行命令并返回输出结果
-
-#### Scenario: 命令超时
-- **WHEN** 命令执行超过 timeout 限制
-- **THEN** 函数 SHALL 使用 asyncio.wait_for 返回超时错误信息
-
-### Requirement: SKILL.md description 格式
-workspace/skills/*/SKILL.md 的 description SHALL 仅说明何时使用 skill，不暴露具体行为细节。
-
-#### Scenario: 懒加载 skill
-- **WHEN** psi-session 初始化时读取 skills description
-- **THEN** description SHALL 仅包含"何时使用"提示，具体行为在 SKILL.md 正文
-
-#### Scenario: 解析 SKILL.md
-- **WHEN** build_system_prompt() 读取 SKILL.md
-- **THEN** SHALL 使用异步 IO 正确解析 YAML frontmatter 并提取 description

--- a/openspec/changes/archive/2026-04-28-update-systems-in-claude-md/tasks.md
+++ b/openspec/changes/archive/2026-04-28-update-systems-in-claude-md/tasks.md
@@ -1,0 +1,11 @@
+## 1. Update CLAUDE.md systems/ directory section
+
+- [x] 1.1 Replace the placeholder "具体接口待定" note with complete interface specification
+- [x] 1.2 Document `build_system_prompt()` async function with signature and behavior
+- [x] 1.3 Document `compact_history()` async function with signature and behavior
+- [x] 1.4 Add code example showing the implementation pattern
+
+## 2. Verification
+
+- [x] 2.1 Verify documentation matches actual implementation in examples/a-simple-bash-only-workspace/systems/system.py
+- [x] 2.2 Ensure consistency with existing CLAUDE.md documentation style

--- a/openspec/specs/anthropic-messages-client/spec.md
+++ b/openspec/specs/anthropic-messages-client/spec.md
@@ -1,0 +1,73 @@
+## Requirements
+
+### Requirement: Client sends messages to Anthropic API
+
+The client SHALL send message requests to Anthropic Messages API endpoint.
+
+#### Scenario: Non-streaming request
+- **WHEN** client sends request with `stream: false`
+- **THEN** client SHALL return complete response as dict
+
+#### Scenario: Streaming request
+- **WHEN** client sends request with `stream: true`
+- **THEN** client SHALL return async generator yielding SSE chunks
+
+### Requirement: Client handles authentication
+
+The client SHALL include API key in request headers for authentication.
+
+#### Scenario: Valid API key
+- **WHEN** client has valid API key configured
+- **THEN** client SHALL include `x-api-key` header with all requests
+
+#### Scenario: Invalid API key
+- **WHEN** API key is invalid or expired
+- **THEN** client SHALL return error dict with status_code 401
+
+### Requirement: Client supports content blocks
+
+The client SHALL support Anthropic content block format in messages.
+
+#### Scenario: Text content block
+- **WHEN** message contains text content block
+- **THEN** client SHALL send content block to API unchanged
+
+#### Scenario: Image content block
+- **WHEN** message contains image content block (base64 or URL)
+- **THEN** client SHALL send content block to API unchanged
+
+### Requirement: Client supports tool use
+
+The client SHALL support Anthropic tool definitions and tool result content blocks.
+
+#### Scenario: Tool definition provided
+- **WHEN** request includes `tools` parameter
+- **THEN** client SHALL include tools in API request
+
+#### Scenario: Tool result in message
+- **WHEN** message contains `tool_result` content block
+- **THEN** client SHALL send tool result to API unchanged
+
+### Requirement: Client handles connection errors
+
+The client SHALL handle network errors gracefully.
+
+#### Scenario: Connection failure
+- **WHEN** network connection to API fails
+- **THEN** client SHALL return error dict with status_code 500 and error message
+
+#### Scenario: Request timeout
+- **WHEN** API request exceeds timeout
+- **THEN** client SHALL return error dict with status_code 500 and timeout message
+
+### Requirement: Client uses async context manager
+
+The client SHALL implement async context manager protocol for resource management.
+
+#### Scenario: Enter context
+- **WHEN** client enters async context
+- **THEN** client SHALL initialize HTTP session
+
+#### Scenario: Exit context
+- **WHEN** client exits async context
+- **THEN** client SHALL close HTTP session and clean up resources

--- a/openspec/specs/anthropic-messages-server/spec.md
+++ b/openspec/specs/anthropic-messages-server/spec.md
@@ -1,0 +1,57 @@
+## Requirements
+
+### Requirement: Server listens on Unix socket
+
+The server SHALL listen for HTTP requests on a Unix socket path specified in configuration.
+
+#### Scenario: Server starts successfully
+- **WHEN** server is started with valid socket path
+- **THEN** server SHALL create socket file and listen for connections
+
+#### Scenario: Socket file already exists
+- **WHEN** socket file already exists at configured path
+- **THEN** server SHALL remove existing file before creating new socket
+
+### Requirement: Server handles POST /v1/messages
+
+The server SHALL accept POST requests to `/v1/messages` endpoint with Anthropic Messages API format.
+
+#### Scenario: Valid request received
+- **WHEN** POST /v1/messages is received with valid Anthropic request body
+- **THEN** server SHALL forward request to Anthropic API and return response
+
+#### Scenario: Invalid JSON body
+- **WHEN** POST /v1/messages is received with malformed JSON
+- **THEN** server SHALL return HTTP 400 with error message
+
+### Requirement: Server supports streaming responses
+
+The server SHALL support streaming responses when `stream: true` is in request body.
+
+#### Scenario: Streaming request
+- **WHEN** request includes `stream: true`
+- **THEN** server SHALL return SSE stream with Anthropic streaming events
+
+#### Scenario: Non-streaming request
+- **WHEN** request does not include `stream` or `stream: false`
+- **THEN** server SHALL return complete JSON response
+
+### Requirement: Server forwards errors appropriately
+
+The server SHALL map Anthropic API errors to appropriate HTTP status codes.
+
+#### Scenario: Authentication failure
+- **WHEN** Anthropic API returns 401 authentication error
+- **THEN** server SHALL return HTTP 401 to client
+
+#### Scenario: Rate limit exceeded
+- **WHEN** Anthropic API returns 429 rate limit error
+- **THEN** server SHALL return HTTP 429 with retry information
+
+### Requirement: Server provides CLI entry point
+
+The server SHALL provide a CLI command `psi-ai-anthropic-messages` for starting the server.
+
+#### Scenario: CLI starts server
+- **WHEN** `psi-ai-anthropic-messages` is invoked with required arguments
+- **THEN** server SHALL start and log connection information

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ license = { file = "LICENSE.md" }
 authors = [{ name = "Hao Zhang", email = "hzhangxyz@outlook.com" }]
 dependencies = [
     "aiohttp>=3.13.5",
+    "anthropic>=0.57.1",
     "anyio>=4.13.0",
     "loguru>=0.7.3",
     "tyro>=1.0.13",
@@ -22,6 +23,7 @@ dev = [
 ]
 
 [project.scripts]
+psi-ai-anthropic-messages = "psi_agent.ai.anthropic_messages.cli:main"
 psi-ai-openai-completions = "psi_agent.ai.openai_completions.cli:main"
 
 [build-system]

--- a/src/psi_agent/ai/anthropic_messages/__init__.py
+++ b/src/psi_agent/ai/anthropic_messages/__init__.py
@@ -1,0 +1,7 @@
+"""Anthropic Messages server and client."""
+
+from psi_agent.ai.anthropic_messages.client import AnthropicMessagesClient
+from psi_agent.ai.anthropic_messages.config import AnthropicMessagesConfig
+from psi_agent.ai.anthropic_messages.server import AnthropicMessagesServer
+
+__all__ = ["AnthropicMessagesClient", "AnthropicMessagesServer", "AnthropicMessagesConfig"]

--- a/src/psi_agent/ai/anthropic_messages/cli.py
+++ b/src/psi_agent/ai/anthropic_messages/cli.py
@@ -1,0 +1,58 @@
+"""CLI entry point for Anthropic Messages server."""
+
+import asyncio
+
+import tyro
+from loguru import logger
+
+from psi_agent.ai.anthropic_messages.config import AnthropicMessagesConfig
+from psi_agent.ai.anthropic_messages.server import AnthropicMessagesServer
+
+
+def run(
+    session_socket: str,
+    model: str,
+    api_key: str,
+    base_url: str = "https://api.anthropic.com",
+) -> None:
+    """Run the Anthropic Messages server.
+
+    Args:
+        session_socket: Path to the Unix socket for communication with psi-session.
+        model: The model name to use for messages (e.g., "claude-sonnet-4-20250514").
+        api_key: The API key for authentication.
+        base_url: The base URL for the Anthropic API.
+    """
+    config = AnthropicMessagesConfig(
+        session_socket=session_socket,
+        model=model,
+        api_key=api_key,
+        base_url=base_url,
+    )
+
+    logger.info("Starting psi-ai-anthropic-messages")
+    logger.debug(f"Config: session_socket={session_socket}, model={model}, base_url={base_url}")
+
+    server = AnthropicMessagesServer(config)
+
+    async def _run() -> None:
+        await server.start()
+        try:
+            # Keep running until interrupted
+            while True:
+                await asyncio.sleep(1)
+        except KeyboardInterrupt:
+            logger.info("Received interrupt signal")
+        finally:
+            await server.stop()
+
+    asyncio.run(_run())
+
+
+def main() -> None:
+    """Main entry point for CLI."""
+    tyro.cli(run)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/psi_agent/ai/anthropic_messages/client.py
+++ b/src/psi_agent/ai/anthropic_messages/client.py
@@ -1,0 +1,161 @@
+"""Anthropic Messages API client for forwarding requests."""
+
+import json
+from collections.abc import AsyncGenerator
+from typing import Any
+
+from anthropic import AsyncAnthropic
+from anthropic.types import Message
+from loguru import logger
+
+from psi_agent.ai.anthropic_messages.config import AnthropicMessagesConfig
+
+
+class AnthropicMessagesClient:
+    """Client for forwarding requests to Anthropic Messages API."""
+
+    def __init__(self, config: AnthropicMessagesConfig) -> None:
+        """Initialize the client.
+
+        Args:
+            config: The configuration for the client.
+        """
+        self.config = config
+        self._client: AsyncAnthropic | None = None
+
+    async def __aenter__(self) -> AnthropicMessagesClient:
+        """Enter async context."""
+        self._client = AsyncAnthropic(
+            api_key=self.config.api_key,
+            base_url=self.config.base_url,
+        )
+        logger.debug(f"Initialized AsyncAnthropic client for {self.config.base_url}")
+        return self
+
+    async def __aexit__(self, _exc_type: Any, _exc_val: Any, _exc_tb: Any) -> None:
+        """Exit async context."""
+        if self._client is not None:
+            await self._client.close()
+            self._client = None
+            logger.debug("Closed AsyncAnthropic client")
+
+    async def messages(
+        self, request_body: dict[str, Any], stream: bool = False
+    ) -> dict[str, Any] | AsyncGenerator[str]:
+        """Send messages request to Anthropic API.
+
+        Args:
+            request_body: The request body in Anthropic Messages format.
+            stream: Whether to stream the response.
+
+        Returns:
+            For non-streaming: The response body as a dict.
+            For streaming: An async generator of SSE chunks.
+        """
+        if self._client is None:
+            raise RuntimeError("Client not initialized. Use async context manager.")
+
+        # Inject model if not present
+        if "model" not in request_body:
+            request_body["model"] = self.config.model
+
+        logger.info(f"Sending request to Anthropic API with model {request_body['model']}")
+        logger.debug("Request headers: x-api-key=*** (hidden)")
+        body_summary = {
+            k: v if k != "messages" else f"[{len(v)} messages]" for k, v in request_body.items()
+        }
+        logger.debug(f"Request body summary: {body_summary}")
+
+        if stream:
+            return self._stream_request(request_body)
+        else:
+            return await self._non_stream_request(request_body)
+
+    async def _non_stream_request(self, body: dict[str, Any]) -> dict[str, Any]:
+        """Send non-streaming request.
+
+        Args:
+            body: The request body.
+
+        Returns:
+            The response body as a dict.
+        """
+        assert self._client is not None
+
+        try:
+            response: Message = await self._client.messages.create(**body)
+            logger.info("Received successful non-streaming response")
+            logger.debug(f"Response id: {response.id}")
+
+            # Convert to dict for JSON serialization
+            return response.model_dump()
+
+        except Exception as e:
+            return self._handle_error(e)
+
+    async def _stream_request(self, body: dict[str, Any]) -> AsyncGenerator[str]:
+        """Send streaming request.
+
+        Args:
+            body: The request body.
+
+        Yields:
+            SSE chunks as strings.
+        """
+        assert self._client is not None
+
+        body["stream"] = True
+        try:
+            logger.info("Starting streaming request")
+            async with self._client.messages.stream(**body) as stream:
+                async for event in stream:
+                    # Convert event to SSE format
+                    event_data = event.model_dump()
+                    yield f"event: {event.type}\ndata: {json.dumps(event_data)}\n\n"
+
+            logger.info("Streaming response completed")
+            yield "event: message_stop\ndata: {}\n\n"
+
+        except Exception as e:
+            error_response = self._handle_error(e)
+            yield f"event: error\ndata: {json.dumps(error_response)}\n\n"
+
+    def _handle_error(self, e: Exception) -> dict[str, Any]:
+        """Handle API errors and return error response.
+
+        Args:
+            e: The exception that occurred.
+
+        Returns:
+            Error dict with status_code.
+        """
+        from anthropic import (
+            APIConnectionError,
+            APIStatusError,
+            APITimeoutError,
+            AuthenticationError,
+            RateLimitError,
+        )
+
+        if isinstance(e, AuthenticationError):
+            logger.error(f"Authentication failed: {e}")
+            return {"error": "Authentication failed", "status_code": 401}
+
+        if isinstance(e, RateLimitError):
+            logger.error(f"Rate limit exceeded: {e}")
+            return {"error": "Rate limit exceeded", "status_code": 429}
+
+        if isinstance(e, APITimeoutError):
+            logger.error(f"Request timeout: {e}")
+            return {"error": "Request timeout", "status_code": 500}
+
+        if isinstance(e, APIConnectionError):
+            logger.error(f"Connection failed: {e}")
+            return {"error": "Connection failed", "status_code": 500}
+
+        if isinstance(e, APIStatusError):
+            logger.error(f"API error {e.status_code}: {e}")
+            return {"error": str(e), "status_code": e.status_code or 500}
+
+        logger.exception(f"Unexpected error: {e}")
+        return {"error": str(e), "status_code": 500}

--- a/src/psi_agent/ai/anthropic_messages/config.py
+++ b/src/psi_agent/ai/anthropic_messages/config.py
@@ -1,0 +1,25 @@
+"""Configuration for Anthropic Messages server."""
+
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass
+class AnthropicMessagesConfig:
+    """Configuration for the Anthropic Messages server.
+
+    Args:
+        session_socket: Path to the Unix socket for communication with psi-session.
+        model: The model name to use for messages (e.g., "claude-sonnet-4-20250514").
+        api_key: The API key for authentication.
+        base_url: The base URL for the Anthropic API.
+    """
+
+    session_socket: str
+    model: str
+    api_key: str
+    base_url: str = "https://api.anthropic.com"
+
+    def socket_path(self) -> Path:
+        """Get the socket path as a Path object."""
+        return Path(self.session_socket)

--- a/src/psi_agent/ai/anthropic_messages/server.py
+++ b/src/psi_agent/ai/anthropic_messages/server.py
@@ -1,0 +1,174 @@
+"""HTTP server for Anthropic Messages over Unix socket."""
+
+import json
+from typing import Any
+
+from aiohttp import web
+from loguru import logger
+
+from psi_agent.ai.anthropic_messages.client import AnthropicMessagesClient
+from psi_agent.ai.anthropic_messages.config import AnthropicMessagesConfig
+
+
+class AnthropicMessagesServer:
+    """HTTP server for Anthropic Messages over Unix socket."""
+
+    def __init__(self, config: AnthropicMessagesConfig) -> None:
+        """Initialize the server.
+
+        Args:
+            config: The configuration for the server.
+        """
+        self.config = config
+        self.app = web.Application()
+        self.client: AnthropicMessagesClient | None = None
+        self._runner: web.AppRunner | None = None
+        self._setup_routes()
+
+    def _setup_routes(self) -> None:
+        """Set up HTTP routes."""
+        self.app.router.add_post("/v1/messages", self._handle_messages)
+        self.app.router.add_route("*", "/v1/{path:.*}", self._handle_other)
+        logger.debug("Routes configured: POST /v1/messages, wildcard /v1/*")
+
+    async def _handle_messages(self, request: web.Request) -> web.Response | web.StreamResponse:
+        """Handle messages request.
+
+        Args:
+            request: The incoming HTTP request.
+
+        Returns:
+            The HTTP response.
+        """
+        logger.info("Received POST /v1/messages request")
+
+        try:
+            body = await request.json()
+        except json.JSONDecodeError as e:
+            logger.error(f"Failed to parse request body: {e}")
+            return web.Response(status=400, text="Invalid JSON body")
+
+        stream = body.get("stream", False)
+        body_summary = {
+            k: v if k != "messages" else f"[{len(v)} messages]" for k, v in body.items()
+        }
+        logger.debug(f"Request body summary: {body_summary}")
+
+        if self.client is None:
+            logger.error("Client not initialized")
+            return web.Response(status=500, text="Server not ready")
+
+        try:
+            if stream:
+                logger.debug("Handling streaming request")
+                return await self._handle_streaming(request, body)
+            else:
+                logger.debug("Handling non-streaming request")
+                return await self._handle_non_streaming(body)
+        except Exception as e:
+            logger.exception(f"Error handling request: {e}")
+            return web.Response(status=500, text=str(e))
+
+    async def _handle_non_streaming(self, body: dict[str, Any]) -> web.Response:
+        """Handle non-streaming request.
+
+        Args:
+            body: The request body.
+
+        Returns:
+            The HTTP response.
+        """
+        from collections.abc import AsyncGenerator
+
+        assert self.client is not None
+        result = await self.client.messages(body, stream=False)
+
+        # Type narrowing: non-streaming returns dict, not AsyncGenerator
+        assert not isinstance(result, AsyncGenerator)
+
+        if "error" in result:
+            status_code = result.get("status_code", 500)
+            logger.error(f"Returning error response with status {status_code}")
+            return web.Response(status=status_code, text=result["error"])
+
+        logger.info("Returning successful non-streaming response")
+        return web.Response(status=200, body=json.dumps(result), content_type="application/json")
+
+    async def _handle_streaming(
+        self, request: web.Request, body: dict[str, Any]
+    ) -> web.StreamResponse:
+        """Handle streaming request.
+
+        Args:
+            request: The incoming HTTP request.
+            body: The request body.
+
+        Returns:
+            The streaming HTTP response.
+        """
+        from collections.abc import AsyncGenerator
+        from typing import cast
+
+        assert self.client is not None
+
+        response = web.StreamResponse()
+        response.content_type = "text/event-stream"
+        await response.prepare(request)
+
+        logger.debug("Starting SSE stream")
+
+        stream_result = await self.client.messages(body, stream=True)
+
+        # Type narrowing: streaming returns AsyncGenerator[str]
+        stream_gen = cast(AsyncGenerator[str], stream_result)
+
+        async for chunk in stream_gen:
+            await response.write(chunk.encode())
+
+        logger.info("Streaming response completed")
+        return response
+
+    async def _handle_other(self, request: web.Request) -> web.Response:
+        """Handle other requests.
+
+        Args:
+            request: The incoming HTTP request.
+
+        Returns:
+            The HTTP response.
+        """
+        logger.warning(f"Received unhandled request: {request.method} {request.path}")
+        return web.Response(status=404, text="Not found")
+
+    async def start(self) -> None:
+        """Start the server on Unix socket."""
+        socket_path = self.config.socket_path()
+
+        # Remove existing socket file if present
+        if socket_path.exists():
+            logger.debug(f"Removing existing socket file: {socket_path}")
+            socket_path.unlink()
+
+        # Initialize client
+        self.client = AnthropicMessagesClient(self.config)
+        assert self.client is not None
+        await self.client.__aenter__()
+
+        # Start server
+        self._runner = web.AppRunner(self.app)
+        await self._runner.setup()
+
+        site = web.UnixSite(self._runner, str(socket_path))
+        await site.start()
+
+        logger.info(f"Server started on Unix socket: {socket_path}")
+        logger.info(f"Model: {self.config.model}")
+        logger.info(f"Base URL: {self.config.base_url}")
+
+    async def stop(self) -> None:
+        """Stop the server."""
+        if self.client is not None:
+            await self.client.__aexit__(None, None, None)
+        if self._runner is not None:
+            await self._runner.cleanup()
+        logger.info("Server stopped")

--- a/tests/ai/anthropic_messages/__init__.py
+++ b/tests/ai/anthropic_messages/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for Anthropic Messages component."""

--- a/tests/ai/anthropic_messages/test_client.py
+++ b/tests/ai/anthropic_messages/test_client.py
@@ -1,0 +1,181 @@
+"""Tests for Anthropic Messages client."""
+
+from collections.abc import AsyncGenerator
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from psi_agent.ai.anthropic_messages.client import AnthropicMessagesClient
+from psi_agent.ai.anthropic_messages.config import AnthropicMessagesConfig
+
+
+class TestAnthropicMessagesClient:
+    """Tests for AnthropicMessagesClient."""
+
+    @pytest.fixture
+    def config(self) -> AnthropicMessagesConfig:
+        """Create test config."""
+        return AnthropicMessagesConfig(
+            session_socket="/tmp/test.sock",
+            model="claude-sonnet-4-20250514",
+            api_key="test-key",
+        )
+
+    @pytest.fixture
+    def client(self, config: AnthropicMessagesConfig) -> AnthropicMessagesClient:
+        """Create test client."""
+        return AnthropicMessagesClient(config)
+
+    @pytest.mark.asyncio
+    async def test_context_manager(self, client: AnthropicMessagesClient) -> None:
+        """Test async context manager protocol."""
+        with patch("psi_agent.ai.anthropic_messages.client.AsyncAnthropic") as mock_anthropic:
+            mock_instance = AsyncMock()
+            mock_instance.close = AsyncMock()
+            mock_anthropic.return_value = mock_instance
+
+            async with client:
+                assert client._client is not None
+
+            assert client._client is None
+
+    @pytest.mark.asyncio
+    async def test_non_streaming_request(self, client: AnthropicMessagesClient) -> None:
+        """Test non-streaming request."""
+        mock_response = MagicMock()
+        mock_response.id = "msg_123"
+        mock_response.model_dump = MagicMock(return_value={"id": "msg_123", "content": []})
+
+        with patch("psi_agent.ai.anthropic_messages.client.AsyncAnthropic") as mock_anthropic:
+            mock_instance = AsyncMock()
+            mock_instance.messages.create = AsyncMock(return_value=mock_response)
+            mock_instance.close = AsyncMock()
+            mock_anthropic.return_value = mock_instance
+
+            async with client:
+                result = await client.messages(
+                    {
+                        "messages": [{"role": "user", "content": "Hello"}],
+                        "max_tokens": 1024,
+                    },
+                    stream=False,
+                )
+
+                # Type narrowing: non-streaming returns dict
+                assert not isinstance(result, AsyncGenerator)
+                assert result["id"] == "msg_123"
+
+    @pytest.mark.asyncio
+    async def test_model_injection(self, client: AnthropicMessagesClient) -> None:
+        """Test model is injected if not provided."""
+        mock_response = MagicMock()
+        mock_response.id = "msg_123"
+        mock_response.model_dump = MagicMock(return_value={"id": "msg_123"})
+
+        with patch("psi_agent.ai.anthropic_messages.client.AsyncAnthropic") as mock_anthropic:
+            mock_instance = AsyncMock()
+            mock_instance.messages.create = AsyncMock(return_value=mock_response)
+            mock_instance.close = AsyncMock()
+            mock_anthropic.return_value = mock_instance
+
+            async with client:
+                await client.messages(
+                    {
+                        "messages": [{"role": "user", "content": "Hello"}],
+                        "max_tokens": 1024,
+                    },
+                    stream=False,
+                )
+
+                # Check that model was injected
+                call_kwargs = mock_instance.messages.create.call_args
+                assert call_kwargs[1]["model"] == "claude-sonnet-4-20250514"
+
+    @pytest.mark.asyncio
+    async def test_authentication_error(self, client: AnthropicMessagesClient) -> None:
+        """Test authentication error handling."""
+        from anthropic import AuthenticationError
+
+        with patch("psi_agent.ai.anthropic_messages.client.AsyncAnthropic") as mock_anthropic:
+            mock_instance = AsyncMock()
+            mock_instance.messages.create = AsyncMock(
+                side_effect=AuthenticationError(
+                    message="Invalid API key",
+                    response=MagicMock(status_code=401),
+                    body={"error": {"message": "Invalid API key"}},
+                )
+            )
+            mock_instance.close = AsyncMock()
+            mock_anthropic.return_value = mock_instance
+
+            async with client:
+                result = await client.messages(
+                    {
+                        "messages": [{"role": "user", "content": "Hello"}],
+                        "max_tokens": 1024,
+                    },
+                    stream=False,
+                )
+
+                # Type narrowing: non-streaming returns dict
+                assert not isinstance(result, AsyncGenerator)
+                assert "error" in result
+                assert result["status_code"] == 401
+
+    @pytest.mark.asyncio
+    async def test_rate_limit_error(self, client: AnthropicMessagesClient) -> None:
+        """Test rate limit error handling."""
+        from anthropic import RateLimitError
+
+        with patch("psi_agent.ai.anthropic_messages.client.AsyncAnthropic") as mock_anthropic:
+            mock_instance = AsyncMock()
+            mock_instance.messages.create = AsyncMock(
+                side_effect=RateLimitError(
+                    message="Rate limit exceeded",
+                    response=MagicMock(status_code=429),
+                    body={"error": {"message": "Rate limit exceeded"}},
+                )
+            )
+            mock_instance.close = AsyncMock()
+            mock_anthropic.return_value = mock_instance
+
+            async with client:
+                result = await client.messages(
+                    {
+                        "messages": [{"role": "user", "content": "Hello"}],
+                        "max_tokens": 1024,
+                    },
+                    stream=False,
+                )
+
+                # Type narrowing: non-streaming returns dict
+                assert not isinstance(result, AsyncGenerator)
+                assert "error" in result
+                assert result["status_code"] == 429
+
+    @pytest.mark.asyncio
+    async def test_connection_error(self, client: AnthropicMessagesClient) -> None:
+        """Test connection error handling."""
+        from anthropic import APIConnectionError
+
+        with patch("psi_agent.ai.anthropic_messages.client.AsyncAnthropic") as mock_anthropic:
+            mock_instance = AsyncMock()
+            mock_instance.messages.create = AsyncMock(
+                side_effect=APIConnectionError(request=MagicMock())
+            )
+            mock_instance.close = AsyncMock()
+            mock_anthropic.return_value = mock_instance
+
+            async with client:
+                result = await client.messages(
+                    {
+                        "messages": [{"role": "user", "content": "Hello"}],
+                        "max_tokens": 1024,
+                    },
+                    stream=False,
+                )
+
+                # Type narrowing: non-streaming returns dict
+                assert not isinstance(result, AsyncGenerator)
+                assert "error" in result
+                assert result["status_code"] == 500

--- a/tests/ai/anthropic_messages/test_config.py
+++ b/tests/ai/anthropic_messages/test_config.py
@@ -1,0 +1,44 @@
+"""Tests for Anthropic Messages config."""
+
+from pathlib import Path
+
+from psi_agent.ai.anthropic_messages.config import AnthropicMessagesConfig
+
+
+class TestAnthropicMessagesConfig:
+    """Tests for AnthropicMessagesConfig."""
+
+    def test_config_creation(self) -> None:
+        """Test creating config with required fields."""
+        config = AnthropicMessagesConfig(
+            session_socket="/tmp/test.sock",
+            model="claude-sonnet-4-20250514",
+            api_key="test-key",
+        )
+
+        assert config.session_socket == "/tmp/test.sock"
+        assert config.model == "claude-sonnet-4-20250514"
+        assert config.api_key == "test-key"
+        assert config.base_url == "https://api.anthropic.com"
+
+    def test_config_with_custom_base_url(self) -> None:
+        """Test creating config with custom base URL."""
+        config = AnthropicMessagesConfig(
+            session_socket="/tmp/test.sock",
+            model="claude-sonnet-4-20250514",
+            api_key="test-key",
+            base_url="https://custom.anthropic.com",
+        )
+
+        assert config.base_url == "https://custom.anthropic.com"
+
+    def test_socket_path(self) -> None:
+        """Test socket_path returns Path object."""
+        config = AnthropicMessagesConfig(
+            session_socket="/tmp/test.sock",
+            model="claude-sonnet-4-20250514",
+            api_key="test-key",
+        )
+
+        assert isinstance(config.socket_path(), Path)
+        assert config.socket_path() == Path("/tmp/test.sock")

--- a/tests/ai/anthropic_messages/test_server.py
+++ b/tests/ai/anthropic_messages/test_server.py
@@ -1,0 +1,120 @@
+"""Tests for Anthropic Messages server."""
+
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from psi_agent.ai.anthropic_messages.config import AnthropicMessagesConfig
+from psi_agent.ai.anthropic_messages.server import AnthropicMessagesServer
+
+
+class TestAnthropicMessagesServer:
+    """Tests for AnthropicMessagesServer."""
+
+    @pytest.fixture
+    def config(self) -> AnthropicMessagesConfig:
+        """Create test config."""
+        return AnthropicMessagesConfig(
+            session_socket="/tmp/test_server.sock",
+            model="claude-sonnet-4-20250514",
+            api_key="test-key",
+        )
+
+    @pytest.fixture
+    def server(self, config: AnthropicMessagesConfig) -> AnthropicMessagesServer:
+        """Create test server."""
+        return AnthropicMessagesServer(config)
+
+    def test_server_creation(
+        self, server: AnthropicMessagesServer, config: AnthropicMessagesConfig
+    ) -> None:
+        """Test server creation."""
+        assert server.config == config
+        assert server.client is None
+        assert server._runner is None
+
+    def test_routes_configured(self, server: AnthropicMessagesServer) -> None:
+        """Test that routes are configured."""
+        routes = [r.resource.canonical for r in server.app.router.routes() if r.resource]
+        assert "/v1/messages" in routes
+
+    @pytest.mark.asyncio
+    async def test_handle_messages_invalid_json(self, server: AnthropicMessagesServer) -> None:
+        """Test handling invalid JSON request."""
+        request = MagicMock()
+        request.json = AsyncMock(side_effect=Exception("Invalid JSON"))
+
+        # Patch json.JSONDecodeError handling
+        import json
+
+        request.json = AsyncMock(side_effect=json.JSONDecodeError("test", "test", 0))
+
+        response = await server._handle_messages(request)
+        assert response.status == 400
+
+    @pytest.mark.asyncio
+    async def test_handle_messages_client_not_initialized(
+        self, server: AnthropicMessagesServer
+    ) -> None:
+        """Test handling request when client not initialized."""
+        request = MagicMock()
+        request.json = AsyncMock(return_value={"messages": []})
+
+        response = await server._handle_messages(request)
+        assert response.status == 500
+
+    @pytest.mark.asyncio
+    async def test_handle_other_request(self, server: AnthropicMessagesServer) -> None:
+        """Test handling unhandled request path."""
+        request = MagicMock()
+        request.method = "GET"
+        request.path = "/v1/unknown"
+
+        response = await server._handle_other(request)
+        assert response.status == 404
+
+    @pytest.mark.asyncio
+    async def test_start_creates_socket(self, config: AnthropicMessagesConfig) -> None:
+        """Test that start creates socket file."""
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            socket_path = Path(tmpdir) / "test.sock"
+            config = AnthropicMessagesConfig(
+                session_socket=str(socket_path),
+                model="claude-sonnet-4-20250514",
+                api_key="test-key",
+            )
+            server = AnthropicMessagesServer(config)
+
+            # Mock the client to avoid actual API calls
+            # Mock UnixSite to avoid actual socket binding
+            with (
+                patch.object(server, "client", None),
+                patch("aiohttp.web.UnixSite") as mock_unix_site,
+            ):
+                mock_site = AsyncMock()
+                mock_unix_site.return_value = mock_site
+
+                await server.start()
+
+                # Check client was initialized
+                assert server.client is not None
+                assert server._runner is not None
+
+                await server.stop()
+
+    @pytest.mark.asyncio
+    async def test_stop_cleans_up(self, server: AnthropicMessagesServer) -> None:
+        """Test that stop cleans up resources."""
+        # Setup mocks
+        server.client = AsyncMock()
+        server.client.__aexit__ = AsyncMock()
+        server._runner = AsyncMock()
+        server._runner.cleanup = AsyncMock()
+
+        await server.stop()
+
+        server.client.__aexit__.assert_called_once()
+        server._runner.cleanup.assert_called_once()

--- a/uv.lock
+++ b/uv.lock
@@ -75,6 +75,34 @@ wheels = [
 ]
 
 [[package]]
+name = "annotated-types"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ee/67/531ea369ba64dcff5ec9c3402f9f51bf748cec26dde048a2f973a4eea7f5/annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89", size = 16081, upload-time = "2024-05-20T21:33:25.928Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53", size = 13643, upload-time = "2024-05-20T21:33:24.1Z" },
+]
+
+[[package]]
+name = "anthropic"
+version = "0.97.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "distro" },
+    { name = "docstring-parser" },
+    { name = "httpx" },
+    { name = "jiter" },
+    { name = "pydantic" },
+    { name = "sniffio" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/14/93/f66ea8bfe39f2e6bb9da8e27fa5457ad2520e8f7612dfc547b17fad55c4d/anthropic-0.97.0.tar.gz", hash = "sha256:021e79fd8e21e90ad94dc5ba2bbbd8b1599f424f5b1fab6c06204009cab764be", size = 669502, upload-time = "2026-04-23T20:52:34.445Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/53/b6/8e851369fa661ad0fef2ae6266bf3b7d52b78ccf011720058f4adaca59e2/anthropic-0.97.0-py3-none-any.whl", hash = "sha256:8a1a472dfabcfc0c52ff6a3eecf724ac7e07107a2f6e2367be55ceb42f5d5613", size = 662126, upload-time = "2026-04-23T20:52:32.377Z" },
+]
+
+[[package]]
 name = "anyio"
 version = "4.13.0"
 source = { registry = "https://pypi.org/simple" }
@@ -96,12 +124,30 @@ wheels = [
 ]
 
 [[package]]
+name = "certifi"
+version = "2026.4.22"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/25/ee/6caf7a40c36a1220410afe15a1cc64993a1f864871f698c0f93acb72842a/certifi-2026.4.22.tar.gz", hash = "sha256:8d455352a37b71bf76a79caa83a3d6c25afee4a385d632127b6afb3963f1c580", size = 137077, upload-time = "2026-04-22T11:26:11.191Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/22/30/7cd8fdcdfbc5b869528b079bfb76dcdf6056b1a2097a662e5e8c04f42965/certifi-2026.4.22-py3-none-any.whl", hash = "sha256:3cb2210c8f88ba2318d29b0388d1023c8492ff72ecdde4ebdaddbb13a31b1c4a", size = 135707, upload-time = "2026-04-22T11:26:09.372Z" },
+]
+
+[[package]]
 name = "colorama"
 version = "0.4.6"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "distro"
+version = "1.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fc/f8/98eea607f65de6527f8a2e8885fc8015d3e6f5775df186e443e0964a11c3/distro-1.9.0.tar.gz", hash = "sha256:2fa77c6fd8940f116ee1d6b94a2f90b13b5ea8d019b98bc8bafdcabcdd9bdbed", size = 60722, upload-time = "2023-12-24T09:54:32.31Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/12/b3/231ffd4ab1fc9d679809f356cebee130ac7daa00d6d6f3206dd4fd137e9e/distro-1.9.0-py3-none-any.whl", hash = "sha256:7bffd925d65168f85027d8da9af6bddab658135b840670a223589bc0c8ef02b2", size = 20277, upload-time = "2023-12-24T09:54:30.421Z" },
 ]
 
 [[package]]
@@ -155,6 +201,43 @@ wheels = [
 ]
 
 [[package]]
+name = "h11"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "httpcore"
+version = "1.0.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+]
+
+[[package]]
+name = "httpx"
+version = "0.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "certifi" },
+    { name = "httpcore" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+]
+
+[[package]]
 name = "idna"
 version = "3.13"
 source = { registry = "https://pypi.org/simple" }
@@ -170,6 +253,41 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "jiter"
+version = "0.14.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6e/c1/0cddc6eb17d4c53a99840953f95dd3accdc5cfc7a337b0e9b26476276be9/jiter-0.14.0.tar.gz", hash = "sha256:e8a39e66dac7153cf3f964a12aad515afa8d74938ec5cc0018adcdae5367c79e", size = 165725, upload-time = "2026-04-10T14:28:42.01Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4f/1e/354ed92461b165bd581f9ef5150971a572c873ec3b68a916d5aa91da3cc2/jiter-0.14.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:6f396837fc7577871ca8c12edaf239ed9ccef3bbe39904ae9b8b63ce0a48b140", size = 315277, upload-time = "2026-04-10T14:27:18.109Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/95/8c7c7028aa8636ac21b7a55faef3e34215e6ed0cbf5ae58258427f621aa3/jiter-0.14.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:a4d50ea3d8ba4176f79754333bd35f1bbcd28e91adc13eb9b7ca91bc52a6cef9", size = 315923, upload-time = "2026-04-10T14:27:19.603Z" },
+    { url = "https://files.pythonhosted.org/packages/47/40/e2a852a44c4a089f2681a16611b7ce113224a80fd8504c46d78491b47220/jiter-0.14.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ce17f8a050447d1b4153bda4fb7d26e6a9e74eb4f4a41913f30934c5075bf615", size = 344943, upload-time = "2026-04-10T14:27:21.262Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/1f/670f92adee1e9895eac41e8a4d623b6da68c4d46249d8b556b60b63f949e/jiter-0.14.0-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f4f1c4b125e1652aefbc2e2c1617b60a160ab789d180e3d423c41439e5f32850", size = 369725, upload-time = "2026-04-10T14:27:22.766Z" },
+    { url = "https://files.pythonhosted.org/packages/01/2f/541c9ba567d05de1c4874a0f8f8c5e3fd78e2b874266623da9a775cf46e0/jiter-0.14.0-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:be808176a6a3a14321d18c603f2d40741858a7c4fc982f83232842689fe86dd9", size = 461210, upload-time = "2026-04-10T14:27:24.315Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/a9/c31cbec09627e0d5de7aeaec7690dba03e090caa808fefd8133137cf45bc/jiter-0.14.0-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:26679d58ba816f88c3849306dd58cb863a90a1cf352cdd4ef67e30ccf8a77994", size = 380002, upload-time = "2026-04-10T14:27:26.155Z" },
+    { url = "https://files.pythonhosted.org/packages/50/02/3c05c1666c41904a2f607475a73e7a4763d1cbde2d18229c4f85b22dc253/jiter-0.14.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:80381f5a19af8fa9aef743f080e34f6b25ebd89656475f8cf0470ec6157052aa", size = 354678, upload-time = "2026-04-10T14:27:27.701Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/97/e15b33545c2b13518f560d695f974b9891b311641bdcf178d63177e8801e/jiter-0.14.0-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:004df5fdb8ecbd6d99f3227df18ba1a259254c4359736a2e6f036c944e02d7c5", size = 358920, upload-time = "2026-04-10T14:27:29.256Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/d2/8b1461def6b96ba44530df20d07ef7a1c7da22f3f9bf1727e2d611077bf1/jiter-0.14.0-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:cff5708f7ed0fa098f2b53446c6fa74c48469118e5cd7497b4f1cd569ab06928", size = 394512, upload-time = "2026-04-10T14:27:31.344Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/88/837566dd6ed6e452e8d3205355afd484ce44b2533edfa4ed73a298ea893e/jiter-0.14.0-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:2492e5f06c36a976d25c7cc347a60e26d5470178d44cde1b9b75e60b4e519f28", size = 521120, upload-time = "2026-04-10T14:27:33.299Z" },
+    { url = "https://files.pythonhosted.org/packages/89/6b/b00b45c4d1b4c031777fe161d620b755b5b02cdade1e316dcb46e4471d63/jiter-0.14.0-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:7609cfbe3a03d37bfdbf5052012d5a879e72b83168a363deae7b3a26564d57de", size = 553668, upload-time = "2026-04-10T14:27:34.868Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/d8/6fe5b42011d19397433d345716eac16728ac241862a2aac9c91923c7509a/jiter-0.14.0-cp314-cp314-win32.whl", hash = "sha256:7282342d32e357543565286b6450378c3cd402eea333fc1ebe146f1fabb306fc", size = 207001, upload-time = "2026-04-10T14:27:36.455Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/43/5c2e08da1efad5e410f0eaaabeadd954812612c33fbbd8fd5328b489139d/jiter-0.14.0-cp314-cp314-win_amd64.whl", hash = "sha256:bd77945f38866a448e73b0b7637366afa814d4617790ecd88a18ca74377e6c02", size = 202187, upload-time = "2026-04-10T14:27:38Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/1f/6e39ac0b4cdfa23e606af5b245df5f9adaa76f35e0c5096790da430ca506/jiter-0.14.0-cp314-cp314-win_arm64.whl", hash = "sha256:f2d4c61da0821ee42e0cdf5489da60a6d074306313a377c2b35af464955a3611", size = 192257, upload-time = "2026-04-10T14:27:39.504Z" },
+    { url = "https://files.pythonhosted.org/packages/05/57/7dbc0ffbbb5176a27e3518716608aa464aee2e2887dc938f0b900a120449/jiter-0.14.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:1bf7ff85517dd2f20a5750081d2b75083c1b269cf75afc7511bdf1f9548beb3b", size = 323441, upload-time = "2026-04-10T14:27:41.039Z" },
+    { url = "https://files.pythonhosted.org/packages/83/6e/7b3314398d8983f06b557aa21b670511ec72d3b79a68ee5e4d9bff972286/jiter-0.14.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c8ef8791c3e78d6c6b157c6d360fbb5c715bebb8113bc6a9303c5caff012754a", size = 348109, upload-time = "2026-04-10T14:27:42.552Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/4f/8dc674bcd7db6dba566de73c08c763c337058baff1dbeb34567045b27cdc/jiter-0.14.0-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e74663b8b10da1fe0f4e4703fd7980d24ad17174b6bb35d8498d6e3ebce2ae6a", size = 368328, upload-time = "2026-04-10T14:27:44.574Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/5f/188e09a1f20906f98bbdec44ed820e19f4e8eb8aff88b9d1a5a497587ff3/jiter-0.14.0-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1aca29ba52913f78362ec9c2da62f22cdc4c3083313403f90c15460979b84d9b", size = 463301, upload-time = "2026-04-10T14:27:46.717Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/f0/19046ef965ed8f349e8554775bb12ff4352f443fbe12b95d31f575891256/jiter-0.14.0-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8b39b7d87a952b79949af5fef44d2544e58c21a28da7f1bae3ef166455c61746", size = 378891, upload-time = "2026-04-10T14:27:48.32Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/c3/da43bd8431ee175695777ee78cf0e93eacbb47393ff493f18c45231b427d/jiter-0.14.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:78d918a68b26e9fab068c2b5453577ef04943ab2807b9a6275df2a812599a310", size = 360749, upload-time = "2026-04-10T14:27:49.88Z" },
+    { url = "https://files.pythonhosted.org/packages/72/26/e054771be889707c6161dbdec9c23d33a9ec70945395d70f07cfea1e9a6f/jiter-0.14.0-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:b08997c35aee1201c1a5361466a8fb9162d03ae7bf6568df70b6c859f1e654a4", size = 358526, upload-time = "2026-04-10T14:27:51.504Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/0f/7bea65ea2a6d91f2bf989ff11a18136644392bf2b0497a1fa50934c30a9c/jiter-0.14.0-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:260bf7ca20704d58d41f669e5e9fe7fe2fa72901a6b324e79056f5d52e9c9be2", size = 393926, upload-time = "2026-04-10T14:27:53.368Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/a1/b1ff7d70deef61ac0b7c6c2f12d2ace950cdeecb4fdc94500a0926802857/jiter-0.14.0-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:37826e3df29e60f30a382f9294348d0238ef127f4b5d7f5f8da78b5b9e050560", size = 521052, upload-time = "2026-04-10T14:27:55.058Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/7b/3b0649983cbaf15eda26a414b5b1982e910c67bd6f7b1b490f3cfc76896a/jiter-0.14.0-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:645be49c46f2900937ba0eaf871ad5183c96858c0af74b6becc7f4e367e36e06", size = 553716, upload-time = "2026-04-10T14:27:57.269Z" },
+    { url = "https://files.pythonhosted.org/packages/97/f8/33d78c83bd93ae0c0af05293a6660f88a1977caef39a6d72a84afab94ce0/jiter-0.14.0-cp314-cp314t-win32.whl", hash = "sha256:2f7877ed45118de283786178eceaf877110abacd04fde31efff3940ae9672674", size = 207957, upload-time = "2026-04-10T14:27:59.285Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/ac/2b760516c03e2227826d1f7025d89bf6bf6357a28fe75c2a2800873c50bf/jiter-0.14.0-cp314-cp314t-win_amd64.whl", hash = "sha256:14c0cb10337c49f5eafe8e7364daca5e29a020ea03580b8f8e6c597fed4e1588", size = 204690, upload-time = "2026-04-10T14:28:00.962Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/2e/a44c20c58aeed0355f2d326969a181696aeb551a25195f47563908a815be/jiter-0.14.0-cp314-cp314t-win_arm64.whl", hash = "sha256:5419d4aa2024961da9fe12a9cfe7484996735dca99e8e090b5c88595ef1951ff", size = 191338, upload-time = "2026-04-10T14:28:02.853Z" },
 ]
 
 [[package]]
@@ -292,6 +410,7 @@ name = "psi-agent"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },
+    { name = "anthropic" },
     { name = "anyio" },
     { name = "loguru" },
     { name = "tyro" },
@@ -308,6 +427,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "aiohttp", specifier = ">=3.13.5" },
+    { name = "anthropic", specifier = ">=0.57.1" },
     { name = "anyio", specifier = ">=4.13.0" },
     { name = "loguru", specifier = ">=0.7.3" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.3" },
@@ -317,6 +437,62 @@ requires-dist = [
     { name = "tyro", specifier = ">=1.0.13" },
 ]
 provides-extras = ["dev"]
+
+[[package]]
+name = "pydantic"
+version = "2.13.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-types" },
+    { name = "pydantic-core" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d9/e4/40d09941a2cebcb20609b86a559817d5b9291c49dd6f8c87e5feffbe703a/pydantic-2.13.3.tar.gz", hash = "sha256:af09e9d1d09f4e7fe37145c1f577e1d61ceb9a41924bf0094a36506285d0a84d", size = 844068, upload-time = "2026-04-20T14:46:43.632Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f3/0a/fd7d723f8f8153418fb40cf9c940e82004fce7e987026b08a68a36dd3fe7/pydantic-2.13.3-py3-none-any.whl", hash = "sha256:6db14ac8dfc9a1e57f87ea2c0de670c251240f43cb0c30a5130e9720dc612927", size = 471981, upload-time = "2026-04-20T14:46:41.402Z" },
+]
+
+[[package]]
+name = "pydantic-core"
+version = "2.46.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2a/ef/f7abb56c49382a246fd2ce9c799691e3c3e7175ec74b14d99e798bcddb1a/pydantic_core-2.46.3.tar.gz", hash = "sha256:41c178f65b8c29807239d47e6050262eb6bf84eb695e41101e62e38df4a5bc2c", size = 471412, upload-time = "2026-04-20T14:40:56.672Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7f/db/a7bcb4940183fda36022cd18ba8dd12f2dff40740ec7b58ce7457befa416/pydantic_core-2.46.3-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:afa3aa644f74e290cdede48a7b0bee37d1c35e71b05105f6b340d484af536d9b", size = 2097614, upload-time = "2026-04-20T14:44:38.374Z" },
+    { url = "https://files.pythonhosted.org/packages/24/35/e4066358a22e3e99519db370494c7528f5a2aa1367370e80e27e20283543/pydantic_core-2.46.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:ced3310e51aa425f7f77da8bbbb5212616655bedbe82c70944320bc1dbe5e018", size = 1951896, upload-time = "2026-04-20T14:40:53.996Z" },
+    { url = "https://files.pythonhosted.org/packages/87/92/37cf4049d1636996e4b888c05a501f40a43ff218983a551d57f9d5e14f0d/pydantic_core-2.46.3-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e29908922ce9da1a30b4da490bd1d3d82c01dcfdf864d2a74aacee674d0bfa34", size = 1979314, upload-time = "2026-04-20T14:41:49.446Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/36/9ff4d676dfbdfb2d591cf43f3d90ded01e15b1404fd101180ed2d62a2fd3/pydantic_core-2.46.3-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:0c9ff69140423eea8ed2d5477df3ba037f671f5e897d206d921bc9fdc39613e7", size = 2056133, upload-time = "2026-04-20T14:42:23.574Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/f0/405b442a4d7ba855b06eec8b2bf9c617d43b8432d099dfdc7bf999293495/pydantic_core-2.46.3-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b675ab0a0d5b1c8fdb81195dc5bcefea3f3c240871cdd7ff9a2de8aa50772eb2", size = 2228726, upload-time = "2026-04-20T14:44:22.816Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/f8/65cd92dd5a0bd89ba277a98ecbfaf6fc36bbd3300973c7a4b826d6ab1391/pydantic_core-2.46.3-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:0087084960f209a9a4af50ecd1fb063d9ad3658c07bb81a7a53f452dacbfb2ba", size = 2301214, upload-time = "2026-04-20T14:44:48.792Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/86/ef96a4c6e79e7a2d0410826a68fbc0eccc0fd44aa733be199d5fcac3bb87/pydantic_core-2.46.3-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ed42e6cc8e1b0e2b9b96e2276bad70ae625d10d6d524aed0c93de974ae029f9f", size = 2099927, upload-time = "2026-04-20T14:41:40.196Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/53/269caf30e0096e0a8a8f929d1982a27b3879872cca2d917d17c2f9fdf4fe/pydantic_core-2.46.3-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:f1771ce258afb3e4201e67d154edbbae712a76a6081079fe247c2f53c6322c22", size = 2128789, upload-time = "2026-04-20T14:41:15.868Z" },
+    { url = "https://files.pythonhosted.org/packages/00/b0/1a6d9b6a587e118482910c244a1c5acf4d192604174132efd12bf0ac486f/pydantic_core-2.46.3-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:a7610b6a5242a6c736d8ad47fd5fff87fcfe8f833b281b1c409c3d6835d9227f", size = 2173815, upload-time = "2026-04-20T14:44:25.152Z" },
+    { url = "https://files.pythonhosted.org/packages/87/56/e7e00d4041a7e62b5a40815590114db3b535bf3ca0bf4dca9f16cef25246/pydantic_core-2.46.3-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:ff5e7783bcc5476e1db448bf268f11cb257b1c276d3e89f00b5727be86dd0127", size = 2181608, upload-time = "2026-04-20T14:41:28.933Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/22/4bd23c3d41f7c185d60808a1de83c76cf5aeabf792f6c636a55c3b1ec7f9/pydantic_core-2.46.3-cp314-cp314-musllinux_1_1_armv7l.whl", hash = "sha256:9d2e32edcc143bc01e95300671915d9ca052d4f745aa0a49c48d4803f8a85f2c", size = 2326968, upload-time = "2026-04-20T14:42:03.962Z" },
+    { url = "https://files.pythonhosted.org/packages/24/ac/66cd45129e3915e5ade3b292cb3bc7fd537f58f8f8dbdaba6170f7cabb74/pydantic_core-2.46.3-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:6e42d83d1c6b87fa56b521479cff237e626a292f3b31b6345c15a99121b454c1", size = 2369842, upload-time = "2026-04-20T14:41:35.52Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/51/dd4248abb84113615473aa20d5545b7c4cd73c8644003b5259686f93996c/pydantic_core-2.46.3-cp314-cp314-win32.whl", hash = "sha256:07bc6d2a28c3adb4f7c6ae46aa4f2d2929af127f587ed44057af50bf1ce0f505", size = 1959661, upload-time = "2026-04-20T14:41:00.042Z" },
+    { url = "https://files.pythonhosted.org/packages/20/eb/59980e5f1ae54a3b86372bd9f0fa373ea2d402e8cdcd3459334430f91e91/pydantic_core-2.46.3-cp314-cp314-win_amd64.whl", hash = "sha256:8940562319bc621da30714617e6a7eaa6b98c84e8c685bcdc02d7ed5e7c7c44e", size = 2071686, upload-time = "2026-04-20T14:43:16.471Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/db/1cf77e5247047dfee34bc01fa9bca134854f528c8eb053e144298893d370/pydantic_core-2.46.3-cp314-cp314-win_arm64.whl", hash = "sha256:5dcbbcf4d22210ced8f837c96db941bdb078f419543472aca5d9a0bb7cddc7df", size = 2026907, upload-time = "2026-04-20T14:43:31.732Z" },
+    { url = "https://files.pythonhosted.org/packages/57/c0/b3df9f6a543276eadba0a48487b082ca1f201745329d97dbfa287034a230/pydantic_core-2.46.3-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:d0fe3dce1e836e418f912c1ad91c73357d03e556a4d286f441bf34fed2dbeecf", size = 2095047, upload-time = "2026-04-20T14:42:37.982Z" },
+    { url = "https://files.pythonhosted.org/packages/66/57/886a938073b97556c168fd99e1a7305bb363cd30a6d2c76086bf0587b32a/pydantic_core-2.46.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:9ce92e58abc722dac1bf835a6798a60b294e48eb0e625ec9fd994b932ac5feee", size = 1934329, upload-time = "2026-04-20T14:43:49.655Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/7c/b42eaa5c34b13b07ecb51da21761297a9b8eb43044c864a035999998f328/pydantic_core-2.46.3-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a03e6467f0f5ab796a486146d1b887b2dc5e5f9b3288898c1b1c3ad974e53e4a", size = 1974847, upload-time = "2026-04-20T14:42:10.737Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/9b/92b42db6543e7de4f99ae977101a2967b63122d4b6cf7773812da2d7d5b5/pydantic_core-2.46.3-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:2798b6ba041b9d70acfb9071a2ea13c8456dd1e6a5555798e41ba7b0790e329c", size = 2041742, upload-time = "2026-04-20T14:40:44.262Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/19/46fbe1efabb5aa2834b43b9454e70f9a83ad9c338c1291e48bdc4fecf167/pydantic_core-2.46.3-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9be3e221bdc6d69abf294dcf7aff6af19c31a5cdcc8f0aa3b14be29df4bd03b1", size = 2236235, upload-time = "2026-04-20T14:41:27.307Z" },
+    { url = "https://files.pythonhosted.org/packages/77/da/b3f95bc009ad60ec53120f5d16c6faa8cabdbe8a20d83849a1f2b8728148/pydantic_core-2.46.3-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f13936129ce841f2a5ddf6f126fea3c43cd128807b5a59588c37cf10178c2e64", size = 2282633, upload-time = "2026-04-20T14:44:33.271Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/6e/401336117722e28f32fb8220df676769d28ebdf08f2f4469646d404c43a3/pydantic_core-2.46.3-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:28b5f2ef03416facccb1c6ef744c69793175fd27e44ef15669201601cf423acb", size = 2109679, upload-time = "2026-04-20T14:44:41.065Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/53/b289f9bc8756a32fe718c46f55afaeaf8d489ee18d1a1e7be1db73f42cc4/pydantic_core-2.46.3-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:830d1247d77ad23852314f069e9d7ddafeec5f684baf9d7e7065ed46a049c4e6", size = 2108342, upload-time = "2026-04-20T14:42:50.144Z" },
+    { url = "https://files.pythonhosted.org/packages/10/5b/8292fc7c1f9111f1b2b7c1b0dcf1179edcd014fc3ea4517499f50b829d71/pydantic_core-2.46.3-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:d0793c90c1a3c74966e7975eaef3ed30ebdff3260a0f815a62a22adc17e4c01c", size = 2157208, upload-time = "2026-04-20T14:42:08.133Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/9e/f80044e9ec07580f057a89fc131f78dda7a58751ddf52bbe05eaf31db50f/pydantic_core-2.46.3-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:d2d0aead851b66f5245ec0c4fb2612ef457f8bbafefdf65a2bf9d6bac6140f47", size = 2167237, upload-time = "2026-04-20T14:42:25.412Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/84/6781a1b037f3b96be9227edbd1101f6d3946746056231bf4ac48cdff1a8d/pydantic_core-2.46.3-cp314-cp314t-musllinux_1_1_armv7l.whl", hash = "sha256:2f40e4246676beb31c5ce77c38a55ca4e465c6b38d11ea1bd935420568e0b1ab", size = 2312540, upload-time = "2026-04-20T14:40:40.313Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/db/19c0839feeb728e7df03255581f198dfdf1c2aeb1e174a8420b63c5252e5/pydantic_core-2.46.3-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:cf489cf8986c543939aeee17a09c04d6ffb43bfef8ca16fcbcc5cfdcbed24dba", size = 2369556, upload-time = "2026-04-20T14:41:09.427Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/15/3228774cb7cd45f5f721ddf1b2242747f4eb834d0c491f0c02d606f09fed/pydantic_core-2.46.3-cp314-cp314t-win32.whl", hash = "sha256:ffe0883b56cfc05798bf994164d2b2ff03efe2d22022a2bb080f3b626176dd56", size = 1949756, upload-time = "2026-04-20T14:41:25.717Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/2a/c79cf53fd91e5a87e30d481809f52f9a60dd221e39de66455cf04deaad37/pydantic_core-2.46.3-cp314-cp314t-win_amd64.whl", hash = "sha256:706d9d0ce9cf4593d07270d8e9f53b161f90c57d315aeec4fb4fd7a8b10240d8", size = 2051305, upload-time = "2026-04-20T14:43:18.627Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/db/d8182a7f1d9343a032265aae186eb063fe26ca4c40f256b21e8da4498e89/pydantic_core-2.46.3-cp314-cp314t-win_arm64.whl", hash = "sha256:77706aeb41df6a76568434701e0917da10692da28cb69d5fb6919ce5fdb07374", size = 2026310, upload-time = "2026-04-20T14:41:01.778Z" },
+]
 
 [[package]]
 name = "pygments"
@@ -381,6 +557,15 @@ wheels = [
 ]
 
 [[package]]
+name = "sniffio"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372, upload-time = "2024-02-25T23:20:04.057Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235, upload-time = "2024-02-25T23:20:01.196Z" },
+]
+
+[[package]]
 name = "ty"
 version = "0.0.33"
 source = { registry = "https://pypi.org/simple" }
@@ -423,6 +608,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
+]
+
+[[package]]
+name = "typing-inspection"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Add new `psi-ai-anthropic-messages` component following the same architecture as `psi-ai-openai-completions`
- Enable native Anthropic API support with streaming, content blocks, and tool use
- Add CLI entry point `psi-ai-anthropic-messages` for starting the server

## Changes

- Add `anthropic` SDK dependency to pyproject.toml
- Implement `AnthropicMessagesClient` with async context manager and error handling
- Implement `AnthropicMessagesServer` with Unix socket HTTP server
- Support POST `/v1/messages` endpoint with streaming (SSE)
- Add unit tests for config, client, and server (16 tests, all passing)
- Add OpenSpec specs for `anthropic-messages-client` and `anthropic-messages-server`

## Test plan

- [x] All unit tests pass (`uv run pytest tests/ai/anthropic_messages/`)
- [x] Lint checks pass (`uv run ruff check`)
- [x] Format checks pass (`uv run ruff format --check`)
- [x] Type checks pass (`uv run ty check`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)