### PR TITLE
Update CONTRIBUTING.md to allow any coding agent

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,41 +1,21 @@
 # Contributing
 
-欢迎提交 issue 和 pull request。
-
-**注意：所有 PR 的代码必须由 Claude Code 编写。**
-
-请使用 Claude Code 完成 PR 的实现工作。Claude Code 会自动读取并遵循 `CLAUDE.md` 中的编码规范。人工编写的 PR 代码将不会被接受。
-
-## 使用 Git Worktree 进行并行开发
-
-你可以通过 git worktree 同时运行多个 Claude Code 会话。这允许在不同的分支上并行工作而不会产生冲突。
-
-```bash
-# 为新分支创建 worktree
-git worktree add worktree/<branch-name> -b <branch-name>
-
-# 或添加现有分支
-git worktree add worktree/<branch-name> <existing-branch>
-
-# 清理过期的 worktree
-git worktree prune
-```
-
-`worktree/` 中的每个 worktree 都是独立的工作目录，可以单独运行 Claude Code。
-
----
-
 Thank you for your interest in contributing!
 
 Issues and pull requests are welcome.
 
-**Note: All PR code must be written by Claude Code.**
+**Note: All PR code must be written by a coding agent (not manually by humans).**
 
-Please use Claude Code to implement your PR. Claude Code will automatically read and follow the coding standards in `CLAUDE.md`. Human-written PR code will not be accepted.
+You may use any coding agent of your choice. If you use Claude Code, it will automatically read and follow the coding standards in `CLAUDE.md`. If you use an alternative coding agent, please ensure:
+
+1. OpenSpec is installed (for change management workflow)
+2. The agent is configured to read and understand `CLAUDE.md` content
+
+Human-written PR code will not be accepted.
 
 ## Parallel Development with Git Worktrees
 
-You can run multiple Claude Code sessions in parallel by using git worktrees. This allows working on different branches simultaneously without conflicts.
+You can run multiple coding agent sessions in parallel by using git worktrees. This allows working on different branches simultaneously without conflicts.
 
 ```bash
 # Create a worktree for a new branch
@@ -48,4 +28,36 @@ git worktree add worktree/<branch-name> <existing-branch>
 git worktree prune
 ```
 
-Each worktree in `worktree/` is a separate working directory where you can run Claude Code independently.
+Each worktree in `worktree/` is a separate working directory where you can run a coding agent independently.
+
+---
+
+# 贡献指南
+
+欢迎提交 issue 和 pull request。
+
+**注意：所有 PR 的代码必须由 coding agent 编写（而非人工编写）。**
+
+您可以使用任意 coding agent。如果您使用 Claude Code，它会自动读取并遵循 `CLAUDE.md` 中的编码规范。如果您使用其他 coding agent，请确保：
+
+1. 已安装 OpenSpec（用于变更管理工作流）
+2. 该 agent 已配置为读取并理解 `CLAUDE.md` 的内容
+
+人工编写的 PR 代码将不会被接受。
+
+## 使用 Git Worktree 进行并行开发
+
+你可以通过 git worktree 同时运行多个 coding agent 会话。这允许在不同的分支上并行工作而不会产生冲突。
+
+```bash
+# 为新分支创建 worktree
+git worktree add worktree/<branch-name> -b <branch-name>
+
+# 或添加现有分支
+git worktree add worktree/<branch-name> <existing-branch>
+
+# 清理过期的 worktree
+git worktree prune
+```
+
+`worktree/` 中的每个 worktree 都是独立的工作目录，可以单独运行 coding agent。

--- a/openspec/changes/archive/2026-04-29-update-contributing/.openspec.yaml
+++ b/openspec/changes/archive/2026-04-29-update-contributing/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-28

