### PR TITLE
Add workspace context to example workspace

### DIFF
--- a/examples/a-simple-bash-only-workspace/systems/system.py
+++ b/examples/a-simple-bash-only-workspace/systems/system.py
@@ -14,7 +14,8 @@ async def build_system_prompt() -> str:
     Returns:
         System prompt string containing skill descriptions and guidelines.
     """
-    skills_dir = Path(__file__).parent.parent / "skills"
+    workspace = Path(__file__).parent.parent
+    skills_dir = workspace / "skills"
     skill_descriptions: list[str] = []
 
     if skills_dir.exists():
@@ -26,7 +27,11 @@ async def build_system_prompt() -> str:
                     if description:
                         skill_descriptions.append(f"- {skill_path.name}: {description}")
 
-    system_prompt = """You are a helpful assistant with access to tools and skills.
+    system_prompt = f"""You are a helpful assistant with access to tools and skills.
+
+## Workspace
+
+Your workspace directory is: {workspace.resolve()}
 
 ## Available Skills
 

--- a/examples/a-simple-bash-only-workspace/tools/bash.py
+++ b/examples/a-simple-bash-only-workspace/tools/bash.py
@@ -1,23 +1,28 @@
 """Async bash tool for executing shell commands."""
 
 import asyncio
+from pathlib import Path
 
 
-async def tool(command: str, timeout: int = 30) -> str:
+async def tool(command: str, timeout: int = 30, cwd: str | None = None) -> str:
     """Execute a bash command asynchronously.
 
     Args:
         command: The bash command to execute.
         timeout: Timeout in seconds. Defaults to 30.
