### PR TITLE
Add psi-workspace-* components for workspace management

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,13 +73,76 @@ Agent 流程：
 
 ### psi-workspace-* 组件
 
-Workspace 管理器。
+Workspace 管理器，提供五个独立的 CLI 工具：
 
-职责：
-- 将 workspace 打包成 squashfs 或 overlayfs
-- 管理挂载
+| 组件 | 职责 |
+|------|------|
+| psi-workspace-pack | 将 workspace 目录打包成 squashfs 镜像 |
+| psi-workspace-unpack | 将 squashfs 镜像解压成目录 |
+| psi-workspace-mount | 将 squashfs 镜像挂载成 overlayfs |
+| psi-workspace-umount | 卸载已挂载的 workspace |
+| psi-workspace-snapshot | 创建 workspace 快照 |
 
-**注意：具体设计待定，未来有新信息时需在此更新。**
+**注意：这些组件需要 root 权限执行 mount/umount 操作。**
+
+#### Squashfs 镜像结构
+
+```
+workspace.squashfs
+├── manifest.json          # 元信息配置
+├── <uuid-1>/              # 基础层（第一次 pack 的目录内容）
+├── <uuid-2>/              # 第一次 snapshot 添加的层
+├── <uuid-3>/              # 第二次 snapshot 添加的层
+└── ...
+```
+
+#### Manifest.json 结构
+
+```json
+{
+  "layers": {
+    "<uuid-1>": { "tag": "v1.0" },
+    "<uuid-2>": { "parent": "<uuid-1>", "tag": "v1.1" },
+    "<uuid-3>": { "parent": "<uuid-2>" }
+  },
+  "default": "<uuid-3>"
+}
+```
+
+**字段说明：**
+- `layers`: 所有层的定义，key 为 UUID
+  - `parent`: 可选，父层 UUID（根层无 parent）
+  - `tag`: 可选，人类可读的标签
+- `default`: 默认挂载的层 UUID
+
+#### CLI 使用示例
+
+**打包 workspace：**
+```bash
+sudo psi-workspace-pack --input ./workspace --output ./workspace.squashfs --tag v1.0
+```
+
+**挂载 workspace：**
+```bash
+sudo psi-workspace-mount --input ./workspace.squashfs --output ./mounted-workspace
+# 或指定特定层
+sudo psi-workspace-mount --input ./workspace.squashfs --output ./mounted-workspace --layer v1.0
+```
+
+**创建快照：**
+```bash
+sudo psi-workspace-snapshot --input ./workspace.squashfs --mount-point ./mounted-workspace --tag v1.1
+```
+
+**卸载 workspace：**
+```bash
+sudo psi-workspace-umount --mount-point ./mounted-workspace
+```
+
+**解压 squashfs：**
+```bash
+psi-workspace-unpack --input ./workspace.squashfs --output ./extracted-workspace
+```
 
 ## Workspace 结构
 

--- a/openspec/changes/archive/2026-04-28-workspace-interface-design/.openspec.yaml
+++ b/openspec/changes/archive/2026-04-28-workspace-interface-design/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-28

--- a/openspec/changes/archive/2026-04-28-workspace-interface-design/design.md
+++ b/openspec/changes/archive/2026-04-28-workspace-interface-design/design.md
@@ -1,0 +1,150 @@
+## Context
+
+psi-agent 的核心理念是**可移植性**——用户只需复制 workspace 目录即可完成 agent 移植。psi-workspace-* 组件负责管理 workspace 的打包、挂载、快照等操作，是实现可移植性的关键。
+
+当前状态：
+- workspace 目录结构已定义（tools/, skills/, schedules/, systems/）
+- psi-workspace-* 组件接口标注为"待定"
+- 需要支持 squashfs 镜像和 overlayfs 挂载
+
+约束：
+- 所有组件使用 tyro 实现 CLI
+- 所有 IO 操作必须是 async
+- 使用 loguru 记录日志
+- 错误通过异常抛出
+
+## Goals / Non-Goals
+
+**Goals:**
+- 定义五个 psi-workspace-* 组件的完整接口
+- 规范 manifest.json 结构
+- 定义 squashfs 镜像内部结构
+- 定义 overlayfs 挂载策略
+- 支持 snapshot 的原子写入
+
+**Non-Goals:**
+- 不定义 psi-session 如何使用 workspace（已在 CLAUDE.md 中定义）
+- 不定义网络传输或远程 workspace 管理
+- 不定义 workspace 版本控制（除 snapshot 外）
+
+## Decisions
+
+### 1. 组件拆分策略
+
+**决定：** 拆分为五个独立组件（mount, umount, snapshot, pack, unpack）
+
+**理由：**
+- 每个功能独立，用户按需调用
+- 符合 Unix 哲学：一个工具做一件事
+- 便于独立测试和维护
+
+**替代方案：** 单一 psi-workspace 组件带子命令
+- 缺点：增加复杂度，不符合 psi-agent 组件化理念
+
+### 2. Squashfs 镜像结构
+
+**决定：**
+```
+workspace.squashfs
+├── manifest.json          # 元信息
+├── <uuid-1>/              # 基础层（第一个 pack 的目录）
+├── <uuid-2>/              # 后续 snapshot 添加的层
+├── <uuid-3>/
+└── ...
+```
+
+**manifest.json 结构：**
+```json
+{
+  "layers": {
+    "<uuid-1>": { "tag": "v1.0" },
+    "<uuid-2>": { "parent": "<uuid-1>", "tag": "v1.1" },
+    "<uuid-3>": { "parent": "<uuid-2>" }
+  },
+  "default": "<uuid-3>"
+}
+```
+
+**理由：**
+- UUID 作为层名保证唯一性，避免命名冲突
+- tag 是可选的，方便用户记忆和引用
+- default 存储单个层 UUID，表示当前最新状态
+- mount 时可通过 UUID 或 tag 指定要挂载的层
+
+### 3. Overlayfs 挂载策略
+
+**决定：**
+1. 将 squashfs 挂载到临时目录（只读）
+2. 根据指定的层（UUID 或 tag）解析出完整层级链
+3. 创建 upper 和 work 目录
+4. 使用 overlayfs 挂载到用户指定路径
+
+**层级链解析：**
+- 从指定层开始，沿 parent 链向上追溯，直到根层
+- overlayfs lowerdir 按从上到下的顺序排列
+
+**挂载命令示例：**
+```bash
+mount -t squashfs workspace.squashfs /tmp/squashfs-xxx -o loop
+mount -t overlay overlay /target/path \
+  -o lowerdir=/tmp/squashfs-xxx/<uuid-3>:/tmp/squashfs-xxx/<uuid-2>:/tmp/squashfs-xxx/<uuid-1> \
+  -o upperdir=/tmp/upper-xxx \
+  -o workdir=/tmp/work-xxx
+```
+
+**理由：**
+- squashfs 只读，需要 upper 层支持写入
+- overlayfs 提供写入层分离
+- 用户可通过 UUID 或 tag 指定要挂载的层版本
+
+### 4. Snapshot 原子写入
+
+**决定：**
+1. 复制原始 squashfs 到临时文件（同目录，确保同文件系统）
+2. 添加 diff 目录到 squashfs
+3. 更新 manifest.json
+4. mv 临时文件到目标路径
+
+**理由：**
+- 避免系统崩溃导致数据损坏
+- 同文件系统保证 mv 是原子操作
+- 临时文件在目标文件附近确保同文件系统
+
+### 5. 错误处理策略
+
+**决定：**
+- 记录日志（loguru）
+- 抛出异常（Python API）
+- CLI 捕获异常并显示错误信息
+
+**理由：**
+- 日志在任何时候都需要记录
+- Python API 使用异常是 Python 惯例
+- CLI 需要友好的错误显示
+
+## Risks / Trade-offs
+
+### 风险：Overlayfs 需要 root 权限
+
+**缓解：**
+- 文档中明确说明权限要求
+- 提供错误提示引导用户使用 sudo
+
+### 风险：Snapshot 可能很慢（复制整个 squashfs）
+
+**缓解：**
+- 文档中说明 snapshot 性能特点
+- 未来可考虑增量 snapshot
+
+### 风险：临时文件可能占用大量空间
+
+**缓解：**
+- 使用系统临时目录（/tmp）
+- 提供 --temp-dir 选项让用户指定
+
+### Trade-off：不支持分支（多个 parent）
+
+**理由：**
+- 简化实现
+- 大多数场景是线性历史
+- 未来可扩展

--- a/openspec/changes/archive/2026-04-28-workspace-interface-design/proposal.md
+++ b/openspec/changes/archive/2026-04-28-workspace-interface-design/proposal.md
@@ -1,0 +1,34 @@
+## Why
+
+psi-workspace-* 组件的接口设计目前未定义（CLAUDE.md 中标注为"待定"）。作为 psi-agent 可移植性核心理念的关键部分，workspace 管理组件需要明确的接口规范，以便开发者能够正确实现打包、挂载、快照等功能。
+
+## What Changes
+
+- 定义五个 psi-workspace-* 组件的 CLI 和 Python API 接口
+- 规范 manifest.json 的结构和内容（UUID 命名层、tag 支持）
+- 定义 squashfs 镜像的内部结构
+- 定义 overlayfs 挂载策略（支持 UUID 或 tag 指定层）
+- 定义 snapshot 的行为和 manifest 更新规则
+- 更新 CLAUDE.md 中的 psi-workspace-* 组件部分
+
+## Capabilities
+
+### New Capabilities
+
+- `workspace-pack`: 将 workspace 目录打包成 squashfs 镜像的接口
+- `workspace-unpack`: 将 squashfs 镜像解压成目录的接口（不挂载）
+- `workspace-mount`: 将 squashfs 镜像挂载成 overlayfs 的接口
+- `workspace-umount`: 卸载已挂载 workspace 的接口
+- `workspace-snapshot`: 创建 workspace 快照的接口
+- `workspace-manifest`: manifest.json 的结构和规范
+
+### Modified Capabilities
+
+None - 这是新能力引入。
+
+## Impact
+
+- **psi-workspace-* 组件**: 五个独立组件需要实现各自接口
+- **CLAUDE.md**: 更新 psi-workspace-* 组件部分，添加完整接口规范
+- **manifest.json**: 定义标准格式，所有组件需要遵循
+- **用户工作流**: 用户通过 CLI 手动调用这些组件管理 workspace

--- a/openspec/changes/archive/2026-04-28-workspace-interface-design/specs/workspace-manifest/spec.md
+++ b/openspec/changes/archive/2026-04-28-workspace-interface-design/specs/workspace-manifest/spec.md
@@ -1,0 +1,83 @@
+## ADDED Requirements
+
+### Requirement: Manifest has valid structure
+The manifest.json SHALL have a valid structure with required fields.
+
+#### Scenario: Required fields present
+- **WHEN** manifest.json is created or updated
+- **THEN** it contains a `layers` object
+- **AND** it contains a `default` field (single UUID string)
+- **AND** `layers` contains at least one layer entry
+
+### Requirement: Layer names are UUIDs
+Each layer name in manifest.json SHALL be a valid UUID.
+
+#### Scenario: UUID format layer names
+- **WHEN** manifest is created
+- **THEN** all layer names are UUID v4 format
+- **AND** all layer names are unique
+
+### Requirement: Manifest layer entries are valid
+Each layer entry in manifest.json SHALL have valid structure.
+
+#### Scenario: Root layer entry (no parent)
+- **WHEN** manifest contains a root layer
+- **THEN** the layer has no `parent` field
+- **AND** the layer MAY have an optional `tag` field
+
+#### Scenario: Non-root layer entry
+- **WHEN** manifest contains a non-root layer
+- **THEN** the layer has a `parent` field referencing an existing layer UUID
+- **AND** the layer MAY have an optional `tag` field
+
+### Requirement: Tags are unique and optional
+Tags in manifest.json SHALL be unique across all layers and optional.
+
+#### Scenario: Unique tags
+- **WHEN** a layer has a tag
+- **THEN** no other layer has the same tag
+- **AND** the tag is a non-empty string
+
+### Requirement: Manifest default field is valid
+The default field SHALL reference an existing layer UUID.
+
+#### Scenario: Default references existing layer
+- **WHEN** manifest is valid
+- **THEN** `default` is a single UUID string
+- **AND** the UUID exists in `layers`
+
+### Requirement: Manifest can be parsed
+The system SHALL parse manifest.json correctly.
+
+#### Scenario: Parse valid manifest
+- **WHEN** system reads a valid manifest.json
+- **THEN** system returns a Manifest data structure
+- **AND** the data structure matches the JSON content
+
+#### Scenario: Parse invalid manifest
+- **WHEN** system reads an invalid manifest.json
+- **THEN** system raises an exception with parse error details
+
+### Requirement: Manifest can be serialized
+The system SHALL serialize Manifest to JSON correctly.
+
+#### Scenario: Serialize manifest
+- **WHEN** system serializes a Manifest data structure
+- **THEN** the output is valid JSON
+- **AND** the JSON matches the manifest structure specification
+
+### Requirement: Layer can be looked up by tag
+The system SHALL support looking up layers by tag.
+
+#### Scenario: Lookup by tag
+- **WHEN** system receives a tag string
+- **THEN** system returns the corresponding layer UUID
+- **AND** system raises an exception if tag is not found
+
+### Requirement: Layer chain can be resolved
+The system SHALL resolve the complete layer chain from any layer.
+
+#### Scenario: Resolve layer chain
+- **WHEN** system receives a layer UUID or tag
+- **THEN** system returns the complete chain from root to that layer
+- **AND** the chain is ordered from root (first) to target layer (last)

