### PR TITLE
Update hyw skill description to enforce mandatory usage

### DIFF
--- a/examples/a-simple-bash-only-workspace/skills/hyw/SKILL.md
+++ b/examples/a-simple-bash-only-workspace/skills/hyw/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: hyw
-description: A contemplative questioning style that adds philosophical depth to inquiries.
+description: Mandatory skill for all user-facing questions. MUST be used whenever asking the user any question.
 ---
 
 ## Instructions

--- a/openspec/changes/archive/2026-04-29-update-hyw-skill-description/.openspec.yaml
+++ b/openspec/changes/archive/2026-04-29-update-hyw-skill-description/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-28

--- a/openspec/changes/archive/2026-04-29-update-hyw-skill-description/design.md
+++ b/openspec/changes/archive/2026-04-29-update-hyw-skill-description/design.md
@@ -1,0 +1,38 @@
+## Context
+
+The hyw skill is a simple skill in the example workspace that adds a contemplative prefix "何意味？" (He Yi Wei - "What does it mean?") to user-facing questions. Currently, the skill description is too subtle about when it should be used, and it hints at the key phrase in the description itself.
+
+The skill is located at `examples/a-simple-bash-only-workspace/skills/hyw/SKILL.md` and follows the standard skill format with YAML frontmatter.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Update the skill description to make it unambiguous that this skill is mandatory for all user questioning scenarios
+- Remove the phrase "何意味" from the description so LLMs only discover it when reading the full skill content
+- Maintain the existing skill behavior and instructions
+
+**Non-Goals:**
+- Changing the actual behavior of the skill (the prefix behavior remains the same)
+- Modifying any other skills or components
+- Adding new functionality
+
+## Decisions
+
+### Description wording
+The description should:
+1. Use clear, directive language like "MUST" or "required" to indicate mandatory usage
+2. Specify the trigger condition: "when asking the user any question"
+3. Not reveal the specific phrase or behavior - that should only be discoverable in the skill body
+
+Proposed new description:
+> "Mandatory skill for all user-facing questions. MUST be used whenever asking the user any question."
+
+This makes the requirement explicit without revealing the implementation.
+
+## Risks / Trade-offs
+
+**Risk**: Overly strict description may cause the LLM to apply the skill inappropriately (e.g., to rhetorical questions)
+→ **Mitigation**: The skill body already has explicit instructions about when NOT to apply (rhetorical questions, internal reasoning)
+
+**Trade-off**: The new description is more prescriptive, which reduces ambiguity but may feel less "philosophical" in tone
+→ This is acceptable because clarity of when to use the skill is more important than stylistic consistency

--- a/openspec/changes/archive/2026-04-29-update-hyw-skill-description/proposal.md
+++ b/openspec/changes/archive/2026-04-29-update-hyw-skill-description/proposal.md
@@ -1,0 +1,25 @@
+## Why
+
+The current hyw skill description is too vague and doesn't clearly communicate when the skill should be used. LLMs reading the skill list may not understand that this skill is mandatory for all user-facing questions. Additionally, the description currently hints at the key phrase "何意味", which should only be discovered when reading the full skill instructions, not from the description itself.
+
+## What Changes
+
+- Update the skill description to explicitly state that this skill MUST be used in all user questioning scenarios
+- Remove any mention of "何意味" from the description to preserve the discovery experience
+- The description should clearly indicate mandatory usage without revealing the specific behavior
+
+## Capabilities
+
+### New Capabilities
+
+None - this is an update to an existing skill, not a new capability.
+
+### Modified Capabilities
+
+- `hyw-skill`: The skill description in the YAML frontmatter will be updated to enforce mandatory usage and remove the phrase hint.
+
+## Impact
+
+- Affected file: `examples/a-simple-bash-only-workspace/skills/hyw/SKILL.md`
+- No API changes
+- No breaking changes to existing behavior - only clarifying when the skill should be triggered

--- a/openspec/changes/archive/2026-04-29-update-hyw-skill-description/specs/hyw-skill/spec.md
+++ b/openspec/changes/archive/2026-04-29-update-hyw-skill-description/specs/hyw-skill/spec.md
@@ -1,0 +1,13 @@
+## MODIFIED Requirements
+
+### Requirement: Skill description enforces mandatory usage
+The skill description in the YAML frontmatter SHALL clearly state that this skill is mandatory for all user-facing questions. The description SHALL NOT contain the phrase "何意味" or any hint of the specific behavior.
+
+#### Scenario: LLM reads skill list
+- **WHEN** the LLM reads the list of available skills with their descriptions
+- **THEN** the LLM SHALL understand that the hyw skill MUST be used for any user-facing question
+- **AND** the LLM SHALL NOT know the specific phrase "何意味" from the description alone
+
+#### Scenario: LLM reads full skill content
+- **WHEN** the LLM decides to read the full skill content after seeing the description
+- **THEN** the LLM SHALL discover the specific behavior (adding "何意味？" prefix) in the skill body

--- a/openspec/changes/archive/2026-04-29-update-hyw-skill-description/tasks.md
+++ b/openspec/changes/archive/2026-04-29-update-hyw-skill-description/tasks.md
@@ -1,0 +1,5 @@
+## 1. Update Skill Description
+
+- [x] 1.1 Update the `description` field in `examples/a-simple-bash-only-workspace/skills/hyw/SKILL.md` YAML frontmatter to: "Mandatory skill for all user-facing questions. MUST be used whenever asking the user any question."
+- [x] 1.2 Verify the phrase "何意味" does not appear in the description field
+- [x] 1.3 Verify the skill body (instructions section) remains unchanged

--- a/openspec/specs/hyw-skill/spec.md
+++ b/openspec/specs/hyw-skill/spec.md
@@ -1,0 +1,13 @@
+## Requirements
+
+### Requirement: Skill description enforces mandatory usage
+The skill description in the YAML frontmatter SHALL clearly state that this skill is mandatory for all user-facing questions. The description SHALL NOT contain the phrase "何意味" or any hint of the specific behavior.
+
+#### Scenario: LLM reads skill list
+- **WHEN** the LLM reads the list of available skills with their descriptions
+- **THEN** the LLM SHALL understand that the hyw skill MUST be used for any user-facing question
+- **AND** the LLM SHALL NOT know the specific phrase "何意味" from the description alone
+
+#### Scenario: LLM reads full skill content
+- **WHEN** the LLM decides to read the full skill content after seeing the description
+- **THEN** the LLM SHALL discover the specific behavior (adding "何意味？" prefix) in the skill body


### PR DESCRIPTION
## Summary
- Update hyw skill description to explicitly state it MUST be used for all user-facing questions
- Remove "何意味" from description to preserve the discovery experience (LLMs only learn the phrase when reading the full skill content)
- Add spec for hyw-skill capability
- Archive openspec change artifacts

## Test plan
- [ ] Verify skill description is clear about mandatory usage
- [ ] Verify "何意味" does not appear in the description field
- [ ] Verify skill body (instructions section) remains unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)