### PR TITLE
Add user-facing README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,93 @@
+# psi-agent
+
+A portable and componentized agent framework.
+
+## Introduction
+
+psi-agent is built on two core principles:
+
+- **Portability**: Copy just the `workspace` directory to migrate your agent completely.
+- **Componentization**: Agents are assembled from independent components that communicate via Unix sockets, ensuring loose coupling.
+
+## Installation
+
+### Using pip
+
+```bash
+pip install psi-agent
+```
+
+### Using uv
+
+```bash
+uv add psi-agent
+```
+
+## Quick Start
+
+1. Create a workspace directory with your tools and skills:
+
+```bash
+mkdir -p workspace/{tools,skills,systems}
+```
+
+2. Start the session with an AI provider:
+
+```bash
+uv run psi-session \
+  --workspace ./workspace \
+  --channel-socket ./channel.sock \
+  --ai-socket ./ai.sock
+```
+
+3. Start an AI component (e.g., OpenAI-compatible):
+
+```bash
+uv run psi-ai-openai-completions \
+  --session-socket ./ai.sock \
+  --model <model-name> \
+  --api-key <your-api-key> \
+  --base-url <provider-api-url>  # e.g., https://openrouter.ai/api/v1
+```
+
+> **Note:** `--base-url` defaults to OpenAI's API. Most users will need to specify a different provider URL (e.g., OpenRouter, Azure, local LLM servers).
+
+4. Start a channel to interact with your agent:
+
+```bash
+uv run psi-channel-repl --session-socket ./channel.sock
+```
+
+## Components
+
+psi-agent consists of four component types:
+
+| Component | Purpose |
+|-----------|---------|
+| `psi-ai-*` | LLM provider adapters (OpenAI, Anthropic, etc.) |
+| `psi-session` | Agent runtime loop, handles messages and tool calls |
+| `psi-channel-*` | Message channels (REPL, Telegram, Feishu, etc.) |
+| `psi-workspace-*` | Workspace packaging and mounting tools |
+
+### Available Packages
+
+After installation, these CLI tools are available:
+
+- `psi-ai-openai-completions` - OpenAI-compatible completion server
+- `psi-ai-anthropic-messages` - Anthropic messages server
+- `psi-session` - Agent session runtime
+- `psi-channel-repl` - Interactive REPL interface
+- `psi-channel-cli` - CLI channel interface
+- `psi-workspace-pack` - Package workspace to squashfs
+- `psi-workspace-unpack` - Extract squashfs to directory
+- `psi-workspace-mount` - Mount squashfs as overlayfs
+- `psi-workspace-umount` - Unmount workspace
+- `psi-workspace-snapshot` - Create workspace snapshot
+
+## Documentation
+
+For detailed documentation including workspace structure, tool development, and configuration, see [CLAUDE.md](CLAUDE.md).
+
+## License
+
+MIT License - see [LICENSE.md](LICENSE.md) for details.