--- a/openspec/changes/archive/2026-04-28-workspace-interface-design/specs/workspace-mount/spec.md
+++ b/openspec/changes/archive/2026-04-28-workspace-interface-design/specs/workspace-mount/spec.md
@@ -1,0 +1,68 @@
+## ADDED Requirements
+
+### Requirement: Mount creates overlayfs from squashfs
+The system SHALL mount a squashfs image as an overlayfs to a target directory.
+
+#### Scenario: Mount with default layer
+- **WHEN** user runs `psi-workspace-mount --input ./workspace.squashfs --output ./mounted-workspace`
+- **THEN** system mounts the squashfs to a temporary directory (read-only)
+- **AND** system resolves the layer chain from manifest default
+- **AND** system creates an overlayfs using the resolved layer chain
+- **AND** system mounts the overlayfs to the user-specified output path
+- **AND** the output path is writable
+
+### Requirement: Mount supports UUID specification
+The system SHALL allow users to specify a layer by UUID.
+
+#### Scenario: Mount with UUID
+- **WHEN** user runs `psi-workspace-mount --input ./workspace.squashfs --output ./mounted-workspace --layer <uuid>`
+- **THEN** system resolves the layer chain from the specified UUID
+- **AND** system creates an overlayfs using the resolved layer chain
+
+### Requirement: Mount supports tag specification
+The system SHALL allow users to specify a layer by tag.
+
+#### Scenario: Mount with tag
+- **WHEN** user runs `psi-workspace-mount --input ./workspace.squashfs --output ./mounted-workspace --layer v1.0`
+- **THEN** system looks up the UUID for tag "v1.0"
+- **AND** system resolves the layer chain from that UUID
+- **AND** system creates an overlayfs using the resolved layer chain
+
+### Requirement: Mount creates required directories
+The system SHALL automatically create upper and work directories for overlayfs.
+
+#### Scenario: Overlayfs directories created
+- **WHEN** mount is executed
+- **THEN** system creates a temporary upper directory for writes
+- **AND** system creates a temporary work directory for overlayfs
+- **AND** both directories are cleaned up on umount
+
+### Requirement: Mount validates inputs
+The system SHALL validate all inputs before mounting.
+
+#### Scenario: Invalid squashfs file
+- **WHEN** user specifies a non-existent squashfs file
+- **THEN** system raises an exception with a clear error message
+
+#### Scenario: Invalid UUID
+- **WHEN** user specifies a UUID that does not exist in manifest
+- **THEN** system raises an exception listing available UUIDs
+
+#### Scenario: Invalid tag
+- **WHEN** user specifies a tag that does not exist in manifest
+- **THEN** system raises an exception listing available tags
+
+### Requirement: Mount requires root privileges
+The system SHALL require appropriate privileges for mount operations.
+
+#### Scenario: Insufficient privileges
+- **WHEN** mount is executed without sufficient privileges
+- **THEN** system raises an exception indicating privilege requirement
+
+### Requirement: Mount uses async operations
+The system SHALL use async operations where possible.
+
+#### Scenario: Async setup operations
+- **WHEN** mount is running
+- **THEN** directory creation and validation use async methods
+- **AND** mount system calls are executed via async subprocess

--- a/openspec/changes/archive/2026-04-28-workspace-interface-design/specs/workspace-pack/spec.md
+++ b/openspec/changes/archive/2026-04-28-workspace-interface-design/specs/workspace-pack/spec.md
@@ -1,0 +1,48 @@
+## ADDED Requirements
+
+### Requirement: Pack creates squashfs from directory
+The system SHALL create a squashfs image from a workspace directory.
+
+#### Scenario: Pack workspace directory
+- **WHEN** user runs `psi-workspace-pack --input ./workspace --output ./workspace.squashfs`
+- **THEN** system creates a squashfs image at the specified output path
+- **AND** the squashfs contains the input directory contents in a UUID-named folder
+- **AND** the squashfs contains a `manifest.json` with the layer defined
+
+#### Scenario: Pack with tag
+- **WHEN** user runs `psi-workspace-pack --input ./workspace --output ./workspace.squashfs --tag v1.0`
+- **THEN** system creates a squashfs with the layer tagged as "v1.0"
+- **AND** manifest.json contains the tag for that layer
+
+### Requirement: Pack creates valid manifest
+The system SHALL create a valid manifest.json in the squashfs.
+
+#### Scenario: Manifest structure
+- **WHEN** pack completes successfully
+- **THEN** manifest.json contains a `layers` object with one UUID key
+- **AND** manifest.json contains a `default` field with the UUID
+- **AND** the layer has no `parent` field (root layer)
+
+### Requirement: Pack generates UUID for layer
+The system SHALL generate a UUID for the layer name.
+
+#### Scenario: UUID generation
+- **WHEN** pack creates a new squashfs
+- **THEN** the layer name is a valid UUID v4
+- **AND** the directory name in squashfs matches the UUID
+
+### Requirement: Pack validates input directory
+The system SHALL validate the input directory exists and is readable.
+
+#### Scenario: Invalid input directory
+- **WHEN** user specifies a non-existent input directory
+- **THEN** system raises an exception with a clear error message
+- **AND** no output file is created
+
+### Requirement: Pack uses async IO
+The system SHALL use async operations for all file system operations.
+
+#### Scenario: Async file operations
+- **WHEN** pack is running
+- **THEN** all file reads and writes use async methods
+- **AND** the squashfs creation does not block the event loop

--- a/openspec/changes/archive/2026-04-28-workspace-interface-design/specs/workspace-snapshot/spec.md
+++ b/openspec/changes/archive/2026-04-28-workspace-interface-design/specs/workspace-snapshot/spec.md
@@ -1,0 +1,71 @@
+## ADDED Requirements
+
+### Requirement: Snapshot creates atomic update
+The system SHALL create a snapshot with atomic write to prevent data loss.
+
+#### Scenario: Snapshot with atomic write
+- **WHEN** user runs `psi-workspace-snapshot --input ./workspace.squashfs --mount-point ./mounted-workspace`
+- **THEN** system copies the original squashfs to a temporary file in the same directory
+- **AND** system adds the diff (upper directory) as a new UUID-named layer
+- **AND** system updates the manifest.json with the new layer
+- **AND** system moves the temporary file to the final location atomically
+
+### Requirement: Snapshot supports custom output
+The system SHALL allow users to specify a custom output path.
+
+#### Scenario: Snapshot to new file
+- **WHEN** user runs `psi-workspace-snapshot --input ./workspace.squashfs --mount-point ./mounted-workspace --output ./workspace-v2.squashfs`
+- **THEN** system creates a new squashfs at the specified output path
+- **AND** the original squashfs is not modified
+
+### Requirement: Snapshot supports tag
+The system SHALL allow users to specify a tag for the new layer.
+
+#### Scenario: Snapshot with tag
+- **WHEN** user runs `psi-workspace-snapshot --input ./workspace.squashfs --mount-point ./mounted-workspace --tag v1.1`
+- **THEN** the new layer has tag "v1.1" in manifest.json
+- **AND** the tag is unique across all layers
+
+### Requirement: Snapshot updates manifest correctly
+The system SHALL update manifest.json with the new layer information.
+
+#### Scenario: Manifest update
+- **WHEN** snapshot completes successfully
+- **THEN** manifest.json contains a new layer entry with a UUID name
+- **AND** the new layer has a `parent` field referencing the current default layer
+- **AND** the `default` field is updated to the new layer UUID
+
+### Requirement: Snapshot generates UUID for new layer
+The system SHALL generate a UUID for the new layer.
+
+#### Scenario: UUID generation
+- **WHEN** snapshot creates a new layer
+- **THEN** the layer name is a valid UUID v4
+- **AND** the directory name in squashfs matches the UUID
+
+### Requirement: Snapshot handles empty diff
+The system SHALL handle cases where no changes were made.
+
+#### Scenario: No changes in upper directory
+- **WHEN** upper directory is empty (no modifications made)
+- **THEN** system logs a warning that no changes were detected
+- **AND** system still creates a snapshot (optional behavior)
+
+### Requirement: Snapshot validates inputs
+The system SHALL validate all inputs before snapshot.
+
+#### Scenario: Invalid squashfs file
+- **WHEN** user specifies a non-existent squashfs file
+- **THEN** system raises an exception with a clear error message
+
+#### Scenario: Invalid mount point
+- **WHEN** user specifies a path that is not an overlayfs mount
+- **THEN** system raises an exception with a clear error message
+
+### Requirement: Snapshot uses async operations
+The system SHALL use async operations where possible.
+
+#### Scenario: Async snapshot operations
+- **WHEN** snapshot is running
+- **THEN** file operations use async methods
+- **AND** squashfs creation uses async subprocess

--- a/openspec/changes/archive/2026-04-28-workspace-interface-design/specs/workspace-umount/spec.md
+++ b/openspec/changes/archive/2026-04-28-workspace-interface-design/specs/workspace-umount/spec.md
@@ -1,0 +1,35 @@
+## ADDED Requirements
+
+### Requirement: Umount cleanly removes overlayfs
+The system SHALL unmount the overlayfs and clean up temporary resources.
+
+#### Scenario: Umount mounted workspace
+- **WHEN** user runs `psi-workspace-umount --output ./mounted-workspace`
+- **THEN** system unmounts the overlayfs from the output path
+- **AND** system unmounts the squashfs from the temporary directory
+- **AND** system removes the temporary upper and work directories
+- **AND** system removes the temporary squashfs mount directory
+
+### Requirement: Umount validates mount point
+The system SHALL validate the specified path is a valid overlayfs mount.
+
+#### Scenario: Invalid mount point
+- **WHEN** user specifies a path that is not an overlayfs mount
+- **THEN** system raises an exception with a clear error message
+
+### Requirement: Umount handles partial cleanup
+The system SHALL attempt cleanup even if unmount fails.
+
+#### Scenario: Unmount failure with cleanup
+- **WHEN** overlayfs unmount fails
+- **THEN** system logs the error
+- **AND** system still attempts to clean up temporary directories
+- **AND** system raises an exception with both errors
+
+### Requirement: Umount uses async operations
+The system SHALL use async operations where possible.
+
+#### Scenario: Async cleanup operations
+- **WHEN** umount is running
+- **THEN** directory removal uses async methods
+- **AND** unmount system calls are executed via async subprocess

--- a/openspec/changes/archive/2026-04-28-workspace-interface-design/specs/workspace-unpack/spec.md
+++ b/openspec/changes/archive/2026-04-28-workspace-interface-design/specs/workspace-unpack/spec.md
@@ -1,0 +1,33 @@
+## ADDED Requirements
+
+### Requirement: Unpack extracts squashfs to directory
+The system SHALL extract a squashfs image to a directory without mounting.
+
+#### Scenario: Unpack squashfs
+- **WHEN** user runs `psi-workspace-unpack --input ./workspace.squashfs --output ./workspace`
+- **THEN** system extracts the squashfs contents to the output directory
+- **AND** the output directory structure matches the squashfs internal structure
+- **AND** overlay layers are created as separate directories
+
+### Requirement: Unpack preserves overlay structure
+The system SHALL create directories matching the squashfs overlay structure.
+
+#### Scenario: Multiple layers unpacked
+- **WHEN** squashfs contains base/, layer-1/, layer-2/ and manifest.json
+- **THEN** output directory contains base/, layer-1/, layer-2/ directories
+- **AND** manifest.json is copied to output directory
+
+### Requirement: Unpack validates input file
+The system SHALL validate the input squashfs exists and is readable.
+
+#### Scenario: Invalid input file
+- **WHEN** user specifies a non-existent squashfs file
+- **THEN** system raises an exception with a clear error message
+- **AND** no output directory is created
+
+### Requirement: Unpack uses async IO
+The system SHALL use async operations for all file system operations.
+
+#### Scenario: Async extraction
+- **WHEN** unpack is running
+- **THEN** all file reads and writes use async methods