--- a/openspec/changes/archive/2026-04-29-update-contributing/design.md
+++ b/openspec/changes/archive/2026-04-29-update-contributing/design.md
@@ -1,0 +1,40 @@
+## Context
+
+CONTRIBUTING.md is a documentation file that sets contribution guidelines for the project. Currently it mandates Claude Code as the only acceptable coding agent for PR contributions. The actual intent is to ensure code quality through automated coding agents while allowing flexibility in tool choice.
+
+The file currently has Chinese content first, followed by English content. The standard convention for open-source projects is to have English as the primary language.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Update CONTRIBUTING.md to allow any coding agent (not just Claude Code)
+- Require that alternative agents have OpenSpec installed and understand CLAUDE.md
+- Restructure document with English first, then Chinese
+- Ensure both language versions are consistent
+
+**Non-Goals:**
+- Changing the underlying code quality requirements
+- Modifying any code or configuration files
+- Creating new tooling or infrastructure
+
+## Decisions
+
+### Document Structure
+- **Decision**: English section first, then Chinese section
+- **Rationale**: English is the lingua franca of open source; this makes the document more accessible to international contributors
+
+### Coding Agent Requirements
+- **Decision**: Allow any coding agent with proper setup
+- **Rationale**: The goal is code quality through automation, not tool lock-in. Contributors should have flexibility while maintaining standards.
+- **Requirements for alternative agents**:
+  1. OpenSpec must be installed (for change management workflow)
+  2. Agent must be configured to read and understand CLAUDE.md content
+
+### Language Consistency
+- **Decision**: Both versions must convey identical requirements
+- **Rationale**: Avoids confusion where contributors follow different rules based on which language they read
+
+## Risks / Trade-offs
+
+- **Risk**: Contributors may not properly configure alternative agents → Mitigation: Clear setup instructions in CONTRIBUTING.md
+- **Risk**: Different agents may interpret CLAUDE.md differently → Mitigation: Acceptable trade-off for flexibility; code review catches issues

--- a/openspec/changes/archive/2026-04-29-update-contributing/proposal.md
+++ b/openspec/changes/archive/2026-04-29-update-contributing/proposal.md
@@ -1,0 +1,27 @@
+## Why
+
+CONTRIBUTING.md currently states that Claude Code is mandatory for all PR contributions. This requirement is too restrictive - the actual intent is to ensure code quality through coding agents, not to mandate a specific tool. Contributors should be able to use any coding agent as long as they properly understand and follow the project's coding standards defined in CLAUDE.md.
+
+## What Changes
+
+- Remove the mandatory Claude Code requirement
+- Clarify that code must be written by coding agents (not humans), but any coding agent is acceptable
+- Add requirement that alternative coding agents must have OpenSpec installed and be configured to understand CLAUDE.md content
+- Reorder sections: English version first, then Chinese version
+- Ensure Chinese and English versions are consistent in content
+
+## Capabilities
+
+### New Capabilities
+
+- `contributing-guidelines`: Define contribution requirements and workflow for the project
+
+### Modified Capabilities
+
+None - this is a documentation update with no spec-level behavior changes.
+
+## Impact
+
+- **Documentation**: CONTRIBUTING.md will be restructured and updated
+- **Contributors**: More flexibility in tool choice while maintaining code quality standards
+- **Workflow**: Contributors using non-Claude Code agents need to ensure proper setup

--- a/openspec/changes/archive/2026-04-29-update-contributing/specs/contributing-guidelines/spec.md
+++ b/openspec/changes/archive/2026-04-29-update-contributing/specs/contributing-guidelines/spec.md
@@ -1,0 +1,41 @@
+## ADDED Requirements
+
+### Requirement: Coding agent requirement
+All PR code MUST be written by a coding agent (not manually by humans).
+
+#### Scenario: PR with coding agent code
+- **WHEN** a contributor submits a PR with code written by a coding agent
+- **THEN** the PR is eligible for review
+
+#### Scenario: PR with manually written code
+- **WHEN** a contributor submits a PR with manually written code
+- **THEN** the PR is not accepted
+
+### Requirement: Coding agent flexibility
+Contributors MAY use any coding agent that meets the setup requirements.
+
+#### Scenario: Using Claude Code
+- **WHEN** a contributor uses Claude Code
+- **THEN** no additional setup is required as Claude Code natively reads CLAUDE.md
+
+#### Scenario: Using alternative coding agent
+- **WHEN** a contributor uses an alternative coding agent
+- **THEN** the agent must have OpenSpec installed and be configured to understand CLAUDE.md content
+
+### Requirement: Document structure
+CONTRIBUTING.md MUST present English content first, followed by Chinese content.
+
+#### Scenario: Reading English section
+- **WHEN** a contributor opens CONTRIBUTING.md
+- **THEN** the English section appears at the top of the file
+
+#### Scenario: Reading Chinese section
+- **WHEN** a contributor scrolls past the English section
+- **THEN** the Chinese section follows with identical requirements
+
+### Requirement: Language consistency
+English and Chinese versions MUST convey identical requirements and information.
+
+#### Scenario: Comparing language versions
+- **WHEN** comparing English and Chinese sections
+- **THEN** both sections describe the same requirements and guidelines

