### PR TITLE
Add continuation prompt for REPL multi-line input

### DIFF
--- a/openspec/changes/archive/2026-04-29-improve-repl-multiline-prompt/.openspec.yaml
+++ b/openspec/changes/archive/2026-04-29-improve-repl-multiline-prompt/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-28

--- a/openspec/changes/archive/2026-04-29-improve-repl-multiline-prompt/design.md
+++ b/openspec/changes/archive/2026-04-29-improve-repl-multiline-prompt/design.md
@@ -1,0 +1,44 @@
+## Context
+
+The REPL channel uses prompt-toolkit for input handling with multiline support. Currently, when users enter multi-line input (via Alt+Enter), the continuation lines show only spaces for alignment with the main prompt (`> `). This makes it difficult to visually distinguish that the user is still in multi-line input mode.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Add a visible continuation prompt symbol for multi-line input
+- Improve user experience by making multi-line mode more obvious
+
+**Non-Goals:**
+- Changing the main prompt symbol (`> `)
+- Changing the keybindings for multi-line input
+- Adding configuration options for prompt symbols
+
+## Decisions
+
+### Decision 1: Use `. ` as continuation prompt
+
+**Choice:** Use `. ` (dot followed by space) as the continuation prompt.
+
+**Rationale:**
+- Visually distinct from the main prompt (`> `) while maintaining similar width
+- Not easily confused with the main prompt or empty space
+- Minimal and unobtrusive
+- User selected this option
+
+**Alternatives considered:**
+- `... ` (ellipsis) - Python style, but wider
+- `| ` (pipe) - Common in shells, but may be confused with pipe operator
+- `~ ` (tilde) - Subtle but may be less obvious
+
+### Decision 2: Use prompt-toolkit's prompt_continuation parameter
+
+**Choice:** Use prompt-toolkit's built-in `prompt_continuation` parameter in `prompt_async()`.
+
+**Rationale:**
+- Native support in prompt-toolkit
+- Simple implementation with no additional dependencies
+- Consistent with prompt-toolkit best practices
+
+## Risks / Trade-offs
+
+- **Risk:** The continuation prompt width must match the main prompt width for proper alignment → **Mitigation:** Both `> ` and `. ` are 2 characters, ensuring alignment

--- a/openspec/changes/archive/2026-04-29-improve-repl-multiline-prompt/proposal.md
+++ b/openspec/changes/archive/2026-04-29-improve-repl-multiline-prompt/proposal.md
@@ -1,0 +1,23 @@
+## Why
+
+Currently, when entering multi-line input in the REPL channel, the continuation lines show only spaces for alignment, making it visually unclear that the user is still in multi-line mode. A visible continuation prompt symbol would improve the user experience by clearly indicating multi-line input state.
+
+## What Changes
+
+- Add a continuation prompt symbol (`. `) for multi-line input in the REPL
+- Use prompt-toolkit's `prompt_continuation` parameter to display the continuation prompt
+
+## Capabilities
+
+### New Capabilities
+
+(None)
+
+### Modified Capabilities
+
+- `repl-multi-line`: Continuation prompt visibility for multi-line input
+
+## Impact
+
+- `src/psi_agent/channel/repl/repl.py` - REPL implementation
+- User experience when entering multi-line input in the REPL

--- a/openspec/changes/archive/2026-04-29-improve-repl-multiline-prompt/specs/repl-multi-line/spec.md
+++ b/openspec/changes/archive/2026-04-29-improve-repl-multiline-prompt/specs/repl-multi-line/spec.md
@@ -1,4 +1,4 @@
-## ADDED Requirements
+## MODIFIED Requirements
 
 ### Requirement: REPL supports multi-line input mode
 

--- a/openspec/changes/archive/2026-04-29-improve-repl-multiline-prompt/tasks.md
+++ b/openspec/changes/archive/2026-04-29-improve-repl-multiline-prompt/tasks.md
@@ -1,0 +1,7 @@
+## 1. Implementation
+
+- [x] 1.1 Add continuation prompt (`. `) to prompt_async call in repl.py
+
+## 2. Verification
+
+- [x] 2.1 Verify the continuation prompt is displayed for multi-line input

--- a/src/psi_agent/channel/repl/repl.py
+++ b/src/psi_agent/channel/repl/repl.py
@@ -81,7 +81,10 @@ class Repl:
         try:
             # Use prompt-toolkit's async prompt with multiline support
             # Enter submits, Alt+Enter or Escape+Enter inserts newline
-            result = await self._session.prompt_async("> ", multiline=True)
+            # Continuation prompt (. ) for lines after the first
+            result = await self._session.prompt_async(
+                "> ", multiline=True, prompt_continuation=". "
+            )
             return result
         except EOFError:
             return None


### PR DESCRIPTION
## Summary

- Add visible continuation prompt (`. `) for multi-line input in the REPL
- Update repl-multi-line spec with the new continuation prompt requirement

Previously, when entering multi-line input, continuation lines showed only spaces for alignment, making it unclear that the user was still in multi-line mode. Now a visible `. ` prompt clearly indicates continuation lines.

## Test plan

- [x] Verified the continuation prompt is configured in prompt_async call

🤖 Generated with [Claude Code](https://claude.com/claude-code)