--- a/openspec/changes/archive/2026-04-28-workspace-interface-design/tasks.md
+++ b/openspec/changes/archive/2026-04-28-workspace-interface-design/tasks.md
@@ -1,0 +1,68 @@
+## 1. 核心数据结构
+
+- [x] 1.1 定义 Manifest 数据结构（layers, default 字段）
+- [x] 1.2 实现 Manifest JSON 解析函数
+- [x] 1.3 实现 Manifest JSON 序列化函数
+- [x] 1.4 编写 Manifest 相关单元测试
+
+## 2. psi-workspace-pack 组件
+
+- [x] 2.1 创建 psi_agent/workspace/pack 模块结构
+- [x] 2.2 实现 pack Python API（输入目录、输出 squashfs 路径）
+- [x] 2.3 实现 squashfs 创建逻辑（使用 mksquashfs 命令）
+- [x] 2.4 实现 manifest.json 创建逻辑
+- [x] 2.5 实现 CLI 入口（使用 tyro）
+- [x] 2.6 编写 pack 相关单元测试
+
+## 3. psi-workspace-unpack 组件
+
+- [x] 3.1 创建 psi_agent/workspace/unpack 模块结构
+- [x] 3.2 实现 unpack Python API（输入 squashfs、输出目录）
+- [x] 3.3 实现 squashfs 解压逻辑（使用 unsquashfs 命令）
+- [x] 3.4 实现 CLI 入口（使用 tyro）
+- [x] 3.5 编写 unpack 相关单元测试
+
+## 4. psi-workspace-mount 组件
+
+- [x] 4.1 创建 psi_agent/workspace/mount 模块结构
+- [x] 4.2 实现 mount Python API（输入 squashfs、输出目录、可选 layers）
+- [x] 4.3 实现 squashfs 挂载逻辑（mount -t squashfs）
+- [x] 4.4 实现 overlayfs 挂载逻辑（mount -t overlay）
+- [x] 4.5 实现临时目录创建和管理
+- [x] 4.6 实现层级配置解析（default 或用户指定）
+- [x] 4.7 实现 CLI 入口（使用 tyro）
+- [x] 4.8 编写 mount 相关单元测试
+
+## 5. psi-workspace-umount 组件
+
+- [x] 5.1 创建 psi_agent/workspace/umount 模块结构
+- [x] 5.2 实现 umount Python API（挂载点路径）
+- [x] 5.3 实现 overlayfs 卸载逻辑
+- [x] 5.4 实现 squashfs 卸载逻辑
+- [x] 5.5 实现临时目录清理逻辑
+- [x] 5.6 实现 CLI 入口（使用 tyro）
+- [x] 5.7 编写 umount 相关单元测试
+
+## 6. psi-workspace-snapshot 组件
+
+- [x] 6.1 创建 psi_agent/workspace/snapshot 模块结构
+- [x] 6.2 实现 snapshot Python API（输入 squashfs、挂载点、可选输出路径）
+- [x] 6.3 实现原子写入逻辑（临时文件 + mv）
+- [x] 6.4 实现 diff 目录添加逻辑
+- [x] 6.5 实现 manifest 更新逻辑（新层、parent、default）
+- [x] 6.6 实现 squashfs 创建逻辑（添加新层）
+- [x] 6.7 实现 CLI 入口（使用 tyro）
+- [x] 6.8 编写 snapshot 相关单元测试
+
+## 7. 文档更新
+
+- [x] 7.1 更新 CLAUDE.md 中 psi-workspace-* 组件部分
+- [x] 7.2 添加 manifest.json 结构规范到 CLAUDE.md
+- [x] 7.3 添加 squashfs 镜像结构规范到 CLAUDE.md
+- [x] 7.4 添加 CLI 使用示例到 CLAUDE.md
+
+## 8. 集成测试
+
+- [x] 8.1 编写 pack + mount + umount + snapshot 端到端测试
+- [x] 8.2 编写多层 snapshot 测试
+- [x] 8.3 编写错误处理测试（权限不足、无效输入等）

--- a/openspec/specs/workspace-manifest/spec.md
+++ b/openspec/specs/workspace-manifest/spec.md
@@ -1,0 +1,83 @@
+## ADDED Requirements
+
+### Requirement: Manifest has valid structure
+The manifest.json SHALL have a valid structure with required fields.
+
+#### Scenario: Required fields present
+- **WHEN** manifest.json is created or updated
+- **THEN** it contains a `layers` object
+- **AND** it contains a `default` field (single UUID string)
+- **AND** `layers` contains at least one layer entry
+
+### Requirement: Layer names are UUIDs
+Each layer name in manifest.json SHALL be a valid UUID.
+
+#### Scenario: UUID format layer names
+- **WHEN** manifest is created
+- **THEN** all layer names are UUID v4 format
+- **AND** all layer names are unique
+
+### Requirement: Manifest layer entries are valid
+Each layer entry in manifest.json SHALL have valid structure.
+
+#### Scenario: Root layer entry (no parent)
+- **WHEN** manifest contains a root layer
+- **THEN** the layer has no `parent` field
+- **AND** the layer MAY have an optional `tag` field
+
+#### Scenario: Non-root layer entry
+- **WHEN** manifest contains a non-root layer
+- **THEN** the layer has a `parent` field referencing an existing layer UUID
+- **AND** the layer MAY have an optional `tag` field
+
+### Requirement: Tags are unique and optional
+Tags in manifest.json SHALL be unique across all layers and optional.
+
+#### Scenario: Unique tags
+- **WHEN** a layer has a tag
+- **THEN** no other layer has the same tag
+- **AND** the tag is a non-empty string
+
+### Requirement: Manifest default field is valid
+The default field SHALL reference an existing layer UUID.
+
+#### Scenario: Default references existing layer
+- **WHEN** manifest is valid
+- **THEN** `default` is a single UUID string
+- **AND** the UUID exists in `layers`
+
+### Requirement: Manifest can be parsed
+The system SHALL parse manifest.json correctly.
+
+#### Scenario: Parse valid manifest
+- **WHEN** system reads a valid manifest.json
+- **THEN** system returns a Manifest data structure
+- **AND** the data structure matches the JSON content
+
+#### Scenario: Parse invalid manifest
+- **WHEN** system reads an invalid manifest.json
+- **THEN** system raises an exception with parse error details
+
+### Requirement: Manifest can be serialized
+The system SHALL serialize Manifest to JSON correctly.
+
+#### Scenario: Serialize manifest
+- **WHEN** system serializes a Manifest data structure
+- **THEN** the output is valid JSON
+- **AND** the JSON matches the manifest structure specification
+
+### Requirement: Layer can be looked up by tag
+The system SHALL support looking up layers by tag.
+
+#### Scenario: Lookup by tag
+- **WHEN** system receives a tag string
+- **THEN** system returns the corresponding layer UUID
+- **AND** system raises an exception if tag is not found
+
+### Requirement: Layer chain can be resolved
+The system SHALL resolve the complete layer chain from any layer.
+
+#### Scenario: Resolve layer chain
+- **WHEN** system receives a layer UUID or tag
+- **THEN** system returns the complete chain from root to that layer
+- **AND** the chain is ordered from root (first) to target layer (last)

--- a/openspec/specs/workspace-mount/spec.md
+++ b/openspec/specs/workspace-mount/spec.md
@@ -1,0 +1,68 @@
+## ADDED Requirements
+
+### Requirement: Mount creates overlayfs from squashfs
+The system SHALL mount a squashfs image as an overlayfs to a target directory.
+
+#### Scenario: Mount with default layer
+- **WHEN** user runs `psi-workspace-mount --input ./workspace.squashfs --output ./mounted-workspace`
+- **THEN** system mounts the squashfs to a temporary directory (read-only)
+- **AND** system resolves the layer chain from manifest default
+- **AND** system creates an overlayfs using the resolved layer chain
+- **AND** system mounts the overlayfs to the user-specified output path
+- **AND** the output path is writable
+
+### Requirement: Mount supports UUID specification
+The system SHALL allow users to specify a layer by UUID.
+
+#### Scenario: Mount with UUID
+- **WHEN** user runs `psi-workspace-mount --input ./workspace.squashfs --output ./mounted-workspace --layer <uuid>`
+- **THEN** system resolves the layer chain from the specified UUID
+- **AND** system creates an overlayfs using the resolved layer chain
+
+### Requirement: Mount supports tag specification
+The system SHALL allow users to specify a layer by tag.
+
+#### Scenario: Mount with tag
+- **WHEN** user runs `psi-workspace-mount --input ./workspace.squashfs --output ./mounted-workspace --layer v1.0`
+- **THEN** system looks up the UUID for tag "v1.0"
+- **AND** system resolves the layer chain from that UUID
+- **AND** system creates an overlayfs using the resolved layer chain
+
+### Requirement: Mount creates required directories
+The system SHALL automatically create upper and work directories for overlayfs.
+
+#### Scenario: Overlayfs directories created
+- **WHEN** mount is executed
+- **THEN** system creates a temporary upper directory for writes
+- **AND** system creates a temporary work directory for overlayfs
+- **AND** both directories are cleaned up on umount
+
+### Requirement: Mount validates inputs
+The system SHALL validate all inputs before mounting.
+
+#### Scenario: Invalid squashfs file
+- **WHEN** user specifies a non-existent squashfs file
+- **THEN** system raises an exception with a clear error message
+
+#### Scenario: Invalid UUID
+- **WHEN** user specifies a UUID that does not exist in manifest
+- **THEN** system raises an exception listing available UUIDs
+
+#### Scenario: Invalid tag
+- **WHEN** user specifies a tag that does not exist in manifest
+- **THEN** system raises an exception listing available tags
+
+### Requirement: Mount requires root privileges
+The system SHALL require appropriate privileges for mount operations.
+
+#### Scenario: Insufficient privileges
+- **WHEN** mount is executed without sufficient privileges
+- **THEN** system raises an exception indicating privilege requirement
+
+### Requirement: Mount uses async operations
+The system SHALL use async operations where possible.
+
+#### Scenario: Async setup operations
+- **WHEN** mount is running
+- **THEN** directory creation and validation use async methods
+- **AND** mount system calls are executed via async subprocess

--- a/openspec/specs/workspace-pack/spec.md
+++ b/openspec/specs/workspace-pack/spec.md
@@ -1,0 +1,48 @@
+## ADDED Requirements
+
+### Requirement: Pack creates squashfs from directory
+The system SHALL create a squashfs image from a workspace directory.
+
+#### Scenario: Pack workspace directory
+- **WHEN** user runs `psi-workspace-pack --input ./workspace --output ./workspace.squashfs`
+- **THEN** system creates a squashfs image at the specified output path
+- **AND** the squashfs contains the input directory contents in a UUID-named folder
+- **AND** the squashfs contains a `manifest.json` with the layer defined
+
+#### Scenario: Pack with tag
+- **WHEN** user runs `psi-workspace-pack --input ./workspace --output ./workspace.squashfs --tag v1.0`
+- **THEN** system creates a squashfs with the layer tagged as "v1.0"
+- **AND** manifest.json contains the tag for that layer
+
+### Requirement: Pack creates valid manifest
+The system SHALL create a valid manifest.json in the squashfs.
+
+#### Scenario: Manifest structure
+- **WHEN** pack completes successfully
+- **THEN** manifest.json contains a `layers` object with one UUID key
+- **AND** manifest.json contains a `default` field with the UUID
+- **AND** the layer has no `parent` field (root layer)
+
+### Requirement: Pack generates UUID for layer
+The system SHALL generate a UUID for the layer name.
+
+#### Scenario: UUID generation
+- **WHEN** pack creates a new squashfs
+- **THEN** the layer name is a valid UUID v4
+- **AND** the directory name in squashfs matches the UUID
+
+### Requirement: Pack validates input directory
+The system SHALL validate the input directory exists and is readable.
+
+#### Scenario: Invalid input directory
+- **WHEN** user specifies a non-existent input directory
+- **THEN** system raises an exception with a clear error message
+- **AND** no output file is created
+
+### Requirement: Pack uses async IO
+The system SHALL use async operations for all file system operations.
+
+#### Scenario: Async file operations
+- **WHEN** pack is running
+- **THEN** all file reads and writes use async methods
+- **AND** the squashfs creation does not block the event loop

