### PR TITLE
Add schedule execution for psi-session

### DIFF
--- a/openspec/changes/archive/2026-04-29-schedule-execution/.openspec.yaml
+++ b/openspec/changes/archive/2026-04-29-schedule-execution/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-28

--- a/openspec/changes/archive/2026-04-29-schedule-execution/design.md
+++ b/openspec/changes/archive/2026-04-29-schedule-execution/design.md
@@ -1,0 +1,69 @@
+## Context
+
+psi-agent workspace 定义了 `schedules/` 目录结构，每个任务有 `TASK.md` 文件包含 YAML frontmatter（含 `cron` 字段）和任务指令。psi-session 目前只处理用户消息，没有定时任务执行能力。
+
+**当前 session 架构：**
+- `runner.py` - 主运行循环，处理消息
+- `server.py` - HTTP 服务器，接收 channel 请求
+- `tool_loader.py` - 加载 tools
+- `history.py` - 对话历史管理
+
+## Goals / Non-Goals
+
+**Goals:**
+- 加载 workspace 的 `schedules/` 目录中的定时任务
+- 解析标准 5 字段 cron 表达式
+- 按时间表触发任务，将 TASK.md 内容作为消息发送给 LLM
+- 支持多个定时任务并发运行
+
+**Non-Goals:**
+- 不支持分布式调度（单进程内运行）
+- 不支持任务持久化（重启后重新计算下次执行时间）
+- 不支持任务动态添加/删除（启动时加载）
+
+## Decisions
+
+### 1. 使用 `croniter` 库解析 cron 表达式
+
+**Rationale:** `croniter` 是 Python 中最成熟的 cron 解析库，支持标准 5 字段格式，计算下次执行时间准确。
+
+**Alternatives considered:**
+- `apscheduler`: 功能更全但更重，适合更复杂的调度场景
+- 手动解析: 容易出错，不值得重复造轮子
+
+### 2. 使用 `asyncio` 实现调度循环
+
+**Rationale:** session 已经是 async 架构，使用 `asyncio.create_task` 可以轻松集成定时任务，不需要额外的线程或进程。
+
+**实现方式：**
+```python
+async def schedule_loop(schedule: Schedule, runner: Runner):
+    while True:
+        next_time = schedule.get_next_run()
+        delay = next_time - datetime.now()
+        await asyncio.sleep(delay.total_seconds())
+        await runner.run(schedule.task_content)
+```
+
+### 3. 任务触发时发送 TASK.md 内容作为用户消息
+
+**Rationale:** 保持简单，TASK.md 的内容就是任务指令，LLM 会根据指令执行相应操作。
+
+### 4. 模块结构
+
+```
+src/psi_agent/session/
+├── schedule.py       # Schedule 加载器和执行器
+└── runner.py         # 集成 schedule 执行
+```
+
+## Risks / Trade-offs
+
+**Risk: 任务执行时间可能超过调度间隔**
+→ Mitigation: 记录警告日志，跳过本次执行（不重叠执行）
+
+**Risk: 时区问题**
+→ Mitigation: 使用本地时间，与 cron 标准一致。未来可扩展支持时区配置。
+
+**Trade-off: 不支持任务持久化**
+→ 接受。重启后重新计算执行时间。如需持久化，可在 workspace 中自行实现。

--- a/openspec/changes/archive/2026-04-29-schedule-execution/proposal.md
+++ b/openspec/changes/archive/2026-04-29-schedule-execution/proposal.md
@@ -1,0 +1,26 @@
+## Why
+
+psi-agent 的 workspace 设计中定义了 `schedules/` 目录用于定时任务，但 psi-session 尚未实现定时任务的加载和执行功能。实现此功能可以让 agent 按照预定的时间表自动执行任务（如每日摘要、定期清理等）。
+
+## What Changes
+
+- 在 psi-session 中添加 schedule 加载器，扫描 workspace 的 `schedules/` 目录
+- 实现 cron 表达式解析，支持标准 5 字段 cron 格式
+- 添加 schedule 执行器，按 cron 时间表触发任务
+- 任务触发时将 TASK.md 内容作为用户消息发送给 LLM
+
+## Capabilities
+
+### New Capabilities
+
+- `schedule-execution`: 定时任务加载和执行功能，支持 cron 表达式定义的时间表
+
+### Modified Capabilities
+
+- `session-core`: session 启动时需要加载并启动 schedule 执行器
+
+## Impact
+
+- **新代码**: `src/psi_agent/session/schedule.py` - schedule 加载器和执行器
+- **修改代码**: `src/psi_agent/session/runner.py` - 集成 schedule 执行器
+- **依赖**: 使用 Python 标准库或轻量级 cron 库（如 `croniter`）

