### PR TITLE
Fix hyw skill to behave more naturally

### DIFF
--- a/examples/a-simple-bash-only-workspace/openspec/changes/archive/2026-04-29-fix-hyw-skill-naturalness/.openspec.yaml
+++ b/examples/a-simple-bash-only-workspace/openspec/changes/archive/2026-04-29-fix-hyw-skill-naturalness/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-28

--- a/examples/a-simple-bash-only-workspace/openspec/changes/archive/2026-04-29-fix-hyw-skill-naturalness/design.md
+++ b/examples/a-simple-bash-only-workspace/openspec/changes/archive/2026-04-29-fix-hyw-skill-naturalness/design.md
@@ -1,0 +1,50 @@
+## Context
+
+The `hyw` skill in the example workspace is designed to add a contemplative "何意味？" (He Yi Wei - "What does it mean?") prefix to questions the AI asks users. However, the current implementation causes the AI to behave unnaturally by:
+
+1. Announcing it has "discovered" or "found" the skill
+2. Explaining the prefix rule to the user before using it
+3. Treating the prefix as a deliberate action rather than an integrated behavior
+
+This happens because the skill is framed as something to "use" rather than a behavioral guideline to internalize.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Make the "何意味？" prefix feel natural and integrated into the AI's personality
+- Prevent the AI from announcing or explaining the skill behavior
+- Maintain the contemplative, philosophical tone intended by the skill
+
+**Non-Goals:**
+- Changing how the system prompt builder works
+- Modifying other skills or the workspace structure
+- Removing the skill entirely
+
+## Decisions
+
+### Decision 1: Reframe skill as behavioral style
+
+**Choice:** Change the skill description from action-oriented to style-oriented.
+
+**Rationale:** The current description "Use this skill when asking the user questions" triggers the AI to think of it as a tool to invoke. A better framing like "A contemplative questioning style that adds philosophical depth" treats it as a personality trait.
+
+**Alternatives considered:**
+- Move the behavior into system.py's system prompt directly → Would lose the skill's modularity
+- Remove the skill entirely → Would lose the intended contemplative tone
+
+### Decision 2: Add explicit anti-announcement instruction
+
+**Choice:** Add an explicit instruction to never announce or explain the prefix behavior.
+
+**Rationale:** Even with better framing, some models may still feel compelled to explain their behavior. An explicit prohibition makes the expectation clear.
+
+### Decision 3: Simplify the skill content
+
+**Choice:** Reduce the skill content to essential guidance, removing verbose explanations.
+
+**Rationale:** Shorter, more direct instructions are easier for the AI to internalize without overthinking.
+
+## Risks / Trade-offs
+
+- **Risk:** Some models may still occasionally announce the behavior → **Mitigation:** The explicit instruction reduces but cannot eliminate this; it's model-dependent behavior
+- **Risk:** The prefix may be applied inconsistently → **Mitigation:** Acceptable trade-off for naturalness; perfect consistency would require more rigid framing that causes the original problem

--- a/examples/a-simple-bash-only-workspace/openspec/changes/archive/2026-04-29-fix-hyw-skill-naturalness/proposal.md
+++ b/examples/a-simple-bash-only-workspace/openspec/changes/archive/2026-04-29-fix-hyw-skill-naturalness/proposal.md
@@ -1,0 +1,27 @@
+## Why
+
+The current `hyw` skill implementation causes the AI to behave unnaturally when asking questions. When the skill is loaded, the AI explicitly announces it has "discovered" the skill and explains the "何意味？" prefix rule before using it, making the interaction feel forced and performative rather than natural.
+
+The root cause is that the skill's description ("Use this skill when asking the user questions") frames it as an action to be "used" rather than a behavioral guideline to be internalized. This causes the AI to treat it as a tool invocation rather than a personality trait.
+
+## What Changes
+
+- Modify the `hyw` skill's SKILL.md to reframe it as a behavioral style guideline rather than a "skill to use"
+- Update the skill description in YAML frontmatter to be more subtle and internal-facing
+- Restructure the instructions to emphasize natural integration over explicit application
+- Add guidance to avoid announcing or explaining the prefix behavior
+
+## Capabilities
+
+### New Capabilities
+
+- `hyw-skill-behavior`: Defines how the "何意味？" prefix should be naturally integrated into AI responses without explicit announcement or explanation
+
+### Modified Capabilities
+
+(None - this is a new capability for the example workspace)
+
+## Impact
+
+- `examples/a-simple-bash-only-workspace/skills/hyw/SKILL.md` - skill definition file
+- User experience when interacting with agents using this workspace

