### PR TITLE
Add user-facing README.md and Chinese translation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # psi-agent
 
+[中文](README_zh.md) | English
+
 A portable and componentized agent framework.
 
 ## Introduction
@@ -50,8 +52,6 @@ uv run psi-ai-openai-completions \
   --base-url <provider-api-url>  # e.g., https://openrouter.ai/api/v1
 ```
 
-> **Note:** `--base-url` defaults to OpenAI's API. Most users will need to specify a different provider URL (e.g., OpenRouter, Azure, local LLM servers).
-
 4. Start a channel to interact with your agent:
 
 ```bash
@@ -69,7 +69,7 @@ psi-agent consists of four component types:
 | `psi-channel-*` | Message channels (REPL, Telegram, Feishu, etc.) |
 | `psi-workspace-*` | Workspace packaging and mounting tools |
 
-### Available Packages
+### Available Scripts
 
 After installation, these CLI tools are available:
 
@@ -90,4 +90,4 @@ For detailed documentation including workspace structure, tool development, and 
 
 ## License
 
-MIT License - see [LICENSE.md](LICENSE.md) for details.
+GNU Affero General Public License v3.0 - see [LICENSE.md](LICENSE.md) for details.

--- a/README_zh.md
+++ b/README_zh.md
@@ -1,5 +1,7 @@
 # psi-agent
 
+中文 | [English](README.md)
+
 一个以**可移植性**和**组件化**为核心理念的 agent 框架。
 
 ## 简介
@@ -50,8 +52,6 @@ uv run psi-ai-openai-completions \
   --base-url <提供商-api-url>  # 例如 https://openrouter.ai/api/v1
 ```
 
-> **注意：** `--base-url` 默认为 OpenAI 的 API。大多数用户需要指定其他提供商的 URL（例如 OpenRouter、Azure、本地 LLM 服务器）。
-
 4. 启动 channel 与 agent 交互：
 
 ```bash
@@ -69,7 +69,7 @@ psi-agent 包含四种组件类型：
 | `psi-channel-*` | 消息通道（REPL、Telegram、飞书等） |
 | `psi-workspace-*` | Workspace 打包和挂载工具 |
 
-### 可用命令
+### 可用脚本
 
 安装后，以下 CLI 工具可用：
 
@@ -90,4 +90,4 @@ psi-agent 包含四种组件类型：
 
 ## 许可证
 
-MIT License - 详见 [LICENSE.md](LICENSE.md)。
+GNU Affero General Public License v3.0 - 详见 [LICENSE.md](LICENSE.md)。

--- a/openspec/changes/archive/2026-04-29-update-readme-naming/.openspec.yaml
+++ b/openspec/changes/archive/2026-04-29-update-readme-naming/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-28

--- a/openspec/changes/archive/2026-04-29-update-readme-naming/design.md
+++ b/openspec/changes/archive/2026-04-29-update-readme-naming/design.md
@@ -1,0 +1,33 @@
+## Context
+
+The README files were recently created but have several naming and content issues that need correction. This is a documentation-only change to improve clarity and follow common conventions.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Use `README_zh.md` naming (common convention for Chinese READMEs)
+- Add language switch links for easy navigation between English and Chinese versions
+- Simplify the --base-url documentation (remove emphasized note)
+- Correct section naming from "Available Packages" to "Available Scripts"
+
+**Non-Goals:**
+- Changing any actual content or functionality descriptions
+- Adding new sections or documentation
+
+## Decisions
+
+1. **README_zh.md naming**
+   - Rationale: `README_zh.md` is the more common convention (e.g., Vue, Element Plus use this pattern)
+   - Alternative considered: `README_CN.md` - less common, `README.zh-CN.md` - also valid but `_zh` is simpler
+
+2. **Language switch at top of file**
+   - Rationale: Users should immediately see the option to switch languages
+   - Format: `[中文](README_zh.md) | [English](README.md)`
+
+3. **Remove emphasized --base-url note**
+   - Rationale: The example already shows `--base-url` with a comment, no need for an additional emphasized note
+
+## Risks / Trade-offs
+
+- **Risk**: Existing links to `README_CN.md` will break
+  - Mitigation: This is a new file with no external links yet