--- a/openspec/specs/workspace-snapshot/spec.md
+++ b/openspec/specs/workspace-snapshot/spec.md
@@ -1,0 +1,71 @@
+## ADDED Requirements
+
+### Requirement: Snapshot creates atomic update
+The system SHALL create a snapshot with atomic write to prevent data loss.
+
+#### Scenario: Snapshot with atomic write
+- **WHEN** user runs `psi-workspace-snapshot --input ./workspace.squashfs --mount-point ./mounted-workspace`
+- **THEN** system copies the original squashfs to a temporary file in the same directory
+- **AND** system adds the diff (upper directory) as a new UUID-named layer
+- **AND** system updates the manifest.json with the new layer
+- **AND** system moves the temporary file to the final location atomically
+
+### Requirement: Snapshot supports custom output
+The system SHALL allow users to specify a custom output path.
+
+#### Scenario: Snapshot to new file
+- **WHEN** user runs `psi-workspace-snapshot --input ./workspace.squashfs --mount-point ./mounted-workspace --output ./workspace-v2.squashfs`
+- **THEN** system creates a new squashfs at the specified output path
+- **AND** the original squashfs is not modified
+
+### Requirement: Snapshot supports tag
+The system SHALL allow users to specify a tag for the new layer.
+
+#### Scenario: Snapshot with tag
+- **WHEN** user runs `psi-workspace-snapshot --input ./workspace.squashfs --mount-point ./mounted-workspace --tag v1.1`
+- **THEN** the new layer has tag "v1.1" in manifest.json
+- **AND** the tag is unique across all layers
+
+### Requirement: Snapshot updates manifest correctly
+The system SHALL update manifest.json with the new layer information.
+
+#### Scenario: Manifest update
+- **WHEN** snapshot completes successfully
+- **THEN** manifest.json contains a new layer entry with a UUID name
+- **AND** the new layer has a `parent` field referencing the current default layer
+- **AND** the `default` field is updated to the new layer UUID
+
+### Requirement: Snapshot generates UUID for new layer
+The system SHALL generate a UUID for the new layer.
+
+#### Scenario: UUID generation
+- **WHEN** snapshot creates a new layer
+- **THEN** the layer name is a valid UUID v4
+- **AND** the directory name in squashfs matches the UUID
+
+### Requirement: Snapshot handles empty diff
+The system SHALL handle cases where no changes were made.
+
+#### Scenario: No changes in upper directory
+- **WHEN** upper directory is empty (no modifications made)
+- **THEN** system logs a warning that no changes were detected
+- **AND** system still creates a snapshot (optional behavior)
+
+### Requirement: Snapshot validates inputs
+The system SHALL validate all inputs before snapshot.
+
+#### Scenario: Invalid squashfs file
+- **WHEN** user specifies a non-existent squashfs file
+- **THEN** system raises an exception with a clear error message
+
+#### Scenario: Invalid mount point
+- **WHEN** user specifies a path that is not an overlayfs mount
+- **THEN** system raises an exception with a clear error message
+
+### Requirement: Snapshot uses async operations
+The system SHALL use async operations where possible.
+
+#### Scenario: Async snapshot operations
+- **WHEN** snapshot is running
+- **THEN** file operations use async methods
+- **AND** squashfs creation uses async subprocess

--- a/openspec/specs/workspace-umount/spec.md
+++ b/openspec/specs/workspace-umount/spec.md
@@ -1,0 +1,35 @@
+## ADDED Requirements
+
+### Requirement: Umount cleanly removes overlayfs
+The system SHALL unmount the overlayfs and clean up temporary resources.
+
+#### Scenario: Umount mounted workspace
+- **WHEN** user runs `psi-workspace-umount --output ./mounted-workspace`
+- **THEN** system unmounts the overlayfs from the output path
+- **AND** system unmounts the squashfs from the temporary directory
+- **AND** system removes the temporary upper and work directories
+- **AND** system removes the temporary squashfs mount directory
+
+### Requirement: Umount validates mount point
+The system SHALL validate the specified path is a valid overlayfs mount.
+
+#### Scenario: Invalid mount point
+- **WHEN** user specifies a path that is not an overlayfs mount
+- **THEN** system raises an exception with a clear error message
+
+### Requirement: Umount handles partial cleanup
+The system SHALL attempt cleanup even if unmount fails.
+
+#### Scenario: Unmount failure with cleanup
+- **WHEN** overlayfs unmount fails
+- **THEN** system logs the error
+- **AND** system still attempts to clean up temporary directories
+- **AND** system raises an exception with both errors
+
+### Requirement: Umount uses async operations
+The system SHALL use async operations where possible.
+
+#### Scenario: Async cleanup operations
+- **WHEN** umount is running
+- **THEN** directory removal uses async methods
+- **AND** unmount system calls are executed via async subprocess

--- a/openspec/specs/workspace-unpack/spec.md
+++ b/openspec/specs/workspace-unpack/spec.md
@@ -1,0 +1,33 @@
+## ADDED Requirements
+
+### Requirement: Unpack extracts squashfs to directory
+The system SHALL extract a squashfs image to a directory without mounting.
+
+#### Scenario: Unpack squashfs
+- **WHEN** user runs `psi-workspace-unpack --input ./workspace.squashfs --output ./workspace`
+- **THEN** system extracts the squashfs contents to the output directory
+- **AND** the output directory structure matches the squashfs internal structure
+- **AND** overlay layers are created as separate directories
+
+### Requirement: Unpack preserves overlay structure
+The system SHALL create directories matching the squashfs overlay structure.
+
+#### Scenario: Multiple layers unpacked
+- **WHEN** squashfs contains base/, layer-1/, layer-2/ and manifest.json
+- **THEN** output directory contains base/, layer-1/, layer-2/ directories
+- **AND** manifest.json is copied to output directory
+
+### Requirement: Unpack validates input file
+The system SHALL validate the input squashfs exists and is readable.
+
+#### Scenario: Invalid input file
+- **WHEN** user specifies a non-existent squashfs file
+- **THEN** system raises an exception with a clear error message
+- **AND** no output directory is created
+
+### Requirement: Unpack uses async IO
+The system SHALL use async operations for all file system operations.
+
+#### Scenario: Async extraction
+- **WHEN** unpack is running
+- **THEN** all file reads and writes use async methods

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,11 @@ psi-ai-anthropic-messages = "psi_agent.ai.anthropic_messages.cli:main"
 psi-ai-openai-completions = "psi_agent.ai.openai_completions.cli:main"
 psi-session = "psi_agent.session.cli:main"
 psi-channel-cli = "psi_agent.channel.cli:main"
+psi-workspace-pack = "psi_agent.workspace.pack.cli:main"
+psi-workspace-unpack = "psi_agent.workspace.unpack.cli:main"
+psi-workspace-mount = "psi_agent.workspace.mount.cli:main"
+psi-workspace-umount = "psi_agent.workspace.umount.cli:main"
+psi-workspace-snapshot = "psi_agent.workspace.snapshot.cli:main"
 
 [build-system]
 requires = ["hatchling", "hatch-vcs"]

--- a/src/psi_agent/workspace/__init__.py
+++ b/src/psi_agent/workspace/__init__.py
@@ -1,0 +1,5 @@
+"""Workspace management components for psi-agent."""
+
+from psi_agent.workspace.manifest import Layer, Manifest
+
+__all__ = ["Manifest", "Layer"]

--- a/src/psi_agent/workspace/manifest.py
+++ b/src/psi_agent/workspace/manifest.py
@@ -1,0 +1,222 @@
+"""Manifest data structure for workspace squashfs images."""
+
+import json
+from dataclasses import dataclass, field
+from uuid import UUID
+
+from loguru import logger
+
+
+class ManifestParseError(Exception):
+    """Raised when manifest JSON parsing fails."""
+
+    pass
+
+
+@dataclass
+class Layer:
+    """A layer in the workspace squashfs.
+
+    Args:
+        parent: Optional parent layer UUID. Root layers have no parent.
+        tag: Optional human-readable tag for the layer.
+    """
+
+    parent: UUID | None = None
+    tag: str | None = None
+
+
+@dataclass
+class Manifest:
+    """Manifest for a workspace squashfs image.
+
+    Args:
+        layers: Mapping of layer UUID to Layer metadata.
+        default: UUID of the default (latest) layer.
+    """
+
+    layers: dict[UUID, Layer] = field(default_factory=dict)
+    default: UUID | None = None
+
+    def get_root_layers(self) -> list[UUID]:
+        """Get all root layers (layers without parent).
+
+        Returns:
+            List of root layer UUIDs.
+        """
+        return [uuid for uuid, layer in self.layers.items() if layer.parent is None]
+
+    def get_children(self, parent_uuid: UUID) -> list[UUID]:
+        """Get all direct children of a layer.
+
+        Args:
+            parent_uuid: UUID of the parent layer.
+
+        Returns:
+            List of child layer UUIDs.
+        """
+        return [uuid for uuid, layer in self.layers.items() if layer.parent == parent_uuid]
+
+    def resolve_chain(self, target_uuid: UUID) -> list[UUID]:
+        """Resolve the complete layer chain from root to target.
+
+        Args:
+            target_uuid: UUID of the target layer.
+
+        Returns:
+            List of UUIDs from root (first) to target (last).
+
+        Raises:
+            ValueError: If target_uuid is not in layers.
+        """
+        if target_uuid not in self.layers:
+            raise ValueError(f"Layer {target_uuid} not found in manifest")
+
+        chain: list[UUID] = [target_uuid]
+        current = target_uuid
+
+        while True:
+            layer = self.layers[current]
+            if layer.parent is None:
+                break
+            if layer.parent not in self.layers:
+                raise ValueError(f"Parent layer {layer.parent} not found for layer {current}")
+            chain.append(layer.parent)
+            current = layer.parent
+
+        chain.reverse()
+        return chain
+
+    def lookup_by_tag(self, tag: str) -> UUID:
+        """Look up a layer UUID by its tag.
+
+        Args:
+            tag: The tag to search for.
+
+        Returns:
+            The UUID of the layer with the given tag.
+
+        Raises:
+            ValueError: If no layer has the given tag.
+        """
+        for uuid, layer in self.layers.items():
+            if layer.tag == tag:
+                return uuid
+        raise ValueError(f"No layer found with tag '{tag}'")
+
+    def get_all_tags(self) -> dict[str, UUID]:
+        """Get all tags and their corresponding layer UUIDs.
+
+        Returns:
+            Mapping of tag to layer UUID.
+        """
+        return {layer.tag: uuid for uuid, layer in self.layers.items() if layer.tag is not None}
+
+
+def parse_manifest(json_str: str) -> Manifest:
+    """Parse a manifest from JSON string.
+
+    Args:
+        json_str: JSON string to parse.
+
+    Returns:
+        Parsed Manifest object.
+
+    Raises:
+        ManifestParseError: If JSON is invalid or doesn't match expected structure.
+    """
+    try:
+        data = json.loads(json_str)
+    except json.JSONDecodeError as e:
+        raise ManifestParseError(f"Invalid JSON: {e}") from e
+
+    if not isinstance(data, dict):
+        raise ManifestParseError("Manifest must be a JSON object")
+
+    if "layers" not in data:
+        raise ManifestParseError("Manifest must have 'layers' field")
+
+    if "default" not in data:
+        raise ManifestParseError("Manifest must have 'default' field")
+
+    layers_data = data["layers"]
+    if not isinstance(layers_data, dict):
+        raise ManifestParseError("'layers' must be an object")
+
+    layers: dict[UUID, Layer] = {}
+    for uuid_str, layer_data in layers_data.items():
+        try:
+            layer_uuid = UUID(uuid_str)
+        except ValueError as e:
+            raise ManifestParseError(f"Invalid UUID '{uuid_str}': {e}") from e
+
+        if not isinstance(layer_data, dict):
+            raise ManifestParseError(f"Layer '{uuid_str}' must be an object")
+
+        parent: UUID | None = None
+        if "parent" in layer_data:
+            try:
+                parent = UUID(layer_data["parent"])
+            except ValueError as e:
+                raise ManifestParseError(f"Invalid parent UUID in layer '{uuid_str}': {e}") from e
+
+        tag: str | None = layer_data.get("tag")
+        if tag is not None and not isinstance(tag, str):
+            raise ManifestParseError(f"Tag in layer '{uuid_str}' must be a string")
+
+        layers[layer_uuid] = Layer(parent=parent, tag=tag)
+
+    # Validate parent references
+    for uuid, layer in layers.items():
+        if layer.parent is not None and layer.parent not in layers:
+            raise ManifestParseError(f"Layer {uuid} references non-existent parent {layer.parent}")
+
+    # Validate default
+    try:
+        default_uuid = UUID(data["default"])
+    except ValueError as e:
+        raise ManifestParseError(f"Invalid default UUID: {e}") from e
+
+    if default_uuid not in layers:
+        raise ManifestParseError(f"Default layer {default_uuid} not found in layers")
+
+    # Validate tag uniqueness
+    tags: dict[str, UUID] = {}
+    for uuid, layer in layers.items():
+        if layer.tag is not None:
+            if layer.tag in tags:
+                raise ManifestParseError(
+                    f"Duplicate tag '{layer.tag}' in layers {tags[layer.tag]} and {uuid}"
+                )
+            tags[layer.tag] = uuid
+
+    logger.debug(f"Parsed manifest with {len(layers)} layers, default={default_uuid}")
+    return Manifest(layers=layers, default=default_uuid)
+
+
+def serialize_manifest(manifest: Manifest) -> str:
+    """Serialize a manifest to JSON string.
+
+    Args:
+        manifest: Manifest object to serialize.
+
+    Returns:
+        JSON string representation of the manifest.
+    """
+    layers_data: dict[str, dict[str, str]] = {}
+    for uuid, layer in manifest.layers.items():
+        layer_data: dict[str, str] = {}
+        if layer.parent is not None:
+            layer_data["parent"] = str(layer.parent)
+        if layer.tag is not None:
+            layer_data["tag"] = layer.tag
+        layers_data[str(uuid)] = layer_data
+
+    data = {
+        "layers": layers_data,
+        "default": str(manifest.default) if manifest.default else "",
+    }
+
+    result = json.dumps(data, indent=2)
+    logger.debug(f"Serialized manifest with {len(manifest.layers)} layers")
+    return result

