### PR TITLE
Migrate psi-ai-openai-completions to official OpenAI SDK

### DIFF
--- a/openspec/changes/archive/2026-04-29-migrate-to-openai-sdk/.openspec.yaml
+++ b/openspec/changes/archive/2026-04-29-migrate-to-openai-sdk/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-28

--- a/openspec/changes/archive/2026-04-29-migrate-to-openai-sdk/design.md
+++ b/openspec/changes/archive/2026-04-29-migrate-to-openai-sdk/design.md
@@ -1,0 +1,81 @@
+## Context
+
+The `psi-ai-openai-completions` component currently implements HTTP communication with OpenAI-compatible APIs using raw `aiohttp`. This requires manual handling of:
+
+- Request/response serialization
+- SSE (Server-Sent Events) parsing for streaming
+- Error type detection and mapping
+- Timeout configuration
+- Connection management
+
+In contrast, `psi-ai-anthropic-messages` uses the official `anthropic` SDK which provides these features out-of-the-box. The OpenAI Python SDK (`openai>=1.0.0`) now has mature async support via `AsyncOpenAI` client, making it suitable for our async-first architecture.
+
+**Current Implementation Analysis:**
+
+| Aspect | Hand-rolled (aiohttp) | SDK (AsyncOpenAI) |
+|--------|----------------------|-------------------|
+| Lines of code | ~169 | ~100 (estimated) |
+| Error types | Manual mapping | Built-in hierarchy |
+| SSE parsing | Manual line parsing | SDK handles |
+| Retry logic | None | Built-in with backoff |
+| Type safety | Dict[str, Any] | Typed responses |
+| Streaming | Manual chunk handling | Async generators |
+
+## Goals / Non-Goals
+
+**Goals:**
+- Replace `aiohttp` with `AsyncOpenAI` in `OpenAICompletionsClient`
+- Reduce code complexity and maintenance burden
+- Gain built-in retry logic and error handling
+- Maintain identical external behavior (Unix socket server, OpenAI protocol)
+
+**Non-Goals:**
+- Changing the server implementation (still uses aiohttp for Unix socket)
+- Modifying the configuration interface
+- Adding new features beyond what SDK provides
+- Changing the anthropic implementation
+
+## Decisions
+
+### Decision 1: Use `AsyncOpenAI` client
+
+**Rationale:** The official SDK provides:
+- Type-safe request/response handling
+- Built-in streaming with async generators
+- Comprehensive error type hierarchy
+- Automatic retry with exponential backoff
+- Connection pooling
+
+**Alternatives considered:**
+- Keep `aiohttp`: More control but more maintenance, no retry logic
+- Use `httpx`: Still requires manual SSE parsing, no OpenAI-specific features
+
+### Decision 2: Keep `aiohttp` for server component
+
+**Rationale:** The server component (`OpenAICompletionsServer`) uses aiohttp's `web.Application` for Unix socket HTTP serving. The OpenAI SDK doesn't provide server functionality - it's purely a client library.
+
+### Decision 3: Use SDK's streaming API with `stream=True`
+
+**Rationale:** The SDK's `stream=True` parameter returns an async iterator that handles SSE parsing automatically. We convert SDK stream events to our SSE format for compatibility with the session component.
+
+**Code pattern:**
+```python
+async with client.chat.completions.create(..., stream=True) as stream:
+    async for chunk in stream:
+        # Convert to SSE format
+        yield f"data: {chunk.model_dump_json()}\n\n"
+```
+
+## Risks / Trade-offs
+
+**Risk: SDK breaking changes**
+→ Mitigation: Pin SDK version in `pyproject.toml`, test before upgrading
+
+**Risk: Different error response format**
+→ Mitigation: SDK exceptions have consistent structure; map to our error dict format
+
+**Risk: Streaming format differences**
+→ Mitigation: Test with multiple providers (OpenAI, OpenRouter, local models)
+
+**Trade-off: Additional dependency**
+→ Acceptable: The SDK is well-maintained and widely used; reduces our maintenance burden

