### PR TITLE
Add PyPI publish workflow for tag releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,3 +31,28 @@ jobs:
 
       - name: Test
         run: uv run pytest
+
+  publish:
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/v')
+    needs: check
+    environment: pypi
+
+    permissions:
+      id-token: write
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          python-version: "3.14"
+
+      - name: Build
+        run: uv build
+
+      - name: Publish to PyPI
+        run: uv publish

--- a/openspec/changes/archive/2026-04-28-add-pypi-publish-ci/.openspec.yaml
+++ b/openspec/changes/archive/2026-04-28-add-pypi-publish-ci/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-28

--- a/openspec/changes/archive/2026-04-28-add-pypi-publish-ci/design.md
+++ b/openspec/changes/archive/2026-04-28-add-pypi-publish-ci/design.md
@@ -1,0 +1,49 @@
+## Context
+
+当前 CI 只运行测试，没有发布流程。需要添加自动发布到 PyPI 的功能，当创建 tag 时触发。
+
+## Goals / Non-Goals
+
+**Goals:**
+- 当创建 tag 时自动构建并发布到 PyPI
+- 使用 GitHub Trusted Publishing（无需管理 API token）
+
+**Non-Goals:**
+- 发布到 TestPyPI
+- 支持 release candidate 或 pre-release 版本
+
+## Decisions
+
+### 使用 GitHub Trusted Publishing
+
+**方案：** 使用 PyPI 的 Trusted Publishing 功能，通过 OIDC 认证，无需存储 API token。
+
+**原因：**
+- 更安全：无需管理长期有效的 API token
+- GitHub Actions 原生支持
+- 官方推荐的最佳实践
+
+### 发布流程设计
+
+**触发条件：** 当推送 tag（格式 `v*`）时触发
+
+**步骤：**
+1. 检出代码
+2. 安装 uv
+3. 构建包：`uv build`
+4. 上传到 PyPI：`uv publish`（使用 trusted publishing）
+
+## Risks / Trade-offs
+
+- 需要在 PyPI 上配置 Trusted Publishing（一次性设置）
+- 只支持正式版本，不支持 pre-release
+
+## PyPI 配置步骤
+
+1. 访问 https://pypi.org/manage/project/psi-agent/settings/publishing/
+2. 添加新 publisher：
+   - Owner: `psi-agent`
+   - Repository: `psi-agent`
+   - Workflow: `ci.yml`
+   - Environment: `pypi`
+3. 在 GitHub 仓库设置中创建 `pypi` environment（可选，用于限制部署分支）

--- a/openspec/changes/archive/2026-04-28-add-pypi-publish-ci/proposal.md
+++ b/openspec/changes/archive/2026-04-28-add-pypi-publish-ci/proposal.md
@@ -1,0 +1,22 @@
+## Why
+
+需要在发布新版本时自动将包上传到 PyPI。当创建 tag 时，CI 应该自动构建并发布到 PyPI，实现自动化发布流程。
+
+## What Changes
+
+- 在 `.github/workflows/ci.yml` 中添加 PyPI 发布流程
+- 当检测到 tag 时，执行 `uv build` 并使用 trusted publishing 上传到 PyPI
+
+## Capabilities
+
+### New Capabilities
+
+<!-- No new capabilities - this is CI/CD configuration -->
+
+### Modified Capabilities
+
+<!-- No spec-level requirement changes -->
+
+## Impact
+
+- `.github/workflows/ci.yml`: 添加 PyPI 发布 job

--- a/openspec/changes/archive/2026-04-28-add-pypi-publish-ci/specs/no-spec-changes/spec.md
+++ b/openspec/changes/archive/2026-04-28-add-pypi-publish-ci/specs/no-spec-changes/spec.md
@@ -1,0 +1,3 @@
+## ADDED Requirements
+
+<!-- No spec-level requirements - this is CI/CD configuration -->

--- a/openspec/changes/archive/2026-04-28-add-pypi-publish-ci/tasks.md
+++ b/openspec/changes/archive/2026-04-28-add-pypi-publish-ci/tasks.md
@@ -1,0 +1,3 @@
+## 1. CI Configuration
+
+- [x] 1.1 Add PyPI publish job to ci.yml triggered by tag


### PR DESCRIPTION
## Summary
- Add publish job triggered by version tags (v*)
- Use GitHub Trusted Publishing with OIDC authentication
- Configure environment: pypi for deployment

## Setup Required
Before this works, configure Trusted Publishing on PyPI:
1. Go to https://pypi.org/manage/project/psi-agent/settings/publishing/
2. Add a new publisher:
   - Owner: `psi-agent`
   - Repository: `psi-agent`
   - Workflow: `ci.yml`
   - Environment: `pypi`

🤖 Generated with [Claude Code](https://claude.com/claude-code)