--- a/src/psi_agent/workspace/mount/__init__.py
+++ b/src/psi_agent/workspace/mount/__init__.py
@@ -1,0 +1,5 @@
+"""Mount workspace squashfs as overlayfs."""
+
+from psi_agent.workspace.mount.api import mount
+
+__all__ = ["mount"]

--- a/src/psi_agent/workspace/mount/api.py
+++ b/src/psi_agent/workspace/mount/api.py
@@ -1,0 +1,215 @@
+"""Mount API for mounting squashfs as overlayfs."""
+
+import asyncio
+import tempfile
+from pathlib import Path
+from uuid import UUID
+
+import anyio
+from loguru import logger
+
+from psi_agent.workspace.manifest import Manifest, parse_manifest
+
+
+class MountError(Exception):
+    """Raised when mount operation fails."""
+
+    pass
+
+
+async def mount(
+    input_file: str | Path,
+    output_dir: str | Path,
+    layer: str | None = None,
+) -> None:
+    """Mount a squashfs image as overlayfs to a directory.
+
+    Args:
+        input_file: Path to the squashfs file.
+        output_dir: Path for the mount point.
+        layer: Optional layer UUID or tag to mount. Defaults to manifest default.
+
+    Raises:
+        MountError: If mount operation fails.
+    """
+    input_path = Path(input_file).resolve()
+    output_path = Path(output_dir).resolve()
+
+    # Validate input file
+    if not input_path.exists():
+        raise MountError(f"Input file does not exist: {input_path}")
+    if not input_path.is_file():
+        raise MountError(f"Input path is not a file: {input_path}")
+
+    logger.info(f"Mounting squashfs from {input_path} to {output_path}")
+
+    # Mount squashfs to temporary directory
+    squashfs_mount = await _create_temp_dir("squashfs-")
+    await _mount_squashfs(input_path, squashfs_mount)
+    logger.debug(f"Mounted squashfs to {squashfs_mount}")
+
+    # Read manifest
+    manifest_path = squashfs_mount / "manifest.json"
+    if not manifest_path.exists():
+        raise MountError("manifest.json not found in squashfs")
+
+    async with await anyio.open_file(manifest_path) as f:
+        manifest_content = await f.read()
+    manifest = parse_manifest(manifest_content)
+
+    # Resolve target layer
+    target_uuid = _resolve_target_layer(manifest, layer)
+    logger.debug(f"Target layer: {target_uuid}")
+
+    # Resolve layer chain
+    chain = manifest.resolve_chain(target_uuid)
+    logger.debug(f"Layer chain: {chain}")
+
+    # Create overlayfs directories
+    upper_dir = await _create_temp_dir("upper-")
+    work_dir = await _create_temp_dir("work-")
+
+    # Build lowerdir path
+    lowerdirs = [str(squashfs_mount / str(uuid)) for uuid in reversed(chain)]
+    lowerdir = ":".join(lowerdirs)
+
+    # Create output directory
+    output_path.mkdir(parents=True, exist_ok=True)
+
+    # Mount overlayfs
+    await _mount_overlayfs(output_path, lowerdir, upper_dir, work_dir)
+    logger.info(f"Successfully mounted overlayfs to {output_path}")
+
+    # Store mount info for later cleanup
+    mount_info_path = output_path / ".psi-mount-info"
+    mount_info = {
+        "squashfs_mount": str(squashfs_mount),
+        "upper_dir": str(upper_dir),
+        "work_dir": str(work_dir),
+    }
+    async with await anyio.open_file(mount_info_path, "w") as f:
+        await f.write(str(mount_info))
+
+
+def _resolve_target_layer(manifest: Manifest, layer: str | None) -> UUID:
+    """Resolve target layer from UUID, tag, or default.
+
+    Args:
+        manifest: The manifest to resolve from.
+        layer: Optional layer UUID or tag string.
+
+    Returns:
+        The resolved layer UUID.
+
+    Raises:
+        MountError: If layer cannot be resolved.
+    """
+    if layer is None:
+        if manifest.default is None:
+            raise MountError("No default layer in manifest")
+        return manifest.default
+
+    # Try to parse as UUID
+    try:
+        uuid = UUID(layer)
+        if uuid in manifest.layers:
+            return uuid
+    except ValueError:
+        pass
+
+    # Try to lookup by tag
+    try:
+        return manifest.lookup_by_tag(layer)
+    except ValueError:
+        pass
+
+    # Layer not found
+    available_tags = list(manifest.get_all_tags().keys())
+    raise MountError(f"Layer '{layer}' not found. Available tags: {available_tags}")
+
+
+async def _create_temp_dir(prefix: str) -> Path:
+    """Create a temporary directory.
+
+    Args:
+        prefix: Prefix for the directory name.
+
+    Returns:
+        Path to the created directory.
+    """
+    temp_base = Path(tempfile.gettempdir())
+    temp_dir = temp_base / f"{prefix}{tempfile.mkdtemp(prefix='')}"
+    temp_dir.mkdir(parents=True, exist_ok=True)
+    return temp_dir
+
+
+async def _mount_squashfs(squashfs_file: Path, mount_point: Path) -> None:
+    """Mount squashfs to directory.
+
+    Args:
+        squashfs_file: Path to squashfs file.
+        mount_point: Path to mount point.
+
+    Raises:
+        MountError: If mount fails.
+    """
+    mount_point.mkdir(parents=True, exist_ok=True)
+
+    cmd = ["mount", "-t", "squashfs", str(squashfs_file), str(mount_point), "-o", "loop"]
+    logger.debug(f"Running: {' '.join(cmd)}")
+
+    process = await asyncio.create_subprocess_exec(
+        *cmd,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+
+    _, stderr = await process.communicate()
+
+    if process.returncode != 0:
+        error_msg = stderr.decode() if stderr else "Unknown error"
+        raise MountError(f"Failed to mount squashfs: {error_msg}")
+
+
+async def _mount_overlayfs(
+    mount_point: Path,
+    lowerdir: str,
+    upper_dir: Path,
+    work_dir: Path,
+) -> None:
+    """Mount overlayfs to directory.
+
+    Args:
+        mount_point: Path to mount point.
+        lowerdir: Colon-separated lower directory paths.
+        upper_dir: Path to upper directory.
+        work_dir: Path to work directory.
+
+    Raises:
+        MountError: If mount fails.
+    """
+    upper_dir.mkdir(parents=True, exist_ok=True)
+    work_dir.mkdir(parents=True, exist_ok=True)
+
+    cmd = [
+        "mount",
+        "-t",
+        "overlay",
+        "overlay",
+        str(mount_point),
+        "-o",
+        f"lowerdir={lowerdir},upperdir={upper_dir},workdir={work_dir}",
+    ]
+    logger.debug(f"Running: {' '.join(cmd)}")
+
+    process = await asyncio.create_subprocess_exec(
+        *cmd,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+
+    _, stderr = await process.communicate()
+
+    if process.returncode != 0:
+        error_msg = stderr.decode() if stderr else "Unknown error"
+        raise MountError(f"Failed to mount overlayfs: {error_msg}")

--- a/src/psi_agent/workspace/mount/cli.py
+++ b/src/psi_agent/workspace/mount/cli.py
@@ -1,0 +1,31 @@
+"""CLI entry point for psi-workspace-mount."""
+
+import asyncio
+
+import tyro
+
+from psi_agent.workspace.mount.api import mount
+
+
+def run(
+    input_file: str,
+    output_dir: str,
+    layer: str | None = None,
+) -> None:
+    """Mount a squashfs image as overlayfs to a directory.
+
+    Args:
+        input_file: Path to the squashfs file.
+        output_dir: Path for the mount point.
+        layer: Optional layer UUID or tag to mount.
+    """
+    asyncio.run(mount(input_file, output_dir, layer))
+
+
+def main() -> None:
+    """CLI entry point."""
+    tyro.cli(run)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/psi_agent/workspace/pack/__init__.py
+++ b/src/psi_agent/workspace/pack/__init__.py
@@ -1,0 +1,5 @@
+"""Pack workspace directory into squashfs image."""
+
+from psi_agent.workspace.pack.api import pack
+
+__all__ = ["pack"]

--- a/src/psi_agent/workspace/pack/api.py
+++ b/src/psi_agent/workspace/pack/api.py
@@ -1,0 +1,126 @@
+"""Pack API for creating squashfs from workspace directory."""
+
+import asyncio
+import tempfile
+from pathlib import Path
+from uuid import uuid4
+
+import anyio
+from loguru import logger
+
+from psi_agent.workspace.manifest import Layer, Manifest, serialize_manifest
+
+
+class PackError(Exception):
+    """Raised when pack operation fails."""
+
+    pass
+
+
+async def pack(
+    input_dir: str | Path,
+    output_file: str | Path,
+    tag: str | None = None,
+) -> None:
+    """Pack a workspace directory into a squashfs image.
+
+    Args:
+        input_dir: Path to the workspace directory.
+        output_file: Path for the output squashfs file.
+        tag: Optional tag for the layer.
+
+    Raises:
+        PackError: If pack operation fails.
+    """
+    input_path = Path(input_dir).resolve()
+    output_path = Path(output_file).resolve()
+
+    # Validate input directory
+    if not input_path.exists():
+        raise PackError(f"Input directory does not exist: {input_path}")
+    if not input_path.is_dir():
+        raise PackError(f"Input path is not a directory: {input_path}")
+
+    # Generate UUID for the layer
+    layer_uuid = uuid4()
+    layer_name = str(layer_uuid)
+
+    logger.info(f"Packing workspace from {input_path} to {output_path}")
+    logger.debug(f"Layer UUID: {layer_uuid}, Tag: {tag}")
+
+    # Create manifest
+    manifest = Manifest(
+        layers={layer_uuid: Layer(tag=tag)},
+        default=layer_uuid,
+    )
+
+    # Create temporary directory for staging
+    with tempfile.TemporaryDirectory() as temp_dir:
+        temp_path = Path(temp_dir)
+
+        # Create layer directory
+        layer_dir = temp_path / layer_name
+        layer_dir.mkdir()
+
+        # Copy input directory contents to layer directory
+        await _copy_directory(input_path, layer_dir)
+
+        # Write manifest.json
+        manifest_path = temp_path / "manifest.json"
+        manifest_content = serialize_manifest(manifest)
+        async with await anyio.open_file(manifest_path, "w") as f:
+            await f.write(manifest_content)
+
+        # Create squashfs
+        await _create_squashfs(temp_path, output_path)
+
+    logger.info(f"Successfully created squashfs at {output_path}")
+
+
+async def _copy_directory(src: Path, dst: Path) -> None:
+    """Copy directory contents asynchronously.
+
+    Args:
+        src: Source directory path.
+        dst: Destination directory path.
+    """
+    for item in src.iterdir():
+        dest_item = dst / item.name
+        if item.is_dir():
+            dest_item.mkdir()
+            await _copy_directory(item, dest_item)
+        else:
+            async with await anyio.open_file(item, "rb") as src_file:
+                content = await src_file.read()
+            async with await anyio.open_file(dest_item, "wb") as dst_file:
+                await dst_file.write(content)
+
+
+async def _create_squashfs(src_dir: Path, output_file: Path) -> None:
+    """Create squashfs image from directory.
+
+    Args:
+        src_dir: Source directory path.
+        output_file: Output squashfs file path.
+
+    Raises:
+        PackError: If mksquashfs command fails.
+    """
+    # Ensure parent directory exists
+    output_file.parent.mkdir(parents=True, exist_ok=True)
+
+    # Run mksquashfs command
+    cmd = ["mksquashfs", str(src_dir), str(output_file), "-noappend", "-comp", "xz"]
+    logger.debug(f"Running: {' '.join(cmd)}")
+
+    process = await asyncio.create_subprocess_exec(
+        *cmd,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+
+    _, stderr = await process.communicate()
+
+    if process.returncode != 0:
+        error_msg = stderr.decode() if stderr else "Unknown error"
+        raise PackError(f"mksquashfs failed: {error_msg}")

--- a/src/psi_agent/workspace/pack/cli.py
+++ b/src/psi_agent/workspace/pack/cli.py
@@ -1,0 +1,31 @@
+"""CLI entry point for psi-workspace-pack."""
+
+import asyncio
+
+import tyro
+
+from psi_agent.workspace.pack.api import pack
+
+
+def run(
+    input_dir: str,
+    output_file: str,
+    tag: str | None = None,
+) -> None:
+    """Pack a workspace directory into a squashfs image.
+
+    Args:
+        input_dir: Path to the workspace directory.
+        output_file: Path for the output squashfs file.
+        tag: Optional tag for the layer.
+    """
+    asyncio.run(pack(input_dir, output_file, tag))
+
+
+def main() -> None:
+    """CLI entry point."""
+    tyro.cli(run)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/psi_agent/workspace/snapshot/__init__.py
+++ b/src/psi_agent/workspace/snapshot/__init__.py
@@ -1,0 +1,5 @@
+"""Snapshot workspace changes."""
+
+from psi_agent.workspace.snapshot.api import snapshot
+
+__all__ = ["snapshot"]

--- a/src/psi_agent/workspace/snapshot/api.py
+++ b/src/psi_agent/workspace/snapshot/api.py
@@ -1,0 +1,219 @@
+"""Snapshot API for creating workspace snapshots."""
+
+import asyncio
+import shutil
+import tempfile
+from pathlib import Path
+from uuid import uuid4
+
+import anyio
+from loguru import logger
+
+from psi_agent.workspace.manifest import Layer, Manifest, parse_manifest, serialize_manifest
+
+
+class SnapshotError(Exception):
+    """Raised when snapshot operation fails."""
+
+    pass
+
+
+async def snapshot(
+    input_file: str | Path,
+    mount_point: str | Path,
+    output_file: str | None = None,
+    tag: str | None = None,
+) -> None:
+    """Create a snapshot of a mounted workspace.
+
+    Args:
+        input_file: Path to the original squashfs file.
+        mount_point: Path to the overlayfs mount point.
+        output_file: Optional path for output squashfs. Defaults to overwriting input.
+        tag: Optional tag for the new layer.
+
+    Raises:
+        SnapshotError: If snapshot operation fails.
+    """
+    input_path = Path(input_file).resolve()
+    mount_path = Path(mount_point).resolve()
+
+    # Validate inputs
+    if not input_path.exists():
+        raise SnapshotError(f"Input file does not exist: {input_path}")
+    if not mount_path.exists():
+        raise SnapshotError(f"Mount point does not exist: {mount_path}")
+
+    # Determine output path
+    output_path = Path(output_file).resolve() if output_file else input_path
+
+    logger.info(f"Creating snapshot from {mount_path} to {output_path}")
+    logger.debug(f"Input: {input_path}, Tag: {tag}")
+
+    # Read mount info to get upper directory
+    mount_info_path = mount_path / ".psi-mount-info"
+    if not mount_info_path.exists():
+        raise SnapshotError(f"Mount info file not found: {mount_info_path}")
+
+    async with await anyio.open_file(mount_info_path) as f:
+        info_content = await f.read()
+
+    import ast
+
+    try:
+        mount_info = ast.literal_eval(info_content)
+    except (SyntaxError, ValueError) as e:
+        raise SnapshotError(f"Invalid mount info: {e}") from e
+
+    upper_dir = Path(mount_info["upper_dir"])
+
+    # Check if there are any changes
+    if not any(upper_dir.iterdir()):
+        logger.warning("No changes detected in upper directory")
+
+    # Read current manifest from squashfs
+    manifest = await _read_manifest_from_squashfs(input_path)
+
+    # Generate new layer UUID
+    new_layer_uuid = uuid4()
+
+    # Create new layer
+    if manifest.default is None:
+        raise SnapshotError("No default layer in manifest")
+
+    new_layer = Layer(parent=manifest.default, tag=tag)
+
+    # Update manifest
+    manifest.layers[new_layer_uuid] = new_layer
+    manifest.default = new_layer_uuid
+
+    logger.debug(f"New layer: {new_layer_uuid}, parent: {manifest.default}")
+
+    # Create temporary directory for staging
+    with tempfile.TemporaryDirectory() as temp_dir:
+        temp_path = Path(temp_dir)
+
+        # Copy squashfs contents to temp directory
+        await _extract_squashfs(input_path, temp_path)
+
+        # Copy upper directory as new layer
+        new_layer_dir = temp_path / str(new_layer_uuid)
+        await _copy_directory(upper_dir, new_layer_dir)
+
+        # Write updated manifest
+        manifest_path = temp_path / "manifest.json"
+        manifest_content = serialize_manifest(manifest)
+        async with await anyio.open_file(manifest_path, "w") as f:
+            await f.write(manifest_content)
+
+        # Create new squashfs
+        temp_squashfs = temp_path / "new.squashfs"
+        await _create_squashfs(temp_path, temp_squashfs)
+
+        # Atomic move to output path
+        if output_path.exists():
+            # Create temp file in same directory for atomic move
+            temp_output = output_path.with_suffix(".tmp")
+            shutil.move(str(temp_squashfs), str(temp_output))
+            shutil.move(str(temp_output), str(output_path))
+        else:
+            shutil.move(str(temp_squashfs), str(output_path))
+
+    logger.info(f"Successfully created snapshot at {output_path}")
+
+
+async def _read_manifest_from_squashfs(squashfs_file: Path) -> Manifest:
+    """Read manifest from squashfs file.
+
+    Args:
+        squashfs_file: Path to squashfs file.
+
+    Returns:
+        Manifest object.
+    """
+    with tempfile.TemporaryDirectory() as temp_dir:
+        temp_path = Path(temp_dir)
+
+        # Extract just the manifest.json
+        cmd = ["unsquashfs", "-d", str(temp_path), str(squashfs_file), "manifest.json"]
+        process = await asyncio.create_subprocess_exec(
+            *cmd,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        await process.communicate()
+
+        manifest_path = temp_path / "manifest.json"
+        if not manifest_path.exists():
+            raise SnapshotError("manifest.json not found in squashfs")
+
+        async with await anyio.open_file(manifest_path) as f:
+            content = await f.read()
+
+        return parse_manifest(content)
+
+
+async def _extract_squashfs(squashfs_file: Path, output_dir: Path) -> None:
+    """Extract squashfs contents to directory.
+
+    Args:
+        squashfs_file: Path to squashfs file.
+        output_dir: Path to output directory.
+    """
+    cmd = ["unsquashfs", "-d", str(output_dir), str(squashfs_file)]
+    logger.debug(f"Running: {' '.join(cmd)}")
+
+    process = await asyncio.create_subprocess_exec(
+        *cmd,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+
+    _, stderr = await process.communicate()
+
+    if process.returncode != 0:
+        error_msg = stderr.decode() if stderr else "Unknown error"
+        raise SnapshotError(f"Failed to extract squashfs: {error_msg}")
+
+
+async def _copy_directory(src: Path, dst: Path) -> None:
+    """Copy directory contents.
+
+    Args:
+        src: Source directory.
+        dst: Destination directory.
+    """
+    dst.mkdir(parents=True, exist_ok=True)
+
+    for item in src.iterdir():
+        dest_item = dst / item.name
+        if item.is_dir():
+            await _copy_directory(item, dest_item)
+        else:
+            async with await anyio.open_file(item, "rb") as src_file:
+                content = await src_file.read()
+            async with await anyio.open_file(dest_item, "wb") as dst_file:
+                await dst_file.write(content)
+
+
+async def _create_squashfs(src_dir: Path, output_file: Path) -> None:
+    """Create squashfs from directory.
+
+    Args:
+        src_dir: Source directory.
+        output_file: Output squashfs file.
+    """
+    cmd = ["mksquashfs", str(src_dir), str(output_file), "-noappend", "-comp", "xz"]
+    logger.debug(f"Running: {' '.join(cmd)}")
+
+    process = await asyncio.create_subprocess_exec(
+        *cmd,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+
+    _, stderr = await process.communicate()
+
+    if process.returncode != 0:
+        error_msg = stderr.decode() if stderr else "Unknown error"
+        raise SnapshotError(f"Failed to create squashfs: {error_msg}")

--- a/src/psi_agent/workspace/snapshot/cli.py
+++ b/src/psi_agent/workspace/snapshot/cli.py
@@ -1,0 +1,33 @@
+"""CLI entry point for psi-workspace-snapshot."""
+
+import asyncio
+
+import tyro
+
+from psi_agent.workspace.snapshot.api import snapshot
+
+
+def run(
+    input_file: str,
+    mount_point: str,
+    output_file: str | None = None,
+    tag: str | None = None,
+) -> None:
+    """Create a snapshot of a mounted workspace.
+
+    Args:
+        input_file: Path to the original squashfs file.
+        mount_point: Path to the overlayfs mount point.
+        output_file: Optional path for output squashfs.
+        tag: Optional tag for the new layer.
+    """
+    asyncio.run(snapshot(input_file, mount_point, output_file, tag))
+
+
+def main() -> None:
+    """CLI entry point."""
+    tyro.cli(run)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/psi_agent/workspace/umount/__init__.py
+++ b/src/psi_agent/workspace/umount/__init__.py
@@ -1,0 +1,5 @@
+"""Umount workspace overlayfs."""
+
+from psi_agent.workspace.umount.api import umount
+
+__all__ = ["umount"]

--- a/src/psi_agent/workspace/umount/api.py
+++ b/src/psi_agent/workspace/umount/api.py
@@ -1,0 +1,119 @@
+"""Umount API for unmounting overlayfs workspace."""
+
+import asyncio
+from pathlib import Path
+
+import anyio
+from loguru import logger
+
+
+class UmountError(Exception):
+    """Raised when umount operation fails."""
+
+    pass
+
+
+async def umount(
+    mount_point: str | Path,
+) -> None:
+    """Unmount an overlayfs workspace.
+
+    Args:
+        mount_point: Path to the mount point.
+
+    Raises:
+        UmountError: If umount operation fails.
+    """
+    mount_path = Path(mount_point).resolve()
+
+    # Validate mount point
+    if not mount_path.exists():
+        raise UmountError(f"Mount point does not exist: {mount_path}")
+
+    logger.info(f"Unmounting workspace at {mount_path}")
+
+    # Read mount info
+    mount_info_path = mount_path / ".psi-mount-info"
+    if not mount_info_path.exists():
+        raise UmountError(f"Mount info file not found: {mount_info_path}")
+
+    async with await anyio.open_file(mount_info_path) as f:
+        info_content = await f.read()
+
+    # Parse mount info (simple dict-like string)
+    # Format: {'squashfs_mount': '/tmp/...', 'upper_dir': '/tmp/...', 'work_dir': '/tmp/...'}
+    import ast
+
+    try:
+        mount_info = ast.literal_eval(info_content)
+    except (SyntaxError, ValueError) as e:
+        raise UmountError(f"Invalid mount info: {e}") from e
+
+    squashfs_mount = Path(mount_info["squashfs_mount"])
+    upper_dir = Path(mount_info["upper_dir"])
+    work_dir = Path(mount_info["work_dir"])
+
+    # Unmount overlayfs
+    await _unmount(mount_path)
+
+    # Unmount squashfs
+    await _unmount(squashfs_mount)
+
+    # Clean up temporary directories
+    await _cleanup_directory(upper_dir)
+    await _cleanup_directory(work_dir)
+    await _cleanup_directory(squashfs_mount)
+
+    # Remove mount info file
+    await anyio.Path(mount_info_path).unlink()
+
+    logger.info(f"Successfully unmounted and cleaned up {mount_path}")
+
+
+async def _unmount(mount_point: Path) -> None:
+    """Unmount a filesystem.
+
+    Args:
+        mount_point: Path to mount point.
+
+    Raises:
+        UmountError: If unmount fails.
+    """
+    cmd = ["umount", str(mount_point)]
+    logger.debug(f"Running: {' '.join(cmd)}")
+
+    process = await asyncio.create_subprocess_exec(
+        *cmd,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+
+    _, stderr = await process.communicate()
+
+    if process.returncode != 0:
+        error_msg = stderr.decode() if stderr else "Unknown error"
+        raise UmountError(f"Failed to unmount {mount_point}: {error_msg}")
+
+
+async def _cleanup_directory(dir_path: Path) -> None:
+    """Remove a directory and its contents.
+
+    Args:
+        dir_path: Path to directory to remove.
+    """
+    if not dir_path.exists():
+        return
+
+    try:
+        # Remove directory contents
+        for item in dir_path.iterdir():
+            if item.is_dir():
+                await _cleanup_directory(item)
+            else:
+                await anyio.Path(item).unlink()
+
+        # Remove empty directory
+        await anyio.Path(dir_path).rmdir()
+        logger.debug(f"Cleaned up directory: {dir_path}")
+    except Exception as e:
+        logger.warning(f"Failed to cleanup directory {dir_path}: {e}")

--- a/src/psi_agent/workspace/umount/cli.py
+++ b/src/psi_agent/workspace/umount/cli.py
@@ -1,0 +1,27 @@
+"""CLI entry point for psi-workspace-umount."""
+
+import asyncio
+
+import tyro
+
+from psi_agent.workspace.umount.api import umount
+
+
+def run(
+    mount_point: str,
+) -> None:
+    """Unmount an overlayfs workspace.
+
+    Args:
+        mount_point: Path to the mount point.
+    """
+    asyncio.run(umount(mount_point))
+
+
+def main() -> None:
+    """CLI entry point."""
+    tyro.cli(run)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/psi_agent/workspace/unpack/__init__.py
+++ b/src/psi_agent/workspace/unpack/__init__.py
@@ -1,0 +1,5 @@
+"""Unpack workspace squashfs to directory."""
+
+from psi_agent.workspace.unpack.api import unpack
+
+__all__ = ["unpack"]

--- a/src/psi_agent/workspace/unpack/api.py
+++ b/src/psi_agent/workspace/unpack/api.py
@@ -1,0 +1,63 @@
+"""Unpack API for extracting squashfs to directory."""
+
+import asyncio
+from pathlib import Path
+
+from loguru import logger
+
+
+class UnpackError(Exception):
+    """Raised when unpack operation fails."""
+
+    pass
+
+
+async def unpack(
+    input_file: str | Path,
+    output_dir: str | Path,
+) -> None:
+    """Unpack a squashfs image to a directory.
+
+    Args:
+        input_file: Path to the squashfs file.
+        output_dir: Path for the output directory.
+
+    Raises:
+        UnpackError: If unpack operation fails.
+    """
+    input_path = Path(input_file).resolve()
+    output_path = Path(output_dir).resolve()
+
+    # Validate input file
+    if not input_path.exists():
+        raise UnpackError(f"Input file does not exist: {input_path}")
+    if not input_path.is_file():
+        raise UnpackError(f"Input path is not a file: {input_path}")
+
+    logger.info(f"Unpacking squashfs from {input_path} to {output_path}")
+
+    # Create output directory
+    output_path.mkdir(parents=True, exist_ok=True)
+
+    # Run unsquashfs command
+    cmd = [
+        "unsquashfs",
+        "-d",
+        str(output_path),
+        str(input_path),
+    ]
+    logger.debug(f"Running: {' '.join(cmd)}")
+
+    process = await asyncio.create_subprocess_exec(
+        *cmd,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+
+    _, stderr = await process.communicate()
+
+    if process.returncode != 0:
+        error_msg = stderr.decode() if stderr else "Unknown error"
+        raise UnpackError(f"unsquashfs failed: {error_msg}")
+
+    logger.info(f"Successfully unpacked to {output_path}")

--- a/src/psi_agent/workspace/unpack/cli.py
+++ b/src/psi_agent/workspace/unpack/cli.py
@@ -1,0 +1,29 @@
+"""CLI entry point for psi-workspace-unpack."""
+
+import asyncio
+
+import tyro
+
+from psi_agent.workspace.unpack.api import unpack
+
+
+def run(
+    input_file: str,
+    output_dir: str,
+) -> None:
+    """Unpack a squashfs image to a directory.
+
+    Args:
+        input_file: Path to the squashfs file.
+        output_dir: Path for the output directory.
+    """
+    asyncio.run(unpack(input_file, output_dir))
+
+
+def main() -> None:
+    """CLI entry point."""
+    tyro.cli(run)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/workspace/__init__.py
+++ b/tests/workspace/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for workspace module."""

--- a/tests/workspace/test_integration.py
+++ b/tests/workspace/test_integration.py
@@ -1,0 +1,65 @@
+"""Integration tests for workspace components.
+
+Note: These tests require root privileges for mount operations.
+Run with: sudo uv run pytest tests/workspace/test_integration.py -v
+"""
+
+import os
+from pathlib import Path
+
+import pytest
+
+from psi_agent.workspace.pack.api import pack
+from psi_agent.workspace.unpack.api import unpack
+
+
+@pytest.mark.skipif(os.geteuid() != 0, reason="Requires root privileges")
+class TestIntegration:
+    """Integration tests for workspace components."""
+
+    async def test_pack_unpack_roundtrip(self, tmp_path: Path) -> None:
+        """Pack and unpack should preserve workspace contents."""
+        # Create input workspace
+        input_dir = tmp_path / "workspace"
+        input_dir.mkdir()
+        (input_dir / "tools").mkdir()
+        (input_dir / "tools" / "test.py").write_text("# test tool")
+        (input_dir / "skills").mkdir()
+        (input_dir / "skills" / "example").mkdir()
+        (input_dir / "skills" / "example" / "SKILL.md").write_text(
+            "---\nname: test\n---\nTest skill"
+        )
+
+        # Pack
+        squashfs_file = tmp_path / "workspace.squashfs"
+        await pack(input_dir, squashfs_file, tag="v1.0")
+
+        # Unpack
+        output_dir = tmp_path / "unpacked"
+        await unpack(squashfs_file, output_dir)
+
+        # Verify contents
+        assert (output_dir / "manifest.json").exists()
+        # The layer directory name is a UUID, so we check for any directory
+        layer_dirs = [d for d in output_dir.iterdir() if d.is_dir() and d.name != "manifest.json"]
+        assert len(layer_dirs) == 1
+
+        layer_dir = layer_dirs[0]
+        assert (layer_dir / "tools" / "test.py").exists()
+        assert (layer_dir / "skills" / "example" / "SKILL.md").exists()
+
+
+class TestNonPrivileged:
+    """Tests that don't require root privileges."""
+
+    async def test_pack_creates_valid_squashfs(self, tmp_path: Path) -> None:
+        """Pack creates a valid squashfs file."""
+        input_dir = tmp_path / "workspace"
+        input_dir.mkdir()
+        (input_dir / "test.txt").write_text("hello")
+
+        squashfs_file = tmp_path / "workspace.squashfs"
+        await pack(input_dir, squashfs_file)
+
+        assert squashfs_file.exists()
+        assert squashfs_file.stat().st_size > 0

--- a/tests/workspace/test_manifest.py
+++ b/tests/workspace/test_manifest.py
@@ -1,0 +1,263 @@
+"""Tests for manifest data structure."""
+
+from uuid import uuid4
+
+import pytest
+
+from psi_agent.workspace.manifest import (
+    Layer,
+    Manifest,
+    ManifestParseError,
+    parse_manifest,
+    serialize_manifest,
+)
+
+
+class TestLayer:
+    """Tests for Layer dataclass."""
+
+    def test_layer_default_values(self) -> None:
+        """Layer with default values has no parent or tag."""
+        layer = Layer()
+        assert layer.parent is None
+        assert layer.tag is None
+
+    def test_layer_with_parent(self) -> None:
+        """Layer can have a parent UUID."""
+        parent_uuid = uuid4()
+        layer = Layer(parent=parent_uuid)
+        assert layer.parent == parent_uuid
+        assert layer.tag is None
+
+    def test_layer_with_tag(self) -> None:
+        """Layer can have a tag."""
+        layer = Layer(tag="v1.0")
+        assert layer.parent is None
+        assert layer.tag == "v1.0"
+
+    def test_layer_with_parent_and_tag(self) -> None:
+        """Layer can have both parent and tag."""
+        parent_uuid = uuid4()
+        layer = Layer(parent=parent_uuid, tag="v1.1")
+        assert layer.parent == parent_uuid
+        assert layer.tag == "v1.1"
+
+
+class TestManifest:
+    """Tests for Manifest dataclass."""
+
+    def test_manifest_default_values(self) -> None:
+        """Manifest with default values has empty layers and no default."""
+        manifest = Manifest()
+        assert manifest.layers == {}
+        assert manifest.default is None
+
+    def test_get_root_layers(self) -> None:
+        """get_root_layers returns layers without parent."""
+        root_uuid = uuid4()
+        child_uuid = uuid4()
+        manifest = Manifest(
+            layers={
+                root_uuid: Layer(tag="root"),
+                child_uuid: Layer(parent=root_uuid, tag="child"),
+            },
+            default=child_uuid,
+        )
+        roots = manifest.get_root_layers()
+        assert roots == [root_uuid]
+
+    def test_get_children(self) -> None:
+        """get_children returns direct children of a layer."""
+        root_uuid = uuid4()
+        child1_uuid = uuid4()
+        child2_uuid = uuid4()
+        manifest = Manifest(
+            layers={
+                root_uuid: Layer(),
+                child1_uuid: Layer(parent=root_uuid),
+                child2_uuid: Layer(parent=root_uuid),
+            },
+            default=child1_uuid,
+        )
+        children = manifest.get_children(root_uuid)
+        assert set(children) == {child1_uuid, child2_uuid}
+
+    def test_resolve_chain(self) -> None:
+        """resolve_chain returns chain from root to target."""
+        root_uuid = uuid4()
+        mid_uuid = uuid4()
+        leaf_uuid = uuid4()
+        manifest = Manifest(
+            layers={
+                root_uuid: Layer(tag="root"),
+                mid_uuid: Layer(parent=root_uuid, tag="mid"),
+                leaf_uuid: Layer(parent=mid_uuid, tag="leaf"),
+            },
+            default=leaf_uuid,
+        )
+        chain = manifest.resolve_chain(leaf_uuid)
+        assert chain == [root_uuid, mid_uuid, leaf_uuid]
+
+    def test_resolve_chain_root_layer(self) -> None:
+        """resolve_chain on root layer returns just the root."""
+        root_uuid = uuid4()
+        manifest = Manifest(
+            layers={root_uuid: Layer(tag="root")},
+            default=root_uuid,
+        )
+        chain = manifest.resolve_chain(root_uuid)
+        assert chain == [root_uuid]
+
+    def test_resolve_chain_invalid_uuid(self) -> None:
+        """resolve_chain raises ValueError for invalid UUID."""
+        manifest = Manifest()
+        with pytest.raises(ValueError, match="not found"):
+            manifest.resolve_chain(uuid4())
+
+    def test_lookup_by_tag(self) -> None:
+        """lookup_by_tag returns UUID for given tag."""
+        layer_uuid = uuid4()
+        manifest = Manifest(
+            layers={layer_uuid: Layer(tag="v1.0")},
+            default=layer_uuid,
+        )
+        result = manifest.lookup_by_tag("v1.0")
+        assert result == layer_uuid
+
+    def test_lookup_by_tag_not_found(self) -> None:
+        """lookup_by_tag raises ValueError for unknown tag."""
+        manifest = Manifest()
+        with pytest.raises(ValueError, match="No layer found"):
+            manifest.lookup_by_tag("unknown")
+
+    def test_get_all_tags(self) -> None:
+        """get_all_tags returns mapping of tags to UUIDs."""
+        uuid1 = uuid4()
+        uuid2 = uuid4()
+        manifest = Manifest(
+            layers={
+                uuid1: Layer(tag="v1.0"),
+                uuid2: Layer(tag="v1.1"),
+            },
+            default=uuid2,
+        )
+        tags = manifest.get_all_tags()
+        assert tags == {"v1.0": uuid1, "v1.1": uuid2}
+
+
+class TestParseManifest:
+    """Tests for parse_manifest function."""
+
+    def test_parse_valid_manifest(self) -> None:
+        """Parse a valid manifest JSON."""
+        uuid1 = uuid4()
+        uuid2 = uuid4()
+        json_str = f'''{{
+            "layers": {{
+                "{uuid1}": {{}},
+                "{uuid2}": {{ "parent": "{uuid1}", "tag": "v1.1" }}
+            }},
+            "default": "{uuid2}"
+        }}'''
+        manifest = parse_manifest(json_str)
+        assert len(manifest.layers) == 2
+        assert manifest.default == uuid2
+        assert manifest.layers[uuid1].parent is None
+        assert manifest.layers[uuid1].tag is None
+        assert manifest.layers[uuid2].parent == uuid1
+        assert manifest.layers[uuid2].tag == "v1.1"
+
+    def test_parse_invalid_json(self) -> None:
+        """Parse raises ManifestParseError for invalid JSON."""
+        with pytest.raises(ManifestParseError, match="Invalid JSON"):
+            parse_manifest("not json")
+
+    def test_parse_missing_layers(self) -> None:
+        """Parse raises ManifestParseError when layers is missing."""
+        with pytest.raises(ManifestParseError, match="must have 'layers'"):
+            parse_manifest('{"default": "uuid"}')
+
+    def test_parse_missing_default(self) -> None:
+        """Parse raises ManifestParseError when default is missing."""
+        uuid1 = uuid4()
+        with pytest.raises(ManifestParseError, match="must have 'default'"):
+            parse_manifest(f'{{"layers": {{"{uuid1}": {{}}}}}}')
+
+    def test_parse_invalid_uuid(self) -> None:
+        """Parse raises ManifestParseError for invalid UUID."""
+        with pytest.raises(ManifestParseError, match="Invalid UUID"):
+            parse_manifest('{"layers": {"not-a-uuid": {}}, "default": "not-a-uuid"}')
+
+    def test_parse_nonexistent_parent(self) -> None:
+        """Parse raises ManifestParseError for nonexistent parent."""
+        uuid1 = uuid4()
+        uuid2 = uuid4()
+        with pytest.raises(ManifestParseError, match="references non-existent parent"):
+            parse_manifest(f'''{{
+                "layers": {{
+                    "{uuid1}": {{ "parent": "{uuid2}" }}
+                }},
+                "default": "{uuid1}"
+            }}''')
+
+    def test_parse_nonexistent_default(self) -> None:
+        """Parse raises ManifestParseError for nonexistent default."""
+        uuid1 = uuid4()
+        uuid2 = uuid4()
+        with pytest.raises(ManifestParseError, match="Default layer.*not found"):
+            parse_manifest(f'''{{
+                "layers": {{
+                    "{uuid1}": {{}}
+                }},
+                "default": "{uuid2}"
+            }}''')
+
+    def test_parse_duplicate_tags(self) -> None:
+        """Parse raises ManifestParseError for duplicate tags."""
+        uuid1 = uuid4()
+        uuid2 = uuid4()
+        with pytest.raises(ManifestParseError, match="Duplicate tag"):
+            parse_manifest(f'''{{
+                "layers": {{
+                    "{uuid1}": {{ "tag": "same" }},
+                    "{uuid2}": {{ "tag": "same" }}
+                }},
+                "default": "{uuid2}"
+            }}''')
+
+
+class TestSerializeManifest:
+    """Tests for serialize_manifest function."""
+
+    def test_serialize_manifest(self) -> None:
+        """Serialize a manifest to JSON."""
+        uuid1 = uuid4()
+        uuid2 = uuid4()
+        manifest = Manifest(
+            layers={
+                uuid1: Layer(tag="v1.0"),
+                uuid2: Layer(parent=uuid1, tag="v1.1"),
+            },
+            default=uuid2,
+        )
+        json_str = serialize_manifest(manifest)
+        # Parse back to verify
+        parsed = parse_manifest(json_str)
+        assert parsed.layers.keys() == manifest.layers.keys()
+        assert parsed.default == manifest.default
+
+    def test_serialize_roundtrip(self) -> None:
+        """Serialize and parse should be identity."""
+        uuid1 = uuid4()
+        uuid2 = uuid4()
+        original = Manifest(
+            layers={
+                uuid1: Layer(),
+                uuid2: Layer(parent=uuid1, tag="test"),
+            },
+            default=uuid2,
+        )
+        json_str = serialize_manifest(original)
+        parsed = parse_manifest(json_str)
+        assert parsed.layers == original.layers
+        assert parsed.default == original.default

--- a/tests/workspace/test_mount.py
+++ b/tests/workspace/test_mount.py
@@ -1,0 +1,74 @@
+"""Tests for mount module."""
+
+from pathlib import Path
+from uuid import uuid4
+
+import pytest
+
+from psi_agent.workspace.manifest import Layer, Manifest
+from psi_agent.workspace.mount.api import MountError, _resolve_target_layer, mount
+
+
+class TestResolveTargetLayer:
+    """Tests for _resolve_target_layer function."""
+
+    def test_resolve_default_layer(self) -> None:
+        """Resolve default layer when no layer specified."""
+        uuid1 = uuid4()
+        manifest = Manifest(
+            layers={uuid1: Layer(tag="v1.0")},
+            default=uuid1,
+        )
+        result = _resolve_target_layer(manifest, None)
+        assert result == uuid1
+
+    def test_resolve_by_uuid(self) -> None:
+        """Resolve layer by UUID string."""
+        uuid1 = uuid4()
+        uuid2 = uuid4()
+        manifest = Manifest(
+            layers={
+                uuid1: Layer(),
+                uuid2: Layer(parent=uuid1),
+            },
+            default=uuid2,
+        )
+        result = _resolve_target_layer(manifest, str(uuid1))
+        assert result == uuid1
+
+    def test_resolve_by_tag(self) -> None:
+        """Resolve layer by tag."""
+        uuid1 = uuid4()
+        manifest = Manifest(
+            layers={uuid1: Layer(tag="v1.0")},
+            default=uuid1,
+        )
+        result = _resolve_target_layer(manifest, "v1.0")
+        assert result == uuid1
+
+    def test_resolve_invalid_layer(self) -> None:
+        """Raise error for invalid layer."""
+        manifest = Manifest()
+        with pytest.raises(MountError, match="not found"):
+            _resolve_target_layer(manifest, "invalid")
+
+
+class TestMount:
+    """Tests for mount function."""
+
+    async def test_mount_nonexistent_input(self, tmp_path: Path) -> None:
+        """Mount raises error for nonexistent input file."""
+        output_dir = tmp_path / "mounted"
+
+        with pytest.raises(MountError, match="does not exist"):
+            await mount(tmp_path / "nonexistent.squashfs", output_dir)
+
+    async def test_mount_directory_as_input(self, tmp_path: Path) -> None:
+        """Mount raises error when input is a directory."""
+        input_dir = tmp_path / "input"
+        input_dir.mkdir()
+
+        output_dir = tmp_path / "mounted"
+
+        with pytest.raises(MountError, match="not a file"):
+            await mount(input_dir, output_dir)

--- a/tests/workspace/test_pack.py
+++ b/tests/workspace/test_pack.py
@@ -1,0 +1,58 @@
+"""Tests for pack module."""
+
+from pathlib import Path
+
+import pytest
+
+from psi_agent.workspace.pack.api import PackError, pack
+
+
+class TestPack:
+    """Tests for pack function."""
+
+    async def test_pack_creates_squashfs(self, tmp_path: Path) -> None:
+        """Pack creates a valid squashfs file."""
+        # Create input workspace
+        input_dir = tmp_path / "workspace"
+        input_dir.mkdir()
+        (input_dir / "tools").mkdir()
+        (input_dir / "tools" / "test.py").write_text("# test tool")
+
+        # Create output path
+        output_file = tmp_path / "workspace.squashfs"
+
+        # Pack
+        await pack(input_dir, output_file)
+
+        # Verify output exists
+        assert output_file.exists()
+        assert output_file.stat().st_size > 0
+
+    async def test_pack_with_tag(self, tmp_path: Path) -> None:
+        """Pack with tag creates squashfs with tagged layer."""
+        input_dir = tmp_path / "workspace"
+        input_dir.mkdir()
+        (input_dir / "test.txt").write_text("test")
+
+        output_file = tmp_path / "workspace.squashfs"
+
+        await pack(input_dir, output_file, tag="v1.0")
+
+        assert output_file.exists()
+
+    async def test_pack_nonexistent_input(self, tmp_path: Path) -> None:
+        """Pack raises error for nonexistent input directory."""
+        output_file = tmp_path / "output.squashfs"
+
+        with pytest.raises(PackError, match="does not exist"):
+            await pack(tmp_path / "nonexistent", output_file)
+
+    async def test_pack_file_as_input(self, tmp_path: Path) -> None:
+        """Pack raises error when input is a file."""
+        input_file = tmp_path / "file.txt"
+        input_file.write_text("test")
+
+        output_file = tmp_path / "output.squashfs"
+
+        with pytest.raises(PackError, match="not a directory"):
+            await pack(input_file, output_file)

--- a/tests/workspace/test_snapshot.py
+++ b/tests/workspace/test_snapshot.py
@@ -1,0 +1,38 @@
+"""Tests for snapshot module."""
+
+from pathlib import Path
+
+import pytest
+
+from psi_agent.workspace.snapshot.api import SnapshotError, snapshot
+
+
+class TestSnapshot:
+    """Tests for snapshot function."""
+
+    async def test_snapshot_nonexistent_input(self, tmp_path: Path) -> None:
+        """Snapshot raises error for nonexistent input file."""
+        mount_point = tmp_path / "mounted"
+        mount_point.mkdir()
+
+        with pytest.raises(SnapshotError, match="Input file does not exist"):
+            await snapshot(tmp_path / "nonexistent.squashfs", mount_point)
+
+    async def test_snapshot_nonexistent_mount_point(self, tmp_path: Path) -> None:
+        """Snapshot raises error for nonexistent mount point."""
+        input_file = tmp_path / "workspace.squashfs"
+        input_file.touch()
+
+        with pytest.raises(SnapshotError, match="Mount point does not exist"):
+            await snapshot(input_file, tmp_path / "nonexistent")
+
+    async def test_snapshot_missing_mount_info(self, tmp_path: Path) -> None:
+        """Snapshot raises error when mount info is missing."""
+        input_file = tmp_path / "workspace.squashfs"
+        input_file.touch()
+
+        mount_point = tmp_path / "mounted"
+        mount_point.mkdir()
+
+        with pytest.raises(SnapshotError, match="Mount info file not found"):
+            await snapshot(input_file, mount_point)

--- a/tests/workspace/test_umount.py
+++ b/tests/workspace/test_umount.py
@@ -1,0 +1,24 @@
+"""Tests for umount module."""
+
+from pathlib import Path
+
+import pytest
+
+from psi_agent.workspace.umount.api import UmountError, umount
+
+
+class TestUmount:
+    """Tests for umount function."""
+
+    async def test_umount_nonexistent_mount_point(self, tmp_path: Path) -> None:
+        """Umount raises error for nonexistent mount point."""
+        with pytest.raises(UmountError, match="does not exist"):
+            await umount(tmp_path / "nonexistent")
+
+    async def test_umount_missing_mount_info(self, tmp_path: Path) -> None:
+        """Umount raises error when mount info file is missing."""
+        mount_dir = tmp_path / "mounted"
+        mount_dir.mkdir()
+
+        with pytest.raises(UmountError, match="Mount info file not found"):
+            await umount(mount_dir)

--- a/tests/workspace/test_unpack.py
+++ b/tests/workspace/test_unpack.py
@@ -1,0 +1,48 @@
+"""Tests for unpack module."""
+
+from pathlib import Path
+
+import pytest
+
+from psi_agent.workspace.pack.api import pack
+from psi_agent.workspace.unpack.api import UnpackError, unpack
+
+
+class TestUnpack:
+    """Tests for unpack function."""
+
+    async def test_unpack_creates_directory(self, tmp_path: Path) -> None:
+        """Unpack creates directory with squashfs contents."""
+        # Create and pack a workspace
+        input_dir = tmp_path / "workspace"
+        input_dir.mkdir()
+        (input_dir / "tools").mkdir()
+        (input_dir / "tools" / "test.py").write_text("# test tool")
+
+        squashfs_file = tmp_path / "workspace.squashfs"
+        await pack(input_dir, squashfs_file)
+
+        # Unpack
+        output_dir = tmp_path / "unpacked"
+        await unpack(squashfs_file, output_dir)
+
+        # Verify output exists
+        assert output_dir.exists()
+        assert (output_dir / "manifest.json").exists()
+
+    async def test_unpack_nonexistent_input(self, tmp_path: Path) -> None:
+        """Unpack raises error for nonexistent input file."""
+        output_dir = tmp_path / "output"
+
+        with pytest.raises(UnpackError, match="does not exist"):
+            await unpack(tmp_path / "nonexistent.squashfs", output_dir)
+
+    async def test_unpack_directory_as_input(self, tmp_path: Path) -> None:
+        """Unpack raises error when input is a directory."""
+        input_dir = tmp_path / "input"
+        input_dir.mkdir()
+
+        output_dir = tmp_path / "output"
+
+        with pytest.raises(UnpackError, match="not a file"):
+            await unpack(input_dir, output_dir)


### PR DESCRIPTION
## Summary

- Implement five CLI tools for managing workspace squashfs images
- Add UUID-based layer naming with optional tags
- Support overlayfs mounting with layer chain resolution
- Implement atomic snapshot writes for data safety

## Components

| Component | Description |
|-----------|-------------|
| `psi-workspace-pack` | Pack workspace directory into squashfs |
| `psi-workspace-unpack` | Extract squashfs to directory |
| `psi-workspace-mount` | Mount squashfs as overlayfs |
| `psi-workspace-umount` | Unmount overlayfs workspace |
| `psi-workspace-snapshot` | Create workspace snapshots |

## Test plan

- [x] Unit tests for manifest parsing/serialization
- [x] Unit tests for pack/unpack operations
- [x] Unit tests for mount layer resolution
- [x] Unit tests for snapshot operations
- [x] Integration tests (requires root for mount operations)

🤖 Generated with [Claude Code](https://claude.com/claude-code)