--- a/openspec/changes/archive/2026-04-29-migrate-to-openai-sdk/proposal.md
+++ b/openspec/changes/archive/2026-04-29-migrate-to-openai-sdk/proposal.md
@@ -1,0 +1,44 @@
+## Why
+
+Currently, `psi-ai-anthropic-messages` uses the official `anthropic` SDK, while `psi-ai-openai-completions` uses a hand-rolled implementation with `aiohttp`. This inconsistency creates maintenance overhead and misses the benefits that the official OpenAI SDK provides: built-in error handling, retry logic, type safety, and streaming abstractions. The OpenAI SDK's async support (`AsyncOpenAI`) makes it a viable replacement that would simplify our codebase.
+
+## What Changes
+
+- Replace hand-rolled `aiohttp`-based HTTP client in `psi-ai-openai-completions` with the official `openai` SDK's `AsyncOpenAI` client
+- Remove manual SSE parsing, error handling, and timeout management code
+- Leverage SDK's built-in error types (`AuthenticationError`, `RateLimitError`, `APIConnectionError`, etc.)
+- Maintain the same Unix socket server interface and OpenAI chat completions protocol
+
+## Capabilities
+
+### New Capabilities
+
+None - this is an internal refactoring that improves implementation quality without changing external behavior.
+
+### Modified Capabilities
+
+None - the OpenAI completions component's requirements remain unchanged. It still:
+- Accepts OpenAI chat completion format requests over Unix socket
+- Supports both streaming and non-streaming responses
+- Returns SSE-formatted streaming responses
+
+## Impact
+
+**Code Changes:**
+- `src/psi_agent/ai/openai_completions/client.py` - Replace `aiohttp` with `AsyncOpenAI`
+- `pyproject.toml` - Add `openai` dependency
+
+**Code Reduction:**
+- Estimated ~40% reduction in client.py lines (169 → ~100 lines)
+- Remove manual SSE parsing logic
+- Remove manual timeout configuration
+- Simplify error handling with SDK exception types
+
+**Dependencies:**
+- Add: `openai` (official Python SDK with async support)
+- Keep: `aiohttp` (still used by server.py for Unix socket HTTP server)
+
+**No Breaking Changes:**
+- External API remains identical (Unix socket + OpenAI chat completions protocol)
+- Configuration interface unchanged
+- CLI arguments unchanged

--- a/openspec/changes/archive/2026-04-29-migrate-to-openai-sdk/specs/spec.md
+++ b/openspec/changes/archive/2026-04-29-migrate-to-openai-sdk/specs/spec.md
@@ -1,0 +1,46 @@
+## ADDED Requirements
+
+### Requirement: OpenAI SDK client integration
+
+The `OpenAICompletionsClient` SHALL use the official `openai` SDK's `AsyncOpenAI` client for all HTTP communication with OpenAI-compatible APIs.
+
+#### Scenario: Non-streaming request with SDK
+- **WHEN** a chat completion request is made without streaming
+- **THEN** the SDK's `client.chat.completions.create()` method is called
+- **AND** the response is returned as a typed object
+
+#### Scenario: Streaming request with SDK
+- **WHEN** a chat completion request is made with streaming enabled
+- **THEN** the SDK's streaming API is used with `stream=True`
+- **AND** chunks are yielded as SSE-formatted strings
+
+### Requirement: SDK error handling
+
+The client SHALL handle SDK-specific exceptions and convert them to the existing error response format.
+
+#### Scenario: Authentication error
+- **WHEN** the API returns a 401 error
+- **THEN** an `AuthenticationError` exception is caught
+- **AND** `{"error": "Authentication failed", "status_code": 401}` is returned
+
+#### Scenario: Rate limit error
+- **WHEN** the API returns a 429 error
+- **THEN** a `RateLimitError` exception is caught
+- **AND** `{"error": "Rate limit exceeded", "status_code": 429}` is returned
+
+#### Scenario: Connection error
+- **WHEN** the API is unreachable
+- **THEN** an `APIConnectionError` exception is caught
+- **AND** `{"error": "Connection failed", "status_code": 500}` is returned
+
+### Requirement: Backward compatibility
+
+The refactored client SHALL maintain identical external behavior to the current implementation.
+
+#### Scenario: Same method signature
+- **WHEN** the client is used
+- **THEN** the `chat_completions(request_body, stream)` method signature remains unchanged
+
+#### Scenario: Same response format
+- **WHEN** a request completes
+- **THEN** the response dict structure matches the current implementation