--- a/openspec/changes/archive/2026-04-29-update-contributing/tasks.md
+++ b/openspec/changes/archive/2026-04-29-update-contributing/tasks.md
@@ -1,0 +1,17 @@
+## 1. Document Restructuring
+
+- [x] 1.1 Rewrite English section with updated coding agent requirements
+- [x] 1.2 Rewrite Chinese section with identical content to English
+- [x] 1.3 Reorder sections: English first, Chinese second
+
+## 2. Content Updates
+
+- [x] 2.1 Remove mandatory Claude Code requirement
+- [x] 2.2 Add coding agent flexibility statement (any agent acceptable)
+- [x] 2.3 Add OpenSpec installation requirement for alternative agents
+- [x] 2.4 Add CLAUDE.md understanding requirement for alternative agents
+
+## 3. Verification
+
+- [x] 3.1 Verify English and Chinese sections are consistent
+- [x] 3.2 Verify all requirements from specs are addressed

--- a/openspec/specs/contributing-guidelines/spec.md
+++ b/openspec/specs/contributing-guidelines/spec.md
@@ -1,0 +1,39 @@
+### Requirement: Coding agent requirement
+All PR code MUST be written by a coding agent (not manually by humans).
+
+#### Scenario: PR with coding agent code
+- **WHEN** a contributor submits a PR with code written by a coding agent
+- **THEN** the PR is eligible for review
+
+#### Scenario: PR with manually written code
+- **WHEN** a contributor submits a PR with manually written code
+- **THEN** the PR is not accepted
+
+### Requirement: Coding agent flexibility
+Contributors MAY use any coding agent that meets the setup requirements.
+
+#### Scenario: Using Claude Code
+- **WHEN** a contributor uses Claude Code
+- **THEN** no additional setup is required as Claude Code natively reads CLAUDE.md
+
+#### Scenario: Using alternative coding agent
+- **WHEN** a contributor uses an alternative coding agent
+- **THEN** the agent must have OpenSpec installed and be configured to understand CLAUDE.md content
+
+### Requirement: Document structure
+CONTRIBUTING.md MUST present English content first, followed by Chinese content.
+
+#### Scenario: Reading English section
+- **WHEN** a contributor opens CONTRIBUTING.md
+- **THEN** the English section appears at the top of the file
+
+#### Scenario: Reading Chinese section
+- **WHEN** a contributor scrolls past the English section
+- **THEN** the Chinese section follows with identical requirements
+
+### Requirement: Language consistency
+English and Chinese versions MUST convey identical requirements and information.
+
+#### Scenario: Comparing language versions
+- **WHEN** comparing English and Chinese sections
+- **THEN** both sections describe the same requirements and guidelines


### PR DESCRIPTION
## Summary

- Remove mandatory Claude Code requirement
- Allow any coding agent with proper setup
- Add OpenSpec installation requirement for alternative agents
- Add CLAUDE.md understanding requirement for alternative agents
- Reorder sections: English first, Chinese second
- Ensure both language versions are consistent

## Test plan

- [ ] Verify English section appears first in CONTRIBUTING.md
- [ ] Verify Chinese section follows with identical content
- [ ] Verify coding agent requirements are clear and accurate

🤖 Generated with [Claude Code](https://claude.com/claude-code)