--- a/openspec/changes/archive/2026-04-29-schedule-execution/specs/schedule-execution/spec.md
+++ b/openspec/changes/archive/2026-04-29-schedule-execution/specs/schedule-execution/spec.md
@@ -1,0 +1,72 @@
+## ADDED Requirements
+
+### Requirement: Schedule loader scans workspace schedules directory
+
+The session SHALL load schedule tasks from the workspace `schedules/` directory on startup.
+
+#### Scenario: Load schedules on startup
+- **WHEN** session starts with a workspace path
+- **THEN** the session SHALL scan `<workspace>/schedules/` for subdirectories
+- **AND** each subdirectory containing `TASK.md` SHALL be loaded as a schedule
+
+#### Scenario: Parse TASK.md with YAML frontmatter
+- **WHEN** a `TASK.md` file is found
+- **THEN** the session SHALL parse YAML frontmatter to extract `name`, `description`, and `cron` fields
+- **AND** the task content (after frontmatter) SHALL be stored as the task instruction
+
+#### Scenario: Handle missing cron field
+- **WHEN** a `TASK.md` file has no `cron` field in frontmatter
+- **THEN** the session SHALL log a warning and skip that schedule
+
+### Requirement: Schedule executor runs tasks at cron intervals
+
+The session SHALL execute schedule tasks according to their cron expressions.
+
+#### Scenario: Execute task at scheduled time
+- **WHEN** the current time matches the cron expression
+- **THEN** the session SHALL execute the task
+
+#### Scenario: Send task content as user message
+- **WHEN** a scheduled task is executed
+- **THEN** the TASK.md content SHALL be sent to the LLM as a user message
+
+#### Scenario: Calculate next run time
+- **WHEN** a task is scheduled
+- **THEN** the session SHALL calculate the next run time using the cron expression
+- **AND** the session SHALL wait until that time before executing
+
+### Requirement: Schedule uses standard 5-field cron format
+
+The session SHALL support standard 5-field cron expressions.
+
+#### Scenario: Parse valid cron expression
+- **WHEN** a cron expression like `"0 9 * * *"` (9am daily) is provided
+- **THEN** the session SHALL correctly parse and interpret it
+
+#### Scenario: Support all cron fields
+- **WHEN** parsing cron expressions
+- **THEN** the session SHALL support minute, hour, day of month, month, day of week fields
+
+### Requirement: Multiple schedules run concurrently
+
+The session SHALL support running multiple scheduled tasks concurrently.
+
+#### Scenario: Multiple schedules
+- **WHEN** multiple schedules are defined in the workspace
+- **THEN** each schedule SHALL run independently in its own async task
+
+#### Scenario: Independent execution
+- **WHEN** one schedule is executing
+- **THEN** other schedules SHALL NOT be blocked
+
+### Requirement: Schedule execution uses async architecture
+
+All schedule operations SHALL use async/await for I/O operations.
+
+#### Scenario: Async file loading
+- **WHEN** loading TASK.md files
+- **THEN** the session SHALL use `anyio.open_file()` for async file reading
+
+#### Scenario: Async sleep for scheduling
+- **WHEN** waiting for next scheduled time
+- **THEN** the session SHALL use `asyncio.sleep()` to avoid blocking

--- a/openspec/changes/archive/2026-04-29-schedule-execution/specs/session-core/spec.md
+++ b/openspec/changes/archive/2026-04-29-schedule-execution/specs/session-core/spec.md
@@ -1,0 +1,18 @@
+## ADDED Requirements
+
+### Requirement: Session starts schedule executor on startup
+
+The session SHALL start the schedule executor when session starts.
+
+#### Scenario: Schedule executor initialized
+- **WHEN** session starts with a workspace path
+- **THEN** the schedule executor SHALL be initialized with the workspace schedules
+
+#### Scenario: Schedule executor runs in background
+- **WHEN** session is running
+- **THEN** all scheduled tasks SHALL run in background async tasks
+- **AND** the session SHALL continue to handle HTTP requests
+
+#### Scenario: No schedules directory
+- **WHEN** workspace does not have a `schedules/` directory
+- **THEN** session SHALL start normally without schedule executor

--- a/openspec/changes/archive/2026-04-29-schedule-execution/tasks.md
+++ b/openspec/changes/archive/2026-04-29-schedule-execution/tasks.md
@@ -1,0 +1,18 @@
+## 1. Setup
+
+- [x] 1.1 Add `croniter` dependency to pyproject.toml
+- [x] 1.2 Create `src/psi_agent/session/schedule.py` module
+
+## 2. Core Implementation
+
+- [x] 2.1 Implement `Schedule` dataclass with cron parsing
+- [x] 2.2 Implement `ScheduleLoader` to scan workspace schedules directory
+- [x] 2.3 Implement `ScheduleExecutor` to run tasks at scheduled times
+- [x] 2.4 Integrate schedule executor with session runner
+
+## 3. Testing
+
+- [x] 3.1 Write unit tests for Schedule dataclass
+- [x] 3.2 Write unit tests for ScheduleLoader
+- [x] 3.3 Write unit tests for cron expression parsing
+- [x] 3.4 Run all quality checks (format, lint, typing, test)

