### PR TITLE
Fix REPL history management - remove duplicate state from channel

### DIFF
--- a/openspec/changes/archive/2026-04-29-fix-repl-history-management/.openspec.yaml
+++ b/openspec/changes/archive/2026-04-29-fix-repl-history-management/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-28

--- a/openspec/changes/archive/2026-04-29-fix-repl-history-management/design.md
+++ b/openspec/changes/archive/2026-04-29-fix-repl-history-management/design.md
@@ -1,0 +1,80 @@
+## Context
+
+Currently, both REPL channel and session maintain message history:
+
+1. **REPL (`repl.py`)**: Maintains `self.history: list[dict[str, str]]`, appends user/assistant messages, sends entire history to session on each request.
+
+2. **Session (`runner.py`)**: Maintains `self.history: History`, loads from file on startup, appends messages, persists to file.
+
+3. **Session Server (`server.py`)**: Receives full message list from channel, extracts only the last user message, discards the rest.
+
+This creates:
+- Redundant state management
+- Unnecessary data transfer (11 messages sent when only 1 is needed)
+- Confusion about who owns conversation state
+
+The architectural principle: **Session is the single source of truth for conversation state**. Channel should only handle input/output, not state.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Remove history management from REPL channel
+- Channel sends only current user message to session
+- Session remains sole authority on conversation history
+- Maintain backward compatibility with session API
+
+**Non-Goals:**
+- Changes to session history management (already correct)
+- Changes to other channels (if any)
+- Adding new features
+
+## Decisions
+
+### Decision 1: Channel sends single message, not message list
+
+**Rationale:** Session already extracts only the last user message from the request. Sending the full history is wasteful and semantically incorrect - channel shouldn't know about conversation history.
+
+**API Change:**
+```python
+# Before
+async def send_message(self, messages: list[dict[str, str]]) -> str
+
+# After
+async def send_message(self, message: str) -> str
+```
+
+### Decision 2: Remove history from REPL class
+
+**Rationale:** The `self.history` attribute in `Repl` class serves no purpose after Decision 1. Session manages all history.
+
+**Code Change:**
+```python
+# Before
+class Repl:
+    def __init__(self, config: ReplConfig) -> None:
+        self.history: list[dict[str, str]] = []
+
+    async def run(self) -> None:
+        self.history.append({"role": "user", "content": user_input})
+        response = await self.client.send_message(self.history)
+        self.history.append({"role": "assistant", "content": response})
+
+# After
+class Repl:
+    async def run(self) -> None:
+        response = await self.client.send_message(user_input)
+```
+
+### Decision 3: Keep session API unchanged
+
+**Rationale:** Session server already handles the request correctly - it extracts the last user message from the messages array. We can keep the request format as-is (messages array with single user message) for consistency with OpenAI API format.
+
+**No change needed to session.**
+
+## Risks / Trade-offs
+
+- **Risk:** If other channels exist that rely on sending full history, they would break.
+  - **Mitigation:** Check for other channel implementations. Currently only REPL exists.
+
+- **Trade-off:** Channel loses visibility into conversation history.
+  - **Acceptable:** Channel should only handle I/O, not state. This is the correct architectural boundary.

--- a/openspec/changes/archive/2026-04-29-fix-repl-history-management/proposal.md
+++ b/openspec/changes/archive/2026-04-29-fix-repl-history-management/proposal.md
@@ -1,0 +1,29 @@
+## Why
+
+The current REPL implementation maintains its own message history and sends the entire history to session on each request. However, session also maintains its own history. This results in duplicate history management and inefficient data transfer - channel sends 11 messages when session only needs the latest user message.
+
+The root cause: `repl-channel` spec incorrectly requires channel to manage history, violating the architectural principle that session is the single source of truth for conversation state.
+
+## What Changes
+
+- **BREAKING**: Remove history management from REPL channel
+- Channel now sends only the current user message to session
+- Session remains the single source of truth for conversation history
+- Update `repl-channel` spec to remove history management requirements
+
+## Capabilities
+
+### New Capabilities
+
+None - this is a fix to existing behavior.
+
+### Modified Capabilities
+
+- `repl-channel`: Remove requirement for REPL to maintain and send conversation history. Channel now sends only the current user message.
+
+## Impact
+
+- `src/psi_agent/channel/repl/repl.py` - Remove `self.history` and related logic
+- `src/psi_agent/channel/repl/client.py` - Change `send_message` to accept single message instead of message list
+- `openspec/specs/repl-channel/spec.md` - Update spec to reflect new behavior
+- Tests in `tests/channel/repl/` - Update to match new API

