### PR TITLE
Add project URLs to pyproject.toml

### DIFF
--- a/openspec/changes/archive/2026-04-29-add-project-url/.openspec.yaml
+++ b/openspec/changes/archive/2026-04-29-add-project-url/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-28

--- a/openspec/changes/archive/2026-04-29-add-project-url/design.md
+++ b/openspec/changes/archive/2026-04-29-add-project-url/design.md
@@ -1,0 +1,28 @@
+## Context
+
+The pyproject.toml file currently defines project metadata (name, description, authors, etc.) but is missing the `[project.urls]` section. This is a standard PEP 621 metadata field that provides links to the project's repository, homepage, and documentation.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Add standard project URL metadata to pyproject.toml
+- Ensure PyPI displays proper links when the package is published
+
+**Non-Goals:**
+- Modifying any code or functionality
+- Changing existing metadata fields
+
+## Decisions
+
+### URL Structure
+
+Add the following URLs to `[project.urls]`:
+- `Repository`: https://github.com/psi-agent/psi-agent
+- `Homepage`: Same as repository (project is hosted on GitHub)
+- `Documentation`: README file served as documentation
+
+This follows the standard pattern for Python packages hosted on GitHub.
+
+## Risks / Trade-offs
+
+No significant risks. This is a metadata-only change with no impact on functionality.

--- a/openspec/changes/archive/2026-04-29-add-project-url/proposal.md
+++ b/openspec/changes/archive/2026-04-29-add-project-url/proposal.md
@@ -1,0 +1,23 @@
+## Why
+
+The pyproject.toml is missing the project URL, which is a standard metadata field for Python packages. This is needed for PyPI package listing and provides users with a way to find the project repository and documentation.
+
+## What Changes
+
+- Add `project.urls` section to pyproject.toml with repository, homepage, and documentation links
+
+## Capabilities
+
+### New Capabilities
+
+- `project-urls`: Adds standard project URL metadata (repository, homepage, documentation) to the package configuration
+
+### Modified Capabilities
+
+None - this is a new metadata addition with no existing capability changes.
+
+## Impact
+
+- pyproject.toml: Add `[project.urls]` section
+- PyPI package page will display the project links
+- No code changes required

--- a/openspec/changes/archive/2026-04-29-add-project-url/specs/project-urls/spec.md
+++ b/openspec/changes/archive/2026-04-29-add-project-url/specs/project-urls/spec.md
@@ -1,0 +1,15 @@
+## ADDED Requirements
+
+### Requirement: Project URLs metadata
+
+The pyproject.toml SHALL include a `[project.urls]` section with standard project links.
+
+#### Scenario: PyPI displays project links
+
+- **WHEN** the package is published to PyPI
+- **THEN** the package page displays links to repository, homepage, and documentation
+
+#### Scenario: Build tools parse URLs
+
+- **WHEN** build tools parse pyproject.toml
+- **THEN** they can extract the project URLs from the `[project.urls]` section

--- a/openspec/changes/archive/2026-04-29-add-project-url/tasks.md
+++ b/openspec/changes/archive/2026-04-29-add-project-url/tasks.md
@@ -1,0 +1,3 @@
+## 1. Configuration Update
+
+- [x] 1.1 Add `[project.urls]` section to pyproject.toml with repository, homepage, and documentation URLs

--- a/openspec/specs/project-urls/spec.md
+++ b/openspec/specs/project-urls/spec.md
@@ -1,0 +1,15 @@
+## ADDED Requirements
+
+### Requirement: Project URLs metadata
+
+The pyproject.toml SHALL include a `[project.urls]` section with standard project links.
+
+#### Scenario: PyPI displays project links
+
+- **WHEN** the package is published to PyPI
+- **THEN** the package page displays links to repository, homepage, and documentation
+
+#### Scenario: Build tools parse URLs
+
+- **WHEN** build tools parse pyproject.toml
+- **THEN** they can extract the project URLs from the `[project.urls]` section

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,7 @@ readme = "CLAUDE.md"
 requires-python = ">=3.14"
 license = { file = "LICENSE.md" }
 authors = [{ name = "Hao Zhang", email = "hzhangxyz@outlook.com" }]
+urls = { Repository = "https://github.com/psi-agent/psi-agent", Homepage = "https://github.com/psi-agent/psi-agent", Documentation = "https://github.com/psi-agent/psi-agent#readme" }
 dependencies = [
     "aiohttp>=3.13.5",
     "anthropic>=0.57.1",


### PR DESCRIPTION
## Summary
- Add `[project.urls]` section to pyproject.toml with repository, homepage, and documentation links
- Enables PyPI to display proper project links when the package is published

## Test plan
- [ ] Verify pyproject.toml syntax is valid
- [ ] Confirm URLs point to correct repository

🤖 Generated with [Claude Code](https://claude.com/claude-code)