--- a/examples/a-simple-bash-only-workspace/openspec/changes/archive/2026-04-29-fix-hyw-skill-naturalness/specs/hyw-skill-behavior/spec.md
+++ b/examples/a-simple-bash-only-workspace/openspec/changes/archive/2026-04-29-fix-hyw-skill-naturalness/specs/hyw-skill-behavior/spec.md
@@ -1,0 +1,33 @@
+## ADDED Requirements
+
+### Requirement: Natural integration of "何意味？" prefix
+
+The skill SHALL guide the AI to naturally incorporate the "何意味？" prefix into questions without explicit announcement, explanation, or meta-commentary about the behavior.
+
+#### Scenario: AI asks a question naturally
+- **WHEN** the AI needs to ask the user a direct question
+- **THEN** the AI SHALL prefix the question with "何意味？" without explaining why it is doing so
+
+#### Scenario: AI does not announce the skill
+- **WHEN** the AI begins a conversation or asks its first question
+- **THEN** the AI SHALL NOT mention that it has a skill, has discovered a skill, or explain the prefix rule
+
+#### Scenario: AI does not use prefix for rhetorical questions
+- **WHEN** the AI is asking a rhetorical question or internal reasoning
+- **THEN** the AI SHALL NOT apply the "何意味？" prefix
+
+### Requirement: Skill description emphasizes behavioral style
+
+The skill's YAML frontmatter description SHALL frame the behavior as a personality trait or conversational style rather than a tool or action to invoke.
+
+#### Scenario: Description reflects internal behavior
+- **WHEN** the system prompt builder reads the skill's description
+- **THEN** the description SHALL describe a behavioral tendency, not a callable action
+
+### Requirement: Instructions prohibit meta-commentary
+
+The skill's instruction content SHALL explicitly direct the AI to avoid explaining or announcing the prefix behavior.
+
+#### Scenario: Instructions prevent announcement
+- **WHEN** the AI reads the full skill instructions
+- **THEN** the instructions SHALL contain explicit guidance to not announce, explain, or comment on the use of the prefix

--- a/examples/a-simple-bash-only-workspace/openspec/changes/archive/2026-04-29-fix-hyw-skill-naturalness/tasks.md
+++ b/examples/a-simple-bash-only-workspace/openspec/changes/archive/2026-04-29-fix-hyw-skill-naturalness/tasks.md
@@ -1,0 +1,14 @@
+## 1. Update Skill YAML Frontmatter
+
+- [x] 1.1 Change the skill description from action-oriented to style-oriented framing
+
+## 2. Update Skill Instructions
+
+- [x] 2.1 Rewrite the instruction content to emphasize natural integration
+- [x] 2.2 Add explicit prohibition against announcing or explaining the prefix behavior
+- [x] 2.3 Simplify and shorten the overall skill content
+
+## 3. Verification
+
+- [x] 3.1 Verify the updated SKILL.md follows the skill specification format
+- [x] 3.2 Test that the skill description is properly parsed by the system prompt builder

--- a/examples/a-simple-bash-only-workspace/openspec/specs/hyw-skill-behavior/spec.md
+++ b/examples/a-simple-bash-only-workspace/openspec/specs/hyw-skill-behavior/spec.md
@@ -1,0 +1,33 @@
+## ADDED Requirements
+
+### Requirement: Natural integration of "何意味？" prefix
+
+The skill SHALL guide the AI to naturally incorporate the "何意味？" prefix into questions without explicit announcement, explanation, or meta-commentary about the behavior.
+
+#### Scenario: AI asks a question naturally
+- **WHEN** the AI needs to ask the user a direct question
+- **THEN** the AI SHALL prefix the question with "何意味？" without explaining why it is doing so
+
+#### Scenario: AI does not announce the skill
+- **WHEN** the AI begins a conversation or asks its first question
+- **THEN** the AI SHALL NOT mention that it has a skill, has discovered a skill, or explain the prefix rule
+
+#### Scenario: AI does not use prefix for rhetorical questions
+- **WHEN** the AI is asking a rhetorical question or internal reasoning
+- **THEN** the AI SHALL NOT apply the "何意味？" prefix
+
+### Requirement: Skill description emphasizes behavioral style
+
+The skill's YAML frontmatter description SHALL frame the behavior as a personality trait or conversational style rather than a tool or action to invoke.
+
+#### Scenario: Description reflects internal behavior
+- **WHEN** the system prompt builder reads the skill's description
+- **THEN** the description SHALL describe a behavioral tendency, not a callable action
+
+### Requirement: Instructions prohibit meta-commentary
+
+The skill's instruction content SHALL explicitly direct the AI to avoid explaining or announcing the prefix behavior.
+
+#### Scenario: Instructions prevent announcement
+- **WHEN** the AI reads the full skill instructions
+- **THEN** the instructions SHALL contain explicit guidance to not announce, explain, or comment on the use of the prefix

--- a/examples/a-simple-bash-only-workspace/skills/hyw/SKILL.md
+++ b/examples/a-simple-bash-only-workspace/skills/hyw/SKILL.md
@@ -1,18 +1,14 @@
 ---
 name: hyw
-description: Use this skill when asking the user questions.
+description: A contemplative questioning style that adds philosophical depth to inquiries.
 ---
 
 ## Instructions
 
-When asking the user any question, always prefix the question with
-"何意味？" (He Yi Wei - meaning "What does it mean?").
+When asking the user a direct question, naturally prefix it with "何意味？" (He Yi Wei - "What does it mean?").
 
-This prefix adds a contemplative, philosophical tone to inquiries,
-inviting the user to reflect on the meaning behind the question.
-
-**Guidelines:**
-
-- Apply this prefix to all direct questions asked to the user
+**Important:**
+- Do not announce, explain, or comment on this behavior
+- Do not mention that you have a skill or are using a skill
+- Simply integrate the prefix naturally into your questions
 - Do not apply to rhetorical questions or internal reasoning
-- Maintain a thoughtful, questioning spirit


### PR DESCRIPTION
## Summary

- Reframe the `hyw` skill from an action to invoke to a behavioral style guideline
- Add explicit prohibition against announcing or explaining the "何意味？" prefix behavior
- Simplify instructions for easier internalization by the AI

The previous skill description ("Use this skill when asking the user questions") caused the AI to announce it had "discovered" the skill and explain the prefix rule before using it, making interactions feel forced and performative.

## Test plan

- [x] Verified SKILL.md follows the skill specification format
- [x] Tested that the skill description is properly parsed by the system prompt builder

🤖 Generated with [Claude Code](https://claude.com/claude-code)