--- a/openspec/changes/archive/2026-04-29-fix-repl-history-management/specs/repl-channel/spec.md
+++ b/openspec/changes/archive/2026-04-29-fix-repl-history-management/specs/repl-channel/spec.md
@@ -1,0 +1,45 @@
+## REMOVED Requirements
+
+### Requirement: REPL maintains conversation history
+
+**Reason**: Session is the single source of truth for conversation history. Channel should only handle input/output, not state management.
+
+**Migration**: History is now managed exclusively by session. Channel sends only the current user message.
+
+#### Scenario: Add user message to history
+- **WHEN** user sends a message
+- **THEN** REPL SHALL add the message to conversation history
+
+#### Scenario: Add assistant message to history
+- **WHEN** session returns a response
+- **THEN** REPL SHALL add the response to conversation history
+
+#### Scenario: Send history with request
+- **WHEN** REPL sends a new message to session
+- **THEN** REPL SHALL include all previous messages in the request
+
+## ADDED Requirements
+
+### Requirement: REPL sends only current message to session
+
+The REPL SHALL send only the current user message to session, not the entire conversation history.
+
+#### Scenario: Send single message
+- **WHEN** user enters a message
+- **THEN** REPL SHALL send only that message to session
+
+#### Scenario: Message format
+- **WHEN** REPL sends a message to session
+- **THEN** the request body SHALL contain a messages array with a single user message
+
+### Requirement: REPL displays session response
+
+The REPL SHALL display the response from session without storing it locally.
+
+#### Scenario: Display response
+- **WHEN** session returns a response
+- **THEN** REPL SHALL display the response content to stdout
+
+#### Scenario: No local history storage
+- **WHEN** REPL receives a response
+- **THEN** REPL SHALL NOT store the response in a local history variable

--- a/openspec/changes/archive/2026-04-29-fix-repl-history-management/tasks.md
+++ b/openspec/changes/archive/2026-04-29-fix-repl-history-management/tasks.md
@@ -1,0 +1,21 @@
+## 1. Update REPL Client API
+
+- [x] 1.1 Change `send_message` signature to accept single message string instead of message list
+- [x] 1.2 Update request body to contain messages array with single user message
+- [x] 1.3 Update log message to reflect single message being sent
+
+## 2. Update REPL Class
+
+- [x] 2.1 Remove `self.history` attribute from `Repl` class
+- [x] 2.2 Remove history append logic in `run()` method
+- [x] 2.3 Update `send_message` call to pass single user input string
+
+## 3. Update Tests
+
+- [x] 3.1 Update `tests/channel/repl/test_client.py` to test new single-message API
+- [x] 3.2 Update `tests/channel/repl/test_repl.py` to remove history-related tests
+- [x] 3.3 Run all tests to verify changes
+
+## 4. Update Spec
+
+- [x] 4.1 Update `openspec/specs/repl-channel/spec.md` to reflect new behavior (remove history management requirement)

--- a/openspec/specs/repl-channel/spec.md
+++ b/openspec/specs/repl-channel/spec.md
@@ -44,21 +44,17 @@ The REPL SHALL send user messages to psi-session via Unix socket using HTTP POST
 - **WHEN** session returns a response
 - **THEN** REPL SHALL display the response content to stdout
 
-### Requirement: REPL maintains conversation history
+### Requirement: REPL sends only current message to session
 
-The REPL SHALL maintain a list of messages for conversation context.
+The REPL SHALL send only the current user message to session, not the entire conversation history. Session is the single source of truth for conversation state.
 
-#### Scenario: Add user message to history
-- **WHEN** user sends a message
-- **THEN** REPL SHALL add the message to conversation history
+#### Scenario: Send single message
+- **WHEN** user enters a message
+- **THEN** REPL SHALL send only that message to session
 
-#### Scenario: Add assistant message to history
-- **WHEN** session returns a response
-- **THEN** REPL SHALL add the response to conversation history
-
-#### Scenario: Send history with request
-- **WHEN** REPL sends a new message to session
-- **THEN** REPL SHALL include all previous messages in the request
+#### Scenario: Message format
+- **WHEN** REPL sends a message to session
+- **THEN** the request body SHALL contain a messages array with a single user message
 
 ### Requirement: REPL supports graceful exit
 