--- a/openspec/changes/archive/2026-04-29-migrate-to-openai-sdk/tasks.md
+++ b/openspec/changes/archive/2026-04-29-migrate-to-openai-sdk/tasks.md
@@ -1,0 +1,27 @@
+## 1. Dependencies
+
+- [x] 1.1 Add `openai` dependency to `pyproject.toml`
+- [x] 1.2 Run `uv lock` to update lockfile
+
+## 2. Client Implementation
+
+- [x] 2.1 Replace `aiohttp.ClientSession` with `AsyncOpenAI` in `OpenAICompletionsClient.__init__`
+- [x] 2.2 Update `__aenter__` to initialize `AsyncOpenAI` client
+- [x] 2.3 Update `__aexit__` to close `AsyncOpenAI` client
+- [x] 2.4 Refactor `_non_stream_request` to use SDK's `chat.completions.create()`
+- [x] 2.5 Refactor `_stream_request` to use SDK's streaming API
+- [x] 2.6 Update `_handle_error` to use SDK exception types
+
+## 3. Testing
+
+- [x] 3.1 Update existing unit tests for new client implementation
+- [x] 3.2 Add tests for SDK error handling scenarios
+- [x] 3.3 Run `ruff check` and `ruff format`
+- [x] 3.4 Run `ty check` for type checking
+- [x] 3.5 Run `pytest` to verify all tests pass
+
+## 4. Verification
+
+- [x] 4.1 Manual test with OpenAI API
+- [x] 4.2 Manual test with OpenRouter API
+- [x] 4.3 Verify streaming and non-streaming modes work correctly

--- a/openspec/specs/psi-ai-openai-completions/spec.md
+++ b/openspec/specs/psi-ai-openai-completions/spec.md
@@ -111,3 +111,48 @@ psi-ai-openai-completions SHALL 提供单元测试，覆盖核心功能。
 #### Scenario: 测试 client 功能
 - **WHEN** 运行 pytest
 - **THEN** SHALL 测试 client 的 API 调用功能
+
+### Requirement: OpenAI SDK client integration
+
+The `OpenAICompletionsClient` SHALL use the official `openai` SDK's `AsyncOpenAI` client for all HTTP communication with OpenAI-compatible APIs.
+
+#### Scenario: Non-streaming request with SDK
+- **WHEN** a chat completion request is made without streaming
+- **THEN** the SDK's `client.chat.completions.create()` method is called
+- **AND** the response is returned as a typed object
+
+#### Scenario: Streaming request with SDK
+- **WHEN** a chat completion request is made with streaming enabled
+- **THEN** the SDK's streaming API is used with `stream=True`
+- **AND** chunks are yielded as SSE-formatted strings
+
+### Requirement: SDK error handling
+
+The client SHALL handle SDK-specific exceptions and convert them to the existing error response format.
+
+#### Scenario: Authentication error
+- **WHEN** the API returns a 401 error
+- **THEN** an `AuthenticationError` exception is caught
+- **AND** `{"error": "Authentication failed", "status_code": 401}` is returned
+
+#### Scenario: Rate limit error
+- **WHEN** the API returns a 429 error
+- **THEN** a `RateLimitError` exception is caught
+- **AND** `{"error": "Rate limit exceeded", "status_code": 429}` is returned
+
+#### Scenario: Connection error
+- **WHEN** the API is unreachable
+- **THEN** an `APIConnectionError` exception is caught
+- **AND** `{"error": "Connection failed", "status_code": 500}` is returned
+
+### Requirement: Backward compatibility
+
+The refactored client SHALL maintain identical external behavior to the current implementation.
+
+#### Scenario: Same method signature
+- **WHEN** the client is used
+- **THEN** the `chat_completions(request_body, stream)` method signature remains unchanged
+
+#### Scenario: Same response format
+- **WHEN** a request completes
+- **THEN** the response dict structure matches the current implementation

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
     "anthropic>=0.57.1",
     "anyio>=4.13.0",
     "loguru>=0.7.3",