--- a/README_CN.md
+++ b/README_CN.md
@@ -1,0 +1,93 @@
+# psi-agent
+
+一个以**可移植性**和**组件化**为核心理念的 agent 框架。
+
+## 简介
+
+psi-agent 基于两个核心原则构建：
+
+- **可移植性**：只需复制 `workspace` 目录即可完成 agent 的完整迁移。
+- **组件化**：agent 由独立组件拼装而成，各组件通过 Unix socket 进行 IPC 通信，确保松耦合。
+
+## 安装
+
+### 使用 pip
+
+```bash
+pip install psi-agent
+```
+
+### 使用 uv
+
+```bash
+uv add psi-agent
+```
+
+## 快速开始
+
+1. 创建 workspace 目录，包含你的 tools 和 skills：
+
+```bash
+mkdir -p workspace/{tools,skills,systems}
+```
+
+2. 启动 session 和 AI provider：
+
+```bash
+uv run psi-session \
+  --workspace ./workspace \
+  --channel-socket ./channel.sock \
+  --ai-socket ./ai.sock
+```
+
+3. 启动 AI 组件（例如 OpenAI 兼容接口）：
+
+```bash
+uv run psi-ai-openai-completions \
+  --session-socket ./ai.sock \
+  --model <模型名称> \
+  --api-key <你的-api-key> \
+  --base-url <提供商-api-url>  # 例如 https://openrouter.ai/api/v1
+```
+
+> **注意：** `--base-url` 默认为 OpenAI 的 API。大多数用户需要指定其他提供商的 URL（例如 OpenRouter、Azure、本地 LLM 服务器）。
+
+4. 启动 channel 与 agent 交互：
+
+```bash
+uv run psi-channel-repl --session-socket ./channel.sock
+```
+
+## 组件
+
+psi-agent 包含四种组件类型：
+
+| 组件 | 用途 |
+|------|------|
+| `psi-ai-*` | LLM 提供商适配器（OpenAI、Anthropic 等） |
+| `psi-session` | Agent 运行循环，处理消息和 tool 调用 |
+| `psi-channel-*` | 消息通道（REPL、Telegram、飞书等） |
+| `psi-workspace-*` | Workspace 打包和挂载工具 |
+
+### 可用命令
+
+安装后，以下 CLI 工具可用：
+
+- `psi-ai-openai-completions` - OpenAI 兼容的 completion 服务器
+- `psi-ai-anthropic-messages` - Anthropic messages 服务器
+- `psi-session` - Agent session 运行时
+- `psi-channel-repl` - 交互式 REPL 界面
+- `psi-channel-cli` - CLI channel 接口
+- `psi-workspace-pack` - 将 workspace 打包为 squashfs
+- `psi-workspace-unpack` - 将 squashfs 解压为目录
+- `psi-workspace-mount` - 将 squashfs 挂载为 overlayfs
+- `psi-workspace-umount` - 卸载 workspace
+- `psi-workspace-snapshot` - 创建 workspace 快照
+
+## 文档
+
+详细文档包括 workspace 结构、tool 开发和配置，请参阅 [CLAUDE.md](CLAUDE.md)。
+
+## 许可证
+
+MIT License - 详见 [LICENSE.md](LICENSE.md)。

--- a/openspec/changes/archive/2026-04-29-add-user-readme/.openspec.yaml
+++ b/openspec/changes/archive/2026-04-29-add-user-readme/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-28

--- a/openspec/changes/archive/2026-04-29-add-user-readme/design.md
+++ b/openspec/changes/archive/2026-04-29-add-user-readme/design.md
@@ -1,0 +1,37 @@
+## Context
+
+psi-agent is a portable and componentized agent framework. Currently, the project uses `CLAUDE.md` as its readme (referenced in `pyproject.toml`), which is developer-focused documentation for AI assistants. Users visiting the GitHub repository or PyPI package page need a clear, simple introduction to understand and use the framework.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Provide a user-friendly README.md that introduces the project
+- Include installation instructions via pip/uv
+- Show a quick start example
+- Give an overview of the component architecture
+- Link to CLAUDE.md for detailed documentation
+
+**Non-Goals:**
+- Comprehensive API documentation (that belongs in docs/)
+- Detailed implementation guides (covered in CLAUDE.md)
+- Changing any code or functionality
+
+## Decisions
+
+1. **README.md Structure**
+   - Rationale: Follow standard Python project README conventions
+   - Sections: Title/Badge, Introduction, Installation, Quick Start, Components, Documentation Link
+
+2. **Keep CLAUDE.md Separate**
+   - Rationale: CLAUDE.md serves a different audience (AI assistants/developers) and should remain unchanged
+   - The new README.md targets end users who want to quickly understand and use the framework
+
+3. **Update pyproject.toml readme field**
+   - Rationale: PyPI will display README.md on the package page, which is more appropriate for users than CLAUDE.md
+
+## Risks / Trade-offs
+
+- **Risk**: README.md may become out of sync with CLAUDE.md
+  - Mitigation: Keep README.md concise and link to CLAUDE.md for details
+- **Trade-off**: Two documentation files to maintain
+  - Acceptable: They serve different purposes and audiences

--- a/openspec/changes/archive/2026-04-29-add-user-readme/proposal.md
+++ b/openspec/changes/archive/2026-04-29-add-user-readme/proposal.md
@@ -1,0 +1,33 @@
+## Why
+
+The project currently lacks a user-facing README.md. The existing `CLAUDE.md` serves as developer documentation for AI assistants, but users need a clear, simple introduction to understand what psi-agent is, how to install it, and how to get started quickly.
+
+## What Changes
+
+- Create a new `README.md` file with user-focused content:
+  - Project introduction and core concepts
+  - Installation instructions
+  - Quick start guide
+  - Component overview
+  - Links to detailed documentation
+- Create a `README_CN.md` file with Chinese translation
+- Update `pyproject.toml` to reference `README.md` instead of `CLAUDE.md`
+- Clarify `--base-url` option in quick start examples (most users use non-OpenAI providers)
+
+## Capabilities
+
+### New Capabilities
+
+- `user-readme`: A user-facing README.md that provides project introduction, installation, and quick start guide.
+- `user-readme-cn`: A Chinese translation of the README for Chinese-speaking users.
+
+### Modified Capabilities
+
+None. This is a documentation-only change with no spec-level behavior changes.
+
+## Impact
+
+- New file: `README.md`
+- New file: `README_CN.md`
+- Modified file: `pyproject.toml` (readme field)
+- No code changes required