--- a/src/psi_agent/channel/repl/client.py
+++ b/src/psi_agent/channel/repl/client.py
@@ -39,11 +39,11 @@ class ReplClient:
             await self._connector.close()
             self._connector = None
 
-    async def send_message(self, messages: list[dict[str, str]]) -> str:
-        """Send messages to psi-session and return the response.
+    async def send_message(self, message: str) -> str:
+        """Send a message to psi-session and return the response.
 
         Args:
-            messages: List of messages in OpenAI chat format.
+            message: The user message string to send.
 
         Returns:
             The assistant's response content.
@@ -58,11 +58,11 @@ class ReplClient:
         url = "http://localhost/v1/chat/completions"
         headers = {"Content-Type": "application/json"}
         body = {
-            "messages": messages,
+            "messages": [{"role": "user", "content": message}],
             "stream": False,
         }
 
-        logger.debug(f"Sending {len(messages)} messages to session")
+        logger.debug("Sending message to session")
 
         try:
             async with self._session.post(url, headers=headers, json=body) as response:

--- a/src/psi_agent/channel/repl/repl.py
+++ b/src/psi_agent/channel/repl/repl.py
@@ -19,7 +19,6 @@ class Repl:
         """
         self.config = config
         self.client = ReplClient(config)
-        self.history: list[dict[str, str]] = []
         self._session: PromptSession[None] | None = None
 
     async def run(self) -> None:
@@ -50,17 +49,11 @@ class Repl:
                     if not user_input.strip():
                         continue
 
-                    # Add user message to history
-                    self.history.append({"role": "user", "content": user_input})
-
                     # Send to session and get response
-                    response = await self.client.send_message(self.history)
+                    response = await self.client.send_message(user_input)
 
                     # Display response
                     print(f"\n{response}\n")
-
-                    # Add assistant response to history
-                    self.history.append({"role": "assistant", "content": response})
 
                 except KeyboardInterrupt:
                     print("\n\nInterrupted. Type /quit or press Ctrl+D to exit.\n")

--- a/tests/channel/repl/test_client.py
+++ b/tests/channel/repl/test_client.py
@@ -159,4 +159,4 @@ class TestReplClient:
         client = ReplClient(config)
 
         with pytest.raises(RuntimeError, match="Client not initialized"):
-            await client.send_message([{"role": "user", "content": "Hi"}])
+            await client.send_message("Hi")

--- a/tests/channel/repl/test_client.py
+++ b/tests/channel/repl/test_client.py
@@ -68,7 +68,7 @@ class TestReplClient:
             mock_session.return_value = mock_session_instance
 
             async with client:
-                result = await client.send_message([{"role": "user", "content": "Hi"}])
+                result = await client.send_message("Hi")
 
                 assert result == "Hello!"
 
@@ -95,7 +95,7 @@ class TestReplClient:
             mock_session.return_value = mock_session_instance
 
             async with client:
-                result = await client.send_message([{"role": "user", "content": "Hi"}])
+                result = await client.send_message("Hi")
 
                 assert "Error" in result
 
@@ -122,7 +122,7 @@ class TestReplClient:
             mock_session.return_value = mock_session_instance
 
             async with client:
-                result = await client.send_message([{"role": "user", "content": "Hi"}])
+                result = await client.send_message("Hi")
 
                 assert "Error" in result
 
@@ -149,7 +149,7 @@ class TestReplClient:
             mock_session.return_value = mock_session_instance
 
             async with client:
-                result = await client.send_message([{"role": "user", "content": "Hi"}])
+                result = await client.send_message("Hi")
 
                 assert "Error" in result
 

--- a/tests/channel/repl/test_repl.py
+++ b/tests/channel/repl/test_repl.py
@@ -84,15 +84,16 @@ class TestRepl:
         async def mock_read() -> str | None:
             return next(input_iter, None)
 
+        mock_send = AsyncMock(return_value="Response")
         with (
             patch.object(repl, "_read_input", mock_read),
-            patch.object(repl.client, "send_message", AsyncMock(return_value="Response")),
+            patch.object(repl.client, "send_message", mock_send),
             patch("builtins.print"),
         ):
             await repl.run()
 
             # send_message should not have been called for empty input
-            repl.client.send_message.assert_not_called()
+            mock_send.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_message_sent_to_session(self, repl: Repl) -> None:
@@ -103,15 +104,16 @@ class TestRepl:
         async def mock_read() -> str | None:
             return next(input_iter, None)
 
+        mock_send = AsyncMock(return_value="Hi there!")
         with (
             patch.object(repl, "_read_input", mock_read),
-            patch.object(repl.client, "send_message", AsyncMock(return_value="Hi there!")),
+            patch.object(repl.client, "send_message", mock_send),
             patch("builtins.print"),
         ):
             await repl.run()
 
             # send_message should be called with the user input
-            repl.client.send_message.assert_called_once_with("Hello")
+            mock_send.assert_called_once_with("Hello")
 
 
 class TestReplHistory:
@@ -157,15 +159,16 @@ class TestReplHistory:
         async def mock_read() -> str | None:
             return next(input_iter, None)
 
+        mock_send = AsyncMock(return_value="Response")
         with (
             patch.object(repl, "_read_input", mock_read),
-            patch.object(repl.client, "send_message", AsyncMock(return_value="Response")),
+            patch.object(repl.client, "send_message", mock_send),
             patch("builtins.print"),
         ):
             await repl.run()
 
             # Check multiline message preserved
-            repl.client.send_message.assert_called_once_with(multiline_input)
+            mock_send.assert_called_once_with(multiline_input)
 
 
 class TestReplEditing:

--- a/tests/channel/repl/test_repl.py
+++ b/tests/channel/repl/test_repl.py
@@ -25,7 +25,6 @@ class TestRepl:
     def test_repl_creation(self, repl: Repl, config: ReplConfig) -> None:
         """Test REPL creation."""
         assert repl.config == config
-        assert repl.history == []
 
     def test_repl_has_client(self, repl: Repl) -> None:
         """Test REPL has client."""
@@ -85,15 +84,19 @@ class TestRepl:
         async def mock_read() -> str | None:
             return next(input_iter, None)
 
-        with patch.object(repl, "_read_input", mock_read), patch("builtins.print"):
+        with (
+            patch.object(repl, "_read_input", mock_read),
+            patch.object(repl.client, "send_message", AsyncMock(return_value="Response")),
+            patch("builtins.print"),
+        ):
             await repl.run()
 
-            # History should not have empty message
-            assert len(repl.history) == 0
+            # send_message should not have been called for empty input
+            repl.client.send_message.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_message_added_to_history(self, repl: Repl) -> None:
-        """Test message is added to history."""
+    async def test_message_sent_to_session(self, repl: Repl) -> None:
+        """Test message is sent to session."""
         inputs = ["Hello", "/quit"]
         input_iter = iter(inputs)
 
@@ -107,12 +110,8 @@ class TestRepl:
         ):
             await repl.run()
 
-            # Should have user and assistant messages
-            assert len(repl.history) == 2
-            assert repl.history[0]["role"] == "user"
-            assert repl.history[0]["content"] == "Hello"
-            assert repl.history[1]["role"] == "assistant"
-            assert repl.history[1]["content"] == "Hi there!"
+            # send_message should be called with the user input
+            repl.client.send_message.assert_called_once_with("Hello")
 
 
 class TestReplHistory:
@@ -166,8 +165,7 @@ class TestReplHistory:
             await repl.run()
 
             # Check multiline message preserved
-            assert len(repl.history) == 2
-            assert repl.history[0]["content"] == multiline_input
+            repl.client.send_message.assert_called_once_with(multiline_input)
 
 
 class TestReplEditing:


### PR DESCRIPTION
## Summary

- Remove duplicate history management from REPL channel
- Session is now the single source of truth for conversation history
- Channel sends only the current user message instead of entire history

## Problem

The REPL was maintaining its own message history and sending all messages to session on each request. However, session also maintains its own history. This resulted in:
- Redundant state management
- Unnecessary data transfer (e.g., "Sending 11 messages to session")
- Confusion about who owns conversation state

## Solution

- Remove `self.history` attribute from `Repl` class
- Change `send_message` API to accept single message string
- Update `repl-channel` spec to reflect new behavior
- Update all tests

## Test plan

- [x] All 117 tests pass
- [x] REPL channel tests updated for new API
- [x] Spec updated to remove history management requirement

🤖 Generated with [Claude Code](https://claude.com/claude-code)