+    "openai>=1.30.0",
     "prompt-toolkit>=3.0.51",
     "tyro>=1.0.13",
 ]

--- a/src/psi_agent/ai/openai_completions/client.py
+++ b/src/psi_agent/ai/openai_completions/client.py
@@ -4,8 +4,9 @@ import json
 from collections.abc import AsyncGenerator
 from typing import Any
 
-import aiohttp
 from loguru import logger
+from openai import AsyncOpenAI
+from openai.types.chat import ChatCompletion
 
 from psi_agent.ai.openai_completions.config import OpenAICompletionsConfig
 
@@ -20,22 +21,23 @@ class OpenAICompletionsClient:
             config: The configuration for the client.
         """
         self.config = config
-        self._session: aiohttp.ClientSession | None = None
-        self._timeout: aiohttp.ClientTimeout | None = None
+        self._client: AsyncOpenAI | None = None
 
     async def __aenter__(self) -> OpenAICompletionsClient:
         """Enter async context."""
-        self._timeout = aiohttp.ClientTimeout(total=60, connect=10)
-        self._session = aiohttp.ClientSession(timeout=self._timeout)
-        logger.debug(f"Initialized aiohttp ClientSession for {self.config.base_url}")
+        self._client = AsyncOpenAI(
+            api_key=self.config.api_key,
+            base_url=self.config.base_url,
+        )
+        logger.debug(f"Initialized AsyncOpenAI client for {self.config.base_url}")
         return self
 
     async def __aexit__(self, _exc_type: Any, _exc_val: Any, _exc_tb: Any) -> None:
         """Exit async context."""
-        if self._session is not None:
-            await self._session.close()
-            self._session = None
-            logger.debug("Closed aiohttp ClientSession")
+        if self._client is not None:
+            await self._client.close()
+            self._client = None
+            logger.debug("Closed AsyncOpenAI client")
 
     async def chat_completions(
         self, request_body: dict[str, Any], stream: bool = False
@@ -50,20 +52,14 @@ class OpenAICompletionsClient:
             For non-streaming: The response body as a dict.
             For streaming: An async generator of SSE chunks.
         """
-        if self._session is None:
+        if self._client is None:
             raise RuntimeError("Client not initialized. Use async context manager.")
 
         # Inject model if not present
         if "model" not in request_body:
             request_body["model"] = self.config.model
 