+        cwd: Working directory for the command. Defaults to None.
 
     Returns:
         Command output as string, or error message if execution fails.
     """
     try:
+        working_dir = Path(cwd) if cwd else None
+
         process = await asyncio.create_subprocess_shell(
             command,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
+            cwd=working_dir,
         )
 
         stdout, stderr = await asyncio.wait_for(

--- a/openspec/changes/archive/2026-04-28-add-workspace-context/.openspec.yaml
+++ b/openspec/changes/archive/2026-04-28-add-workspace-context/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-28

--- a/openspec/changes/archive/2026-04-28-add-workspace-context/design.md
+++ b/openspec/changes/archive/2026-04-28-add-workspace-context/design.md
@@ -1,0 +1,35 @@
+## Context
+
+当前 agent 不知道自己的 workspace 目录在哪里。`build_system_prompt()` 没有传递 workspace 路径信息，bash tool 也没有参数指定工作目录。
+
+## Goals / Non-Goals
+
+**Goals:**
+- 在 system prompt 中告知 agent 其 workspace 目录路径
+- 在 bash tool 中添加 `cwd` 参数用于指定命令运行目录
+
+**Non-Goals:**
+- 修改 psi-session 核心逻辑
+- 添加其他 workspace 相关功能
+
+## Decisions
+
+### 在 system prompt 中添加 workspace 路径
+
+**方案：** 修改 `build_system_prompt()` 接受 workspace 路径参数，并在 prompt 中声明。
+
+**原因：**
+- Agent 需要知道自己的工作目录才能正确执行文件操作
+- 简单直接，无需修改 session 核心逻辑
+
+### 在 bash tool 中添加 cwd 参数
+
+**方案：** 添加可选的 `cwd` 参数，使用 `asyncio.create_subprocess_shell` 的 `cwd` 参数。
+
+**原因：**
+- 符合 Python subprocess 标准做法
+- 向后兼容（参数可选，默认为 None）
+
+## Risks / Trade-offs
+
+- 无显著风险

--- a/openspec/changes/archive/2026-04-28-add-workspace-context/proposal.md
+++ b/openspec/changes/archive/2026-04-28-add-workspace-context/proposal.md
@@ -1,0 +1,23 @@
+## Why
+
+Agent 不知道自己的 workspace 目录在哪里，导致执行 bash 命令时无法确定工作目录。需要在 system prompt 中告知 agent 其 workspace 路径，并在 bash tool 中提供设置运行目录的参数。
+
+## What Changes
+
+- 在 `build_system_prompt()` 中添加 workspace 目录信息
+- 在 bash tool 中添加 `cwd` 参数，用于指定命令运行目录
+
+## Capabilities
+
+### New Capabilities
+
+<!-- No new capabilities - this is an enhancement to existing workspace tools -->
+
+### Modified Capabilities
+
+<!-- No spec-level requirement changes -->
+
+## Impact
+
+- `examples/a-simple-bash-only-workspace/systems/system.py`: 添加 workspace 路径到 system prompt
+- `examples/a-simple-bash-only-workspace/tools/bash.py`: 添加 `cwd` 参数

--- a/openspec/changes/archive/2026-04-28-add-workspace-context/specs/no-spec-changes/spec.md
+++ b/openspec/changes/archive/2026-04-28-add-workspace-context/specs/no-spec-changes/spec.md
@@ -1,0 +1,3 @@
+## ADDED Requirements
+
+<!-- No spec-level requirements - this is an enhancement to example workspace -->

--- a/openspec/changes/archive/2026-04-28-add-workspace-context/tasks.md
+++ b/openspec/changes/archive/2026-04-28-add-workspace-context/tasks.md
@@ -1,0 +1,7 @@
+## 1. System Prompt
+
+- [x] 1.1 Modify `build_system_prompt()` to accept workspace path and include it in prompt
+
+## 2. Bash Tool
+
+- [x] 2.1 Add `cwd` parameter to bash tool

--- a/openspec/changes/archive/2026-04-28-fix-workspace-context-source/.openspec.yaml
+++ b/openspec/changes/archive/2026-04-28-fix-workspace-context-source/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-28

--- a/openspec/changes/archive/2026-04-28-fix-workspace-context-source/design.md
+++ b/openspec/changes/archive/2026-04-28-fix-workspace-context-source/design.md
@@ -1,0 +1,28 @@
+## Context
+
+当前实现从 session 传递 workspace 路径到 `build_system_prompt()`，这违反了 workspace 自包含的设计理念。`system.py` 位于 `workspace/systems/` 目录下，可以通过 `Path(__file__).parent.parent` 直接获取 workspace 路径。
+
+## Goals / Non-Goals
+
+**Goals:**
+- 让 `system.py` 自己获取 workspace 路径
+- 移除 session 中不必要的参数传递逻辑
+
+**Non-Goals:**
+- 改变 system prompt 的内容或格式
+
+## Decisions
+
+### 使用 `__file__` 获取 workspace 路径
+
+**方案：** 在 `build_system_prompt()` 中使用 `Path(__file__).parent.parent` 获取 workspace 目录。
+
+**原因：**
+- `system.py` 位于 `workspace/systems/system.py`
+- `Path(__file__).parent` = `workspace/systems/`
+- `Path(__file__).parent.parent` = `workspace/`
+- 无需外部传递，完全自包含
+
+## Risks / Trade-offs
+
+- 无风险，这是更简洁正确的实现

--- a/openspec/changes/archive/2026-04-28-fix-workspace-context-source/proposal.md
+++ b/openspec/changes/archive/2026-04-28-fix-workspace-context-source/proposal.md
@@ -1,0 +1,24 @@
+## Why
+
+之前的实现错误地从 session 传递 workspace 路径到 `build_system_prompt()`。这违反了 workspace 自包含的设计理念。workspace 路径应该由 `system.py` 自己通过 `__file__` 获取，无需外部传递。
+
+## What Changes
+
+- 移除 `runner.py` 中传递 workspace 参数的逻辑
+- 修改 `system.py` 使用 `Path(__file__).parent.parent` 获取 workspace 路径
+- `build_system_prompt()` 不再接受参数
+
+## Capabilities
+
+### New Capabilities
+
+<!-- No new capabilities -->
+
+### Modified Capabilities
+
+<!-- No spec-level requirement changes -->
+
+## Impact
+
+- `src/psi_agent/session/runner.py`: 移除 workspace 参数传递逻辑
+- `examples/a-simple-bash-only-workspace/systems/system.py`: 使用 `__file__` 获取 workspace 路径

--- a/openspec/changes/archive/2026-04-28-fix-workspace-context-source/specs/no-spec-changes/spec.md
+++ b/openspec/changes/archive/2026-04-28-fix-workspace-context-source/specs/no-spec-changes/spec.md
@@ -1,0 +1,3 @@
+## ADDED Requirements
+
+<!-- No spec-level requirements - this is a bug fix -->

--- a/openspec/changes/archive/2026-04-28-fix-workspace-context-source/tasks.md
+++ b/openspec/changes/archive/2026-04-28-fix-workspace-context-source/tasks.md
@@ -1,0 +1,4 @@
+## 1. Fix
+
+- [x] 1.1 Remove workspace parameter passing from runner.py
+- [x] 1.2 Update system.py to use `__file__` for workspace path


### PR DESCRIPTION
## Summary
- Add workspace directory path to system prompt using `__file__` to derive path self-contained
- Add `cwd` parameter to bash tool for specifying working directory
- Workspace path is self-derived by `system.py`, maintaining workspace self-containment design

## Test plan
- [x] All 96 tests pass
- [x] Lint and format checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)