--- a/openspec/changes/archive/2026-04-29-update-readme-naming/proposal.md
+++ b/openspec/changes/archive/2026-04-29-update-readme-naming/proposal.md
@@ -1,0 +1,24 @@
+## Why
+
+The current README files have several issues that reduce clarity and usability: the Chinese README uses an uncommon naming convention, there's no cross-linking between language versions, the --base-url note is unnecessarily emphasized, and the "Available Packages" section is mislabeled.
+
+## What Changes
+
+- Rename `README_CN.md` to `README_zh.md` (more common naming convention for Chinese READMEs)
+- Add language switch links at the top of both README.md and README_zh.md
+- Remove the emphasized note about --base-url (keep it simple in the command example)
+- Rename "Available Packages" section to "Available Scripts" (these are CLI commands, not packages)
+- Fix license information: change from MIT to AGPLv3 (correct license for this project)
+- Ensure consistency between English and Chinese README content
+
+## Capabilities
+
+### Modified Capabilities
+
+- `user-readme`: Update README requirements to include language switching and correct section naming
+
+## Impact
+
+- Renamed file: `README_CN.md` → `README_zh.md`
+- Modified files: `README.md`, `README_zh.md`
+- No code changes required

--- a/openspec/changes/archive/2026-04-29-update-readme-naming/specs/user-readme/spec.md
+++ b/openspec/changes/archive/2026-04-29-update-readme-naming/specs/user-readme/spec.md
@@ -1,11 +1,4 @@
-## ADDED Requirements
-
-### Requirement: README.md exists with user-facing content
-The project SHALL have a README.md file in the root directory that provides a user-friendly introduction to the project.
-
-#### Scenario: User views README.md
-- **WHEN** a user opens the repository or PyPI page
-- **THEN** they see a README.md with project introduction, installation instructions, and quick start guide
+## MODIFIED Requirements
 
 ### Requirement: README.md contains essential sections
 The README.md SHALL include the following sections:
@@ -22,12 +15,7 @@ The README.md SHALL include the following sections:
 - **THEN** they can quickly understand what psi-agent is, how to install it, and how to get started
 - **AND** they can switch to the Chinese version via the language link
 
-### Requirement: pyproject.toml references README.md
-The pyproject.toml file SHALL reference README.md in the `readme` field.
-
-#### Scenario: PyPI displays README.md
-- **WHEN** the package is published to PyPI
-- **THEN** the README.md content is displayed on the package page
+## ADDED Requirements
 
 ### Requirement: Chinese README uses common naming convention
 The Chinese README SHALL be named `README_zh.md` following common conventions.

--- a/openspec/changes/archive/2026-04-29-update-readme-naming/tasks.md
+++ b/openspec/changes/archive/2026-04-29-update-readme-naming/tasks.md
@@ -1,0 +1,24 @@
+## 1. Rename Chinese README
+
+- [x] 1.1 Rename README_CN.md to README_zh.md
+
+## 2. Update README.md
+
+- [x] 2.1 Add language switch link at the top
+- [x] 2.2 Remove emphasized --base-url note
+- [x] 2.3 Rename "Available Packages" to "Available Scripts"
+
+## 3. Update README_zh.md
+
+- [x] 3.1 Add language switch link at the top
+- [x] 3.2 Remove emphasized --base-url note
+- [x] 3.3 Rename "可用命令" section to match English version
+
+## 4. Fix license information
+
+- [x] 4.1 Update license in README.md from MIT to AGPLv3
+- [x] 4.2 Update license in README_zh.md from MIT to AGPLv3
+
+## 5. Ensure consistency
+
+- [x] 5.1 Verify both READMEs have consistent content and structure


### PR DESCRIPTION
## Summary

- Add user-facing README.md with project introduction, installation, quick start, and component overview
- Add Chinese translation (README_zh.md) with language switch links
- Fix license information from MIT to AGPLv3
- Improve documentation clarity (rename "Available Packages" to "Available Scripts", simplify --base-url example)

## Test plan

- [ ] Verify README.md renders correctly on GitHub
- [ ] Verify language switch links work between README.md and README_zh.md
- [ ] Verify pyproject.toml references correct README file

🤖 Generated with [Claude Code](https://claude.com/claude-code)