--- a/openspec/specs/schedule-execution/spec.md
+++ b/openspec/specs/schedule-execution/spec.md
@@ -1,0 +1,72 @@
+## ADDED Requirements
+
+### Requirement: Schedule loader scans workspace schedules directory
+
+The session SHALL load schedule tasks from the workspace `schedules/` directory on startup.
+
+#### Scenario: Load schedules on startup
+- **WHEN** session starts with a workspace path
+- **THEN** the session SHALL scan `<workspace>/schedules/` for subdirectories
+- **AND** each subdirectory containing `TASK.md` SHALL be loaded as a schedule
+
+#### Scenario: Parse TASK.md with YAML frontmatter
+- **WHEN** a `TASK.md` file is found
+- **THEN** the session SHALL parse YAML frontmatter to extract `name`, `description`, and `cron` fields
+- **AND** the task content (after frontmatter) SHALL be stored as the task instruction
+
+#### Scenario: Handle missing cron field
+- **WHEN** a `TASK.md` file has no `cron` field in frontmatter
+- **THEN** the session SHALL log a warning and skip that schedule
+
+### Requirement: Schedule executor runs tasks at cron intervals
+
+The session SHALL execute schedule tasks according to their cron expressions.
+
+#### Scenario: Execute task at scheduled time
+- **WHEN** the current time matches the cron expression
+- **THEN** the session SHALL execute the task
+
+#### Scenario: Send task content as user message
+- **WHEN** a scheduled task is executed
+- **THEN** the TASK.md content SHALL be sent to the LLM as a user message
+
+#### Scenario: Calculate next run time
+- **WHEN** a task is scheduled
+- **THEN** the session SHALL calculate the next run time using the cron expression
+- **AND** the session SHALL wait until that time before executing
+
+### Requirement: Schedule uses standard 5-field cron format
+
+The session SHALL support standard 5-field cron expressions.
+
+#### Scenario: Parse valid cron expression
+- **WHEN** a cron expression like `"0 9 * * *"` (9am daily) is provided
+- **THEN** the session SHALL correctly parse and interpret it
+
+#### Scenario: Support all cron fields
+- **WHEN** parsing cron expressions
+- **THEN** the session SHALL support minute, hour, day of month, month, day of week fields
+
+### Requirement: Multiple schedules run concurrently
+
+The session SHALL support running multiple scheduled tasks concurrently.
+
+#### Scenario: Multiple schedules
+- **WHEN** multiple schedules are defined in the workspace
+- **THEN** each schedule SHALL run independently in its own async task
+
+#### Scenario: Independent execution
+- **WHEN** one schedule is executing
+- **THEN** other schedules SHALL NOT be blocked
+
+### Requirement: Schedule execution uses async architecture
+
+All schedule operations SHALL use async/await for I/O operations.
+
+#### Scenario: Async file loading
+- **WHEN** loading TASK.md files
+- **THEN** the session SHALL use `anyio.open_file()` for async file reading
+
+#### Scenario: Async sleep for scheduling
+- **WHEN** waiting for next scheduled time
+- **THEN** the session SHALL use `asyncio.sleep()` to avoid blocking

--- a/openspec/specs/session-core/spec.md
+++ b/openspec/specs/session-core/spec.md
@@ -73,3 +73,20 @@ The session SHALL process tool_call responses from psi-ai, execute corresponding
 #### Scenario: Multiple tool calls executed in parallel
 - **WHEN** psi-ai returns multiple tool_calls
 - **THEN** session executes all tools concurrently