--- a/openspec/changes/archive/2026-04-29-add-user-readme/specs/user-readme/spec.md
+++ b/openspec/changes/archive/2026-04-29-add-user-readme/specs/user-readme/spec.md
@@ -1,0 +1,27 @@
+## ADDED Requirements
+
+### Requirement: README.md exists with user-facing content
+The project SHALL have a README.md file in the root directory that provides a user-friendly introduction to the project.
+
+#### Scenario: User views README.md
+- **WHEN** a user opens the repository or PyPI page
+- **THEN** they see a README.md with project introduction, installation instructions, and quick start guide
+
+### Requirement: README.md contains essential sections
+The README.md SHALL include the following sections:
+1. Project title and brief description
+2. Installation instructions
+3. Quick start example
+4. Component overview
+5. Link to detailed documentation
+
+#### Scenario: User reads README.md structure
+- **WHEN** a user reads README.md
+- **THEN** they can quickly understand what psi-agent is, how to install it, and how to get started
+
+### Requirement: pyproject.toml references README.md
+The pyproject.toml file SHALL reference README.md in the `readme` field.
+
+#### Scenario: PyPI displays README.md
+- **WHEN** the package is published to PyPI
+- **THEN** the README.md content is displayed on the package page

--- a/openspec/changes/archive/2026-04-29-add-user-readme/tasks.md
+++ b/openspec/changes/archive/2026-04-29-add-user-readme/tasks.md
@@ -1,0 +1,19 @@
+## 1. Create README.md
+
+- [x] 1.1 Create README.md with project title and introduction
+- [x] 1.2 Add installation instructions (pip and uv)
+- [x] 1.3 Add quick start example with basic usage
+- [x] 1.4 Add component overview section
+- [x] 1.5 Add link to CLAUDE.md for detailed documentation
+
+## 2. Update pyproject.toml
+
+- [x] 2.1 Change readme field from "CLAUDE.md" to "README.md"
+
+## 3. Enhance README content
+
+- [x] 3.1 Add --base-url option to quick start example (most users use non-OpenAI providers)
+
+## 4. Create Chinese README
+
+- [x] 4.1 Create README_CN.md with Chinese translation of README.md

--- a/openspec/specs/user-readme/spec.md
+++ b/openspec/specs/user-readme/spec.md
@@ -1,0 +1,27 @@
+## ADDED Requirements
+
+### Requirement: README.md exists with user-facing content
+The project SHALL have a README.md file in the root directory that provides a user-friendly introduction to the project.
+
+#### Scenario: User views README.md
+- **WHEN** a user opens the repository or PyPI page
+- **THEN** they see a README.md with project introduction, installation instructions, and quick start guide
+
+### Requirement: README.md contains essential sections
+The README.md SHALL include the following sections:
+1. Project title and brief description
+2. Installation instructions
+3. Quick start example
+4. Component overview
+5. Link to detailed documentation
+
+#### Scenario: User reads README.md structure
+- **WHEN** a user reads README.md
+- **THEN** they can quickly understand what psi-agent is, how to install it, and how to get started
+
+### Requirement: pyproject.toml references README.md
+The pyproject.toml file SHALL reference README.md in the `readme` field.
+
+#### Scenario: PyPI displays README.md
+- **WHEN** the package is published to PyPI
+- **THEN** the README.md content is displayed on the package page

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "psi-agent"
 dynamic = ["version"]
 description = "A portable and componentized agent framework"
-readme = "CLAUDE.md"
+readme = "README.md"
 requires-python = ">=3.14"
 license = { file = "LICENSE.md" }
 authors = [{ name = "Hao Zhang", email = "hzhangxyz@outlook.com" }]


### PR DESCRIPTION
## Summary
- Create simple README.md with installation, quick start, and component overview
- Update pyproject.toml readme field from CLAUDE.md to README.md

## Test plan
- [ ] Verify README.md renders correctly on GitHub
- [ ] Confirm pyproject.toml points to correct readme file

🤖 Generated with [Claude Code](https://claude.com/claude-code)