-        url = f"{self.config.base_url}/chat/completions"
-        headers = {
-            "Authorization": f"Bearer {self.config.api_key}",
-            "Content-Type": "application/json",
-        }
-
-        logger.info(f"Sending request to {url}")
+        logger.info(f"Sending request to {self.config.base_url}/chat/completions")
         logger.debug("Request headers: Authorization=Bearer *** (hidden)")
         body_summary = {
             k: v if k != "messages" else f"[{len(v)} messages]" for k, v in request_body.items()
@@ -71,98 +67,91 @@ class OpenAICompletionsClient:
         logger.debug(f"Request body summary: {body_summary}")
 
         if stream:
-            return self._stream_request(url, headers, request_body)
+            return self._stream_request(request_body)
         else:
-            return await self._non_stream_request(url, headers, request_body)
+            return await self._non_stream_request(request_body)
 
-    async def _non_stream_request(
-        self, url: str, headers: dict[str, str], body: dict[str, Any]
-    ) -> dict[str, Any]:
+    async def _non_stream_request(self, body: dict[str, Any]) -> dict[str, Any]:
         """Send non-streaming request.
 
         Args:
-            url: The API URL.
-            headers: The request headers.
             body: The request body.
 
         Returns:
             The response body as a dict.
         """
-        assert self._session is not None
+        assert self._client is not None
 
         try:
-            async with self._session.post(url, headers=headers, json=body) as response:
-                logger.debug(f"Response status: {response.status}")
+            response: ChatCompletion = await self._client.chat.completions.create(**body)
+            logger.info("Received successful non-streaming response")
+            logger.debug(f"Response id: {response.id}")
+            return response.model_dump()
 
-                if response.status == 401:
-                    logger.error("API authentication failed (401)")
-                    return {"error": "Authentication failed", "status_code": 401}
+        except Exception as e:
+            return self._handle_error(e)
 
-                if response.status != 200:
-                    text = await response.text()
-                    logger.error(f"API request failed with status {response.status}")
-                    return {"error": text, "status_code": response.status}
-
-                result = await response.json()
-                logger.info("Received successful non-streaming response")
-                logger.debug(f"Response keys: {list(result.keys())}")
-                return result
-
-        except aiohttp.ClientConnectorError as e:
-            logger.error(f"Failed to connect to upstream API: {e}")
-            return {"error": "Connection failed", "status_code": 500}
-
-    async def _stream_request(
-        self, url: str, headers: dict[str, str], body: dict[str, Any]
-    ) -> AsyncGenerator[str]:
+    async def _stream_request(self, body: dict[str, Any]) -> AsyncGenerator[str]:
         """Send streaming request.
 
         Args:
-            url: The API URL.
-            headers: The request headers.
             body: The request body.
 
         Yields:
             SSE chunks as strings.
         """
-        assert self._session is not None
+        assert self._client is not None
 
         body["stream"] = True
         try:
-            async with self._session.post(url, headers=headers, json=body) as response:
-                logger.debug(f"Stream response status: {response.status}")
+            logger.info("Starting streaming request")
+            stream = await self._client.chat.completions.create(**body)
+            async for chunk in stream:
+                yield f"data: {chunk.model_dump_json()}\n\n"
 
-                if response.status == 401:
-                    logger.error("API authentication failed (401) during streaming")
-                    error_data = {"error": "Authentication failed", "status_code": 401}
-                    yield f"data: {json.dumps(error_data)}\n\n"
-                    return
+            logger.info("Streaming response completed")
+            yield "data: [DONE]\n\n"
 
-                if response.status != 200:
-                    text = await response.text()
-                    logger.error(f"Stream request failed with status {response.status}")
-                    error_data = {"error": text, "status_code": response.status}
-                    yield f"data: {json.dumps(error_data)}\n\n"
-                    return
+        except Exception as e:
+            error_response = self._handle_error(e)
+            yield f"data: {json.dumps(error_response)}\n\n"
 
-                logger.info("Started streaming response")
-                # aiohttp uses response.content for streaming
-                async for line in response.content:
-                    line_text = line.decode().strip()
-                    if line_text.startswith("data: "):
-                        yield line_text + "\n"
-                    elif line_text == "":
-                        yield "\n"
+    def _handle_error(self, e: Exception) -> dict[str, Any]:
+        """Handle API errors and return error response.
 
-                logger.info("Streaming response completed")
-                yield "data: [DONE]\n\n"
+        Args:
+            e: The exception that occurred.
 
-        except aiohttp.ClientConnectorError as e:
-            logger.error(f"Failed to connect to upstream API during streaming: {e}")
-            error_data = {"error": "Connection failed", "status_code": 500}
-            yield f"data: {json.dumps(error_data)}\n\n"
+        Returns:
+            Error dict with status_code.
+        """
+        from openai import (
+            APIConnectionError,
+            APIStatusError,
+            APITimeoutError,
+            AuthenticationError,
+            RateLimitError,
+        )
 
-        except TimeoutError as e:
-            logger.error(f"Stream timeout: {e}")
-            error_data = {"error": "Request timeout", "status_code": 500}
-            yield f"data: {json.dumps(error_data)}\n\n"
+        if isinstance(e, AuthenticationError):
+            logger.error(f"Authentication failed: {e}")
+            return {"error": "Authentication failed", "status_code": 401}
+
+        if isinstance(e, RateLimitError):
+            logger.error(f"Rate limit exceeded: {e}")
+            return {"error": "Rate limit exceeded", "status_code": 429}
+
+        if isinstance(e, APITimeoutError):
+            logger.error(f"Request timeout: {e}")
+            return {"error": "Request timeout", "status_code": 500}
+
+        if isinstance(e, APIConnectionError):
+            logger.error(f"Connection failed: {e}")
+            return {"error": "Connection failed", "status_code": 500}
+
+        if isinstance(e, APIStatusError):
+            logger.error(f"API error {e.status_code}: {e}")
+            return {"error": str(e), "status_code": e.status_code or 500}
+
+        logger.exception(f"Unexpected error: {e}")
+        return {"error": str(e), "status_code": 500}

--- a/tests/ai/openai_completions/test_client.py
+++ b/tests/ai/openai_completions/test_client.py
@@ -1,6 +1,14 @@
 """Tests for OpenAI completions client."""
 
+import httpx
 import pytest
+from openai import (
+    APIConnectionError,
+    APIStatusError,
+    APITimeoutError,
+    AuthenticationError,
+    RateLimitError,
+)
 
 from psi_agent.ai.openai_completions.client import OpenAICompletionsClient
 from psi_agent.ai.openai_completions.config import OpenAICompletionsConfig
@@ -28,10 +36,10 @@ async def test_client_context_manager(config: OpenAICompletionsConfig) -> None:
 
     # Should work with context
     async with client:
-        assert client._session is not None
+        assert client._client is not None
 
     # Should be closed after context
-    assert client._session is None
+    assert client._client is None
 
 
 @pytest.mark.asyncio
@@ -55,3 +63,95 @@ async def test_client_model_already_present(config: OpenAICompletionsConfig) -> 
         body = {"model": "custom-model", "messages": [{"role": "user", "content": "Hello"}]}
         # Model should remain as-is
         assert body["model"] == "custom-model"
+
+
+def _make_mock_request() -> httpx.Request:
+    """Create a mock httpx.Request for error construction."""
+    return httpx.Request("POST", "https://api.example.com/v1/chat/completions")
+
+
+def _make_mock_response(status_code: int = 200) -> httpx.Response:
+    """Create a mock httpx.Response for error construction."""
+    request = _make_mock_request()
+    return httpx.Response(status_code=status_code, request=request)
+
+
+@pytest.mark.asyncio
+async def test_handle_authentication_error(config: OpenAICompletionsConfig) -> None:
+    """Test authentication error handling."""
+    client = OpenAICompletionsClient(config)
+
+    async with client:
+        error = AuthenticationError(
+            message="Invalid API key",
+            response=_make_mock_response(401),
+            body=None,
+        )
+        result = client._handle_error(error)
+        assert result == {"error": "Authentication failed", "status_code": 401}
+
+
+@pytest.mark.asyncio
+async def test_handle_rate_limit_error(config: OpenAICompletionsConfig) -> None:
+    """Test rate limit error handling."""
+    client = OpenAICompletionsClient(config)
+
+    async with client:
+        error = RateLimitError(
+            message="Rate limit exceeded",
+            response=_make_mock_response(429),
+            body=None,
+        )
+        result = client._handle_error(error)
+        assert result == {"error": "Rate limit exceeded", "status_code": 429}
+
+
+@pytest.mark.asyncio
+async def test_handle_connection_error(config: OpenAICompletionsConfig) -> None:
+    """Test connection error handling."""
+    client = OpenAICompletionsClient(config)
+
+    async with client:
+        error = APIConnectionError(
+            message="Connection failed",
+            request=_make_mock_request(),
+        )
+        result = client._handle_error(error)
+        assert result == {"error": "Connection failed", "status_code": 500}
+
+
+@pytest.mark.asyncio
+async def test_handle_timeout_error(config: OpenAICompletionsConfig) -> None:
+    """Test timeout error handling."""
+    client = OpenAICompletionsClient(config)
+
+    async with client:
+        error = APITimeoutError(request=_make_mock_request())
+        result = client._handle_error(error)
+        assert result == {"error": "Request timeout", "status_code": 500}
+
+
+@pytest.mark.asyncio
+async def test_handle_api_status_error(config: OpenAICompletionsConfig) -> None:
+    """Test API status error handling."""
+    client = OpenAICompletionsClient(config)
+
+    async with client:
+        error = APIStatusError(
+            message="Internal server error",
+            response=_make_mock_response(500),
+            body=None,
+        )
+        result = client._handle_error(error)
+        assert result["status_code"] == 500
+
+
+@pytest.mark.asyncio
+async def test_handle_unknown_error(config: OpenAICompletionsConfig) -> None:
+    """Test unknown error handling."""
+    client = OpenAICompletionsClient(config)
+
+    async with client:
+        error = ValueError("Something went wrong")
+        result = client._handle_error(error)
+        assert result == {"error": "Something went wrong", "status_code": 500}

--- a/uv.lock
+++ b/uv.lock
@@ -349,6 +349,25 @@ wheels = [
 ]
 
 [[package]]
+name = "openai"
+version = "2.33.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "distro" },
+    { name = "httpx" },
+    { name = "jiter" },
+    { name = "pydantic" },
+    { name = "sniffio" },
+    { name = "tqdm" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f0/ee/d056c82f63c05f06baac0cffb4a90952d8274f90c49dfe244f20497b9bbd/openai-2.33.0.tar.gz", hash = "sha256:f850c435e2a4685bba3295bd54912dd26315d9c1b7733068186134d6e0599f9a", size = 693254, upload-time = "2026-04-28T14:04:42.428Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7d/32/37734d769bc8b42e4938785313cc05aade6cb0fa72479d3220a0d61a4e78/openai-2.33.0-py3-none-any.whl", hash = "sha256:03ac37d70e8c9e3a8124214e3afa785e2cbc12e627fbd98177a086ef2fd87ad5", size = 1162695, upload-time = "2026-04-28T14:04:40.482Z" },
+]
+
+[[package]]
 name = "packaging"
 version = "26.2"
 source = { registry = "https://pypi.org/simple" }
@@ -425,6 +444,7 @@ dependencies = [
     { name = "anthropic" },
     { name = "anyio" },
     { name = "loguru" },
+    { name = "openai" },
     { name = "prompt-toolkit" },
     { name = "tyro" },
 ]
@@ -443,6 +463,7 @@ requires-dist = [
     { name = "anthropic", specifier = ">=0.57.1" },
     { name = "anyio", specifier = ">=4.13.0" },
     { name = "loguru", specifier = ">=0.7.3" },
+    { name = "openai", specifier = ">=1.30.0" },
     { name = "prompt-toolkit", specifier = ">=3.0.51" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.3" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=1.3.0" },
@@ -577,6 +598,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372, upload-time = "2024-02-25T23:20:04.057Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235, upload-time = "2024-02-25T23:20:01.196Z" },
+]
+
+[[package]]
+name = "tqdm"
+version = "4.67.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/09/a9/6ba95a270c6f1fbcd8dac228323f2777d886cb206987444e4bce66338dd4/tqdm-4.67.3.tar.gz", hash = "sha256:7d825f03f89244ef73f1d4ce193cb1774a8179fd96f31d7e1dcde62092b960bb", size = 169598, upload-time = "2026-02-03T17:35:53.048Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/16/e1/3079a9ff9b8e11b846c6ac5c8b5bfb7ff225eee721825310c91b3b50304f/tqdm-4.67.3-py3-none-any.whl", hash = "sha256:ee1e4c0e59148062281c49d80b25b67771a127c85fc9676d3be5f243206826bf", size = 78374, upload-time = "2026-02-03T17:35:50.982Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Replace hand-rolled `aiohttp` HTTP client with official `openai` SDK's `AsyncOpenAI`
- Reduce code complexity and gain built-in error handling, retry logic, and type safety
- Add comprehensive tests for SDK error handling scenarios
- Update spec with new SDK integration requirements

## Changes
- `pyproject.toml`: Add `openai>=1.30.0` dependency
- `client.py`: Refactor to use `AsyncOpenAI` instead of `aiohttp.ClientSession`
- `test_client.py`: Add tests for authentication, rate limit, connection, and timeout errors
- `spec.md`: Add requirements for SDK integration, error handling, and backward compatibility

## Test plan
- [x] All existing tests pass (14/14)
- [x] New error handling tests pass
- [x] `ruff check` and `ruff format` pass
- [x] `ty check` passes
- [x] Manual test with OpenRouter API (non-streaming)
- [x] Manual test with OpenRouter API (streaming)

🤖 Generated with [Claude Code](https://claude.com/claude-code)