+
+### Requirement: Session starts schedule executor on startup
+
+The session SHALL start the schedule executor when session starts.
+
+#### Scenario: Schedule executor initialized
+- **WHEN** session starts with a workspace path
+- **THEN** the schedule executor SHALL be initialized with the workspace schedules
+
+#### Scenario: Schedule executor runs in background
+- **WHEN** session is running
+- **THEN** all scheduled tasks SHALL run in background async tasks
+- **AND** the session SHALL continue to handle HTTP requests
+
+#### Scenario: No schedules directory
+- **WHEN** workspace does not have a `schedules/` directory
+- **THEN** session SHALL start normally without schedule executor

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ dependencies = [
     "aiohttp>=3.13.5",
     "anthropic>=0.57.1",
     "anyio>=4.13.0",
+    "croniter>=3.0.0",
     "loguru>=0.7.3",
     "openai>=1.30.0",
     "prompt-toolkit>=3.0.51",

--- a/src/psi_agent/session/schedule.py
+++ b/src/psi_agent/session/schedule.py
@@ -1,0 +1,238 @@
+"""Schedule loading and execution for psi-session."""
+
+from __future__ import annotations
+
+import asyncio
+import re
+from dataclasses import dataclass, field
+from datetime import datetime
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import anyio
+import croniter
+from loguru import logger
+
+if TYPE_CHECKING:
+    from psi_agent.session.runner import SessionRunner
+
+
+@dataclass
+class Schedule:
+    """A scheduled task with cron expression.
+
+    Attributes:
+        name: Task name from frontmatter.
+        description: Task description from frontmatter.
+        cron: Cron expression for scheduling.
+        content: Task instruction content (after frontmatter).
+        task_dir: Path to the task directory.
+    """
+
+    name: str
+    cron: str
+    content: str
+    task_dir: Path
+    description: str = ""
+    _croniter: croniter.croniter | None = field(default=None, repr=False, compare=False)
+
+    def get_next_run(self) -> datetime:
+        """Get the next run time based on cron expression.
+
+        Returns:
+            Next scheduled datetime.
+        """
+        if self._croniter is None:
+            self._croniter = croniter.croniter(self.cron, datetime.now())
+        return self._croniter.get_next(datetime)  # type: ignore[no-any-return]
+
+    def get_seconds_until_next_run(self) -> float:
+        """Get seconds until next scheduled run.
+
+        Returns:
+            Seconds until next run.
+        """
+        next_run = self.get_next_run()
+        now = datetime.now()
+        delta = next_run - now
+        return max(0.0, delta.total_seconds())
+
+
+def parse_frontmatter(content: str) -> tuple[dict[str, str], str]:
+    """Parse YAML frontmatter from content.
+
+    Args:
+        content: File content with optional frontmatter.
+
+    Returns:
+        Tuple of (frontmatter dict, remaining content).
+    """
+    pattern = r"^---\s*\n(.*?)\n---\s*\n(.*)$"
+    match = re.match(pattern, content, re.DOTALL)
+
+    if not match:
+        return {}, content
+
+    frontmatter_str = match.group(1)
+    remaining = match.group(2)
+
+    # Parse simple YAML key: value pairs
+    frontmatter: dict[str, str] = {}
+    for line in frontmatter_str.split("\n"):
+        if ":" in line:
+            key, value = line.split(":", 1)
+            value = value.strip()
+            # Strip quotes if present
+            is_double_quoted = value.startswith('"') and value.endswith('"')
+            is_single_quoted = value.startswith("'") and value.endswith("'")
+            if is_double_quoted or is_single_quoted:
+                value = value[1:-1]
+            frontmatter[key.strip()] = value
+
+    return frontmatter, remaining
+
+
+async def load_schedule(task_dir: Path) -> Schedule | None:
+    """Load a schedule from a task directory.
+
+    Args:
+        task_dir: Path to the task directory containing TASK.md.
+
+    Returns:
+        Schedule object, or None if invalid.
+    """
+    task_file = task_dir / "TASK.md"
+    if not task_file.exists():
+        logger.debug(f"No TASK.md in {task_dir}")
+        return None
+
+    try:
+        async with await anyio.open_file(task_file) as f:
+            content = await f.read()
+
+        frontmatter, task_content = parse_frontmatter(content)
+
+        # Check required fields
+        if "cron" not in frontmatter:
+            logger.warning(f"Missing 'cron' field in {task_file}")
+            return None
+
+        name = frontmatter.get("name", task_dir.name)
+        description = frontmatter.get("description", "")
+
+        return Schedule(
+            name=name,
+            description=description,
+            cron=frontmatter["cron"],
+            content=task_content.strip(),
+            task_dir=task_dir,
+        )
+
+    except Exception as e:
+        logger.error(f"Failed to load schedule from {task_dir}: {e}")
+        return None
+
+
+async def load_schedules(workspace: Path) -> list[Schedule]:
+    """Load all schedules from workspace.
+
+    Args:
+        workspace: Path to workspace directory.
+
+    Returns:
+        List of valid Schedule objects.
+    """
+    schedules_dir = workspace / "schedules"
+    if not schedules_dir.exists():
+        logger.debug("No schedules directory in workspace")
+        return []
+
+    schedules = []
+    for entry in schedules_dir.iterdir():
+        if entry.is_dir():
+            schedule = await load_schedule(entry)
+            if schedule is not None:
+                schedules.append(schedule)
+                logger.info(f"Loaded schedule: {schedule.name} (cron: {schedule.cron})")
+
+    return schedules
+
+
+class ScheduleExecutor:
+    """Executor for running scheduled tasks."""
+
+    def __init__(self, schedules: list[Schedule], runner: SessionRunner) -> None:
+        """Initialize the executor.
+
+        Args:
+            schedules: List of schedules to execute.
+            runner: Session runner to use for task execution.
+        """
+        self.schedules = schedules
+        self.runner = runner
+        self._tasks: list[asyncio.Task[None]] = []
+        self._running = False
+
+    async def start(self) -> None:
+        """Start all schedule loops."""
+        if not self.schedules:
+            logger.info("No schedules to run")
+            return
+
+        self._running = True
+        for schedule in self.schedules:
+            task = asyncio.create_task(self._schedule_loop(schedule))
+            self._tasks.append(task)
+            logger.info(f"Started schedule loop for: {schedule.name}")
+
+    async def stop(self) -> None:
+        """Stop all schedule loops."""
+        self._running = False
+        for task in self._tasks:
+            task.cancel()
+        self._tasks.clear()
+        logger.info("Stopped all schedule loops")
+
+    async def _schedule_loop(self, schedule: Schedule) -> None:
+        """Run a single schedule loop.
+
+        Args:
+            schedule: The schedule to run.
+        """
+        while self._running:
+            try:
+                # Calculate wait time
+                delay = schedule.get_seconds_until_next_run()
+                next_run = schedule.get_next_run()
+                logger.debug(f"Schedule '{schedule.name}' next run at {next_run}")
+
+                # Wait until scheduled time
+                await asyncio.sleep(delay)
+
+                if not self._running:
+                    break
+
+                # Execute the task
+                logger.info(f"Executing scheduled task: {schedule.name}")
+                await self._execute_task(schedule)
+
+            except asyncio.CancelledError:
+                logger.debug(f"Schedule loop cancelled for: {schedule.name}")
+                break
+            except Exception as e:
+                logger.error(f"Error in schedule loop for {schedule.name}: {e}")
+                # Continue running despite errors
+                await asyncio.sleep(60)  # Wait a minute before retry
+
+    async def _execute_task(self, schedule: Schedule) -> None:
+        """Execute a scheduled task.
+
+        Args:
+            schedule: The schedule to execute.
+        """
+        try:
+            user_message = {"role": "user", "content": schedule.content}
+            await self.runner.process_request(user_message)
+            logger.info(f"Completed scheduled task: {schedule.name}")
+        except Exception as e:
+            logger.error(f"Failed to execute scheduled task {schedule.name}: {e}")

--- a/src/psi_agent/session/server.py
+++ b/src/psi_agent/session/server.py
@@ -8,6 +8,7 @@ from loguru import logger
 
 from psi_agent.session.config import SessionConfig
 from psi_agent.session.runner import SessionRunner
+from psi_agent.session.schedule import ScheduleExecutor, load_schedules
 
 
 class SessionServer:
@@ -23,6 +24,7 @@ class SessionServer:
         self.app = web.Application()
         self.runner: SessionRunner | None = None
         self._runner: web.AppRunner | None = None
+        self._schedule_executor: ScheduleExecutor | None = None
         self._setup_routes()
 
     def _setup_routes(self) -> None:
@@ -195,6 +197,12 @@ class SessionServer:
         self.runner = SessionRunner(self.config)
         await self.runner.__aenter__()
 
+        # Load and start schedules
+        schedules = await load_schedules(self.config.workspace_path())
+        if schedules:
+            self._schedule_executor = ScheduleExecutor(schedules, self.runner)
+            await self._schedule_executor.start()
+
         # Start server
         self._runner = web.AppRunner(self.app)
         await self._runner.setup()
@@ -209,6 +217,11 @@ class SessionServer:
 
     async def stop(self) -> None:
         """Stop the server."""
+        # Stop schedule executor
+        if self._schedule_executor is not None:
+            await self._schedule_executor.stop()
+            self._schedule_executor = None
+
         if self.runner is not None:
             await self.runner.__aexit__(None, None, None)
         if self._runner is not None:

--- a/tests/session/schedule/__init__.py
+++ b/tests/session/schedule/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for session schedule module."""

--- a/tests/session/schedule/test_cron.py
+++ b/tests/session/schedule/test_cron.py
@@ -1,0 +1,120 @@
+"""Tests for cron expression parsing."""
+
+from datetime import datetime
+
+from psi_agent.session.schedule import Schedule
+
+
+class TestCronParsing:
+    """Tests for cron expression parsing."""
+
+    def test_every_minute(self) -> None:
+        """Test every minute cron expression."""
+        schedule = Schedule(
+            name="test",
+            cron="* * * * *",
+            content="test",
+            task_dir=Path("/tmp"),
+        )
+
+        next_run = schedule.get_next_run()
+        assert next_run > datetime.now()
+
+    def test_specific_hour(self) -> None:
+        """Test specific hour cron expression."""
+        schedule = Schedule(
+            name="test",
+            cron="0 9 * * *",  # 9am daily
+            content="test",
+            task_dir=Path("/tmp"),
+        )
+
+        next_run = schedule.get_next_run()
+        assert next_run.hour == 9
+        assert next_run.minute == 0
+
+    def test_specific_day_of_week(self) -> None:
+        """Test specific day of week cron expression."""
+        schedule = Schedule(
+            name="test",
+            cron="0 9 * * 1",  # 9am every Monday
+            content="test",
+            task_dir=Path("/tmp"),
+        )
+
+        next_run = schedule.get_next_run()
+        # Monday is 0 in Python, but cron uses 0-7 where 0 and 7 are Sunday
+        # croniter follows cron convention
+        assert next_run.hour == 9
+        assert next_run.minute == 0
+
+    def test_specific_day_of_month(self) -> None:
+        """Test specific day of month cron expression."""
+        schedule = Schedule(
+            name="test",
+            cron="0 9 15 * *",  # 9am on 15th of every month
+            content="test",
+            task_dir=Path("/tmp"),
+        )
+
+        next_run = schedule.get_next_run()
+        assert next_run.hour == 9
+        assert next_run.minute == 0
+        assert next_run.day == 15
+
+    def test_specific_month(self) -> None:
+        """Test specific month cron expression."""
+        schedule = Schedule(
+            name="test",
+            cron="0 9 1 1 *",  # 9am on January 1st
+            content="test",
+            task_dir=Path("/tmp"),
+        )
+
+        next_run = schedule.get_next_run()
+        assert next_run.hour == 9
+        assert next_run.minute == 0
+        assert next_run.day == 1
+        assert next_run.month == 1
+
+    def test_multiple_values(self) -> None:
+        """Test multiple values in cron expression."""
+        schedule = Schedule(
+            name="test",
+            cron="0 9,18 * * *",  # 9am and 6pm daily
+            content="test",
+            task_dir=Path("/tmp"),
+        )
+
+        next_run = schedule.get_next_run()
+        assert next_run.hour in [9, 18]
+        assert next_run.minute == 0
+
+    def test_range(self) -> None:
+        """Test range in cron expression."""
+        schedule = Schedule(
+            name="test",
+            cron="0 9-17 * * *",  # Every hour from 9am to 5pm
+            content="test",
+            task_dir=Path("/tmp"),
+        )
+
+        next_run = schedule.get_next_run()
+        assert 9 <= next_run.hour <= 17
+        assert next_run.minute == 0
+
+    def test_step(self) -> None:
+        """Test step in cron expression."""
+        schedule = Schedule(
+            name="test",
+            cron="*/15 * * * *",  # Every 15 minutes
+            content="test",
+            task_dir=Path("/tmp"),
+        )
+
+        next_run = schedule.get_next_run()
+        assert next_run.minute % 15 == 0
+
+
+# Import Path for the tests
+from pathlib import Path  # noqa: E402

--- a/tests/session/schedule/test_loader.py
+++ b/tests/session/schedule/test_loader.py
@@ -1,0 +1,171 @@
+"""Tests for ScheduleLoader functions."""
+
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from psi_agent.session.schedule import load_schedule, load_schedules, parse_frontmatter
+
+
+class TestParseFrontmatter:
+    """Tests for parse_frontmatter function."""
+
+    def test_no_frontmatter(self) -> None:
+        """Test content without frontmatter."""
+        content = "Just some content\nwithout frontmatter"
+        frontmatter, remaining = parse_frontmatter(content)
+
+        assert frontmatter == {}
+        assert remaining == content
+
+    def test_with_frontmatter(self) -> None:
+        """Test content with frontmatter."""
+        content = """---
+name: test-task
+description: A test task
+cron: "0 9 * * *"
+---
+
+Task content here."""
+        frontmatter, remaining = parse_frontmatter(content)
+
+        assert frontmatter["name"] == "test-task"
+        assert frontmatter["description"] == "A test task"
+        assert frontmatter["cron"] == "0 9 * * *"
+        assert remaining.strip() == "Task content here."
+
+    def test_frontmatter_with_multiline_content(self) -> None:
+        """Test frontmatter with multiline content."""
+        content = """---
+name: test-task
+cron: "0 9 * * *"
+---
+
+Line 1
+Line 2
+Line 3"""
+        frontmatter, remaining = parse_frontmatter(content)
+
+        assert frontmatter["name"] == "test-task"
+        assert "Line 1" in remaining
+        assert "Line 2" in remaining
+        assert "Line 3" in remaining
+
+
+class TestLoadSchedule:
+    """Tests for load_schedule function."""
+
+    @pytest.mark.asyncio
+    async def test_load_valid_schedule(self) -> None:
+        """Test loading a valid schedule."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            task_dir = Path(tmpdir) / "test-task"
+            task_dir.mkdir()
+
+            task_file = task_dir / "TASK.md"
+            task_file.write_text("""---
+name: test-task
+description: A test task
+cron: "0 9 * * *"
+---
+
+Do something daily.""")
+
+            schedule = await load_schedule(task_dir)
+
+            assert schedule is not None
+            assert schedule.name == "test-task"
+            assert schedule.description == "A test task"
+            assert schedule.cron == "0 9 * * *"
+            assert schedule.content == "Do something daily."
+
+    @pytest.mark.asyncio
+    async def test_load_missing_task_md(self) -> None:
+        """Test loading from directory without TASK.md."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            task_dir = Path(tmpdir) / "test-task"
+            task_dir.mkdir()
+
+            schedule = await load_schedule(task_dir)
+
+            assert schedule is None
+
+    @pytest.mark.asyncio
+    async def test_load_missing_cron(self) -> None:
+        """Test loading schedule without cron field."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            task_dir = Path(tmpdir) / "test-task"
+            task_dir.mkdir()
+
+            task_file = task_dir / "TASK.md"
+            task_file.write_text("""---
+name: test-task
+---
+
+No cron here.""")
+
+            schedule = await load_schedule(task_dir)
+
+            assert schedule is None
+
+
+class TestLoadSchedules:
+    """Tests for load_schedules function."""
+
+    @pytest.mark.asyncio
+    async def test_load_multiple_schedules(self) -> None:
+        """Test loading multiple schedules from workspace."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            workspace = Path(tmpdir)
+            schedules_dir = workspace / "schedules"
+            schedules_dir.mkdir()
+
+            # Create first task
+            task1_dir = schedules_dir / "task1"
+            task1_dir.mkdir()
+            (task1_dir / "TASK.md").write_text("""---
+name: task1
+cron: "0 9 * * *"
+---
+
+Task 1 content.""")
+
+            # Create second task
+            task2_dir = schedules_dir / "task2"
+            task2_dir.mkdir()
+            (task2_dir / "TASK.md").write_text("""---
+name: task2
+cron: "0 18 * * *"
+---
+
+Task 2 content.""")
+
+            schedules = await load_schedules(workspace)
+
+            assert len(schedules) == 2
+            names = [s.name for s in schedules]
+            assert "task1" in names
+            assert "task2" in names
+
+    @pytest.mark.asyncio
+    async def test_load_no_schedules_dir(self) -> None:
+        """Test loading from workspace without schedules directory."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            workspace = Path(tmpdir)
+
+            schedules = await load_schedules(workspace)
+
+            assert schedules == []
+
+    @pytest.mark.asyncio
+    async def test_load_empty_schedules_dir(self) -> None:
+        """Test loading from empty schedules directory."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            workspace = Path(tmpdir)
+            schedules_dir = workspace / "schedules"
+            schedules_dir.mkdir()
+
+            schedules = await load_schedules(workspace)
+
+            assert schedules == []

--- a/tests/session/schedule/test_schedule.py
+++ b/tests/session/schedule/test_schedule.py
@@ -1,0 +1,92 @@
+"""Tests for Schedule dataclass."""
+
+from datetime import datetime
+from pathlib import Path
+
+from psi_agent.session.schedule import Schedule
+
+
+class TestSchedule:
+    """Tests for Schedule class."""
+
+    def test_schedule_creation(self) -> None:
+        """Test Schedule can be created with required fields."""
+        schedule = Schedule(
+            name="test-task",
+            cron="0 9 * * *",
+            content="Test task content",
+            task_dir=Path("/tmp/test"),
+        )
+
+        assert schedule.name == "test-task"
+        assert schedule.cron == "0 9 * * *"
+        assert schedule.content == "Test task content"
+        assert schedule.description == ""
+
+    def test_schedule_with_description(self) -> None:
+        """Test Schedule with optional description."""
+        schedule = Schedule(
+            name="test-task",
+            description="A test task",
+            cron="0 9 * * *",
+            content="Test task content",
+            task_dir=Path("/tmp/test"),
+        )
+
+        assert schedule.description == "A test task"
+
+    def test_get_next_run(self) -> None:
+        """Test get_next_run returns a future datetime."""
+        schedule = Schedule(
+            name="test-task",
+            cron="0 9 * * *",  # 9am daily
+            content="Test task content",
+            task_dir=Path("/tmp/test"),
+        )
+
+        next_run = schedule.get_next_run()
+
+        assert isinstance(next_run, datetime)
+        assert next_run > datetime.now()
+
+    def test_get_seconds_until_next_run(self) -> None:
+        """Test get_seconds_until_next_run returns positive value."""
+        schedule = Schedule(
+            name="test-task",
+            cron="0 9 * * *",
+            content="Test task content",
+            task_dir=Path("/tmp/test"),
+        )
+
+        seconds = schedule.get_seconds_until_next_run()
+
+        assert seconds >= 0
+        assert isinstance(seconds, float)
+
+    def test_cron_every_minute(self) -> None:
+        """Test cron expression for every minute."""
+        schedule = Schedule(
+            name="test-task",
+            cron="* * * * *",
+            content="Test task content",
+            task_dir=Path("/tmp/test"),
+        )
+
+        next_run = schedule.get_next_run()
+
+        # Should be within the next minute
+        assert isinstance(next_run, datetime)
+
+    def test_cron_specific_time(self) -> None:
+        """Test cron expression for specific time."""
+        schedule = Schedule(
+            name="test-task",
+            cron="30 14 * * *",  # 2:30pm daily
+            content="Test task content",
+            task_dir=Path("/tmp/test"),
+        )
+
+        next_run = schedule.get_next_run()
+
+        assert next_run.minute == 30
+        assert next_run.hour == 14

--- a/uv.lock
+++ b/uv.lock
@@ -142,6 +142,18 @@ wheels = [
 ]
 
 [[package]]
+name = "croniter"
+version = "6.2.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "python-dateutil" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/df/de/5832661ed55107b8a09af3f0a2e71e0957226a59eb1dcf0a445cce6daf20/croniter-6.2.2.tar.gz", hash = "sha256:ba60832a5ec8e12e51b8691c3309a113d1cf6526bdf1a48150ce8ec7a532d0ab", size = 113762, upload-time = "2026-03-15T08:43:48.112Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d0/39/783980e78cb92c2d7bdb1fc7dbc86e94ccc6d58224d76a7f1f51b6c51e30/croniter-6.2.2-py3-none-any.whl", hash = "sha256:a5d17b1060974d36251ea4faf388233eca8acf0d09cbd92d35f4c4ac8f279960", size = 45422, upload-time = "2026-03-15T08:43:46.626Z" },
+]
+
+[[package]]
 name = "distro"
 version = "1.9.0"
 source = { registry = "https://pypi.org/simple" }
@@ -443,6 +455,7 @@ dependencies = [
     { name = "aiohttp" },
     { name = "anthropic" },
     { name = "anyio" },
+    { name = "croniter" },
     { name = "loguru" },
     { name = "openai" },
     { name = "prompt-toolkit" },
@@ -463,6 +476,7 @@ requires-dist = [
     { name = "aiohttp", specifier = ">=3.13.5" },
     { name = "anthropic", specifier = ">=0.57.1" },
     { name = "anyio", specifier = ">=4.13.0" },
+    { name = "croniter", specifier = ">=3.0.0" },
     { name = "loguru", specifier = ">=0.7.3" },
     { name = "openai", specifier = ">=1.30.0" },
     { name = "prompt-toolkit", specifier = ">=3.0.51" },
@@ -569,6 +583,18 @@ wheels = [
 ]
 
 [[package]]
+name = "python-dateutil"
+version = "2.9.0.post0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
+]
+
+[[package]]
 name = "python-telegram-bot"
 version = "22.7"
 source = { registry = "https://pypi.org/simple" }
@@ -604,6 +630,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ea/f9/0ae446942c846b8266059ad8a30702a35afae55f5cdc54c5adf8d7afdc27/ruff-0.15.12-py3-none-win32.whl", hash = "sha256:d0185894e038d7043ba8fd6aee7499ece6462dc0ea9f1e260c7451807c714c20", size = 10657277, upload-time = "2026-04-24T18:17:18.591Z" },
     { url = "https://files.pythonhosted.org/packages/33/f1/9614e03e1cdcbf9437570b5400ced8a720b5db22b28d8e0f1bda429f660d/ruff-0.15.12-py3-none-win_amd64.whl", hash = "sha256:c87a162d61ab3adca47c03f7f717c68672edec7d1b5499e652331780fe74950d", size = 11837758, upload-time = "2026-04-24T18:17:00.113Z" },
     { url = "https://files.pythonhosted.org/packages/c0/98/6beb4b351e472e5f4c4613f7c35a5290b8be2497e183825310c4c3a3984b/ruff-0.15.12-py3-none-win_arm64.whl", hash = "sha256:a538f7a82d061cee7be55542aca1d86d1393d55d81d4fcc314370f4340930d4f", size = 11120821, upload-time = "2026-04-24T18:16:57.979Z" },
+]
+
+[[package]]
+name = "six"
+version = "1.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Implement scheduled task loading from workspace `schedules/` directory
- Parse TASK.md with YAML frontmatter containing `name`, `description`, and `cron` fields
- Execute tasks at scheduled times using `croniter` for cron expression parsing
- Support standard 5-field cron format (minute, hour, day of month, month, day of week)
- Multiple schedules run concurrently as independent async tasks

## Features

- Schedule loader scans workspace on session startup
- Schedule executor runs tasks at cron intervals
- Task content sent to LLM as user message when triggered
- Full async architecture using `anyio` and `asyncio`
- Graceful handling of missing cron fields and invalid schedules

## Test plan

- [x] Unit tests for Schedule dataclass
- [x] Unit tests for ScheduleLoader
- [x] Unit tests for cron expression parsing
- [x] All quality checks pass (format, lint, typing, test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)