### PR TITLE
Code quality improvements: future annotations and ty config

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -346,6 +346,13 @@ from psi_agent.ai.openai_completions.config import OpenAICompletionsConfig
 
 ### 类型注解规范
 
+**所有 Python 文件必须以 `from __future__ import annotations` 开头**（在模块文档字符串之后）。
+
+这确保：
+- 现代 PEP 604 联合语法 (`X | Y`) 在所有上下文中可用
+- 前向引用无需字符串引用
+- 与未来 Python 版本的行为一致
+
 使用 Python 3.14+ 现代语法：
 
 - **可选类型**：使用 `X | None` 而非 `Optional[X]`
@@ -356,6 +363,8 @@ from psi_agent.ai.openai_completions.config import OpenAICompletionsConfig
 
 ```python
 # 正确 ✓
+from __future__ import annotations
+
 def func(data: dict[str, Any] | None) -> list[str]:
     ...
 

--- a/openspec/changes/archive/2026-04-29-add-future-annotations/.openspec.yaml
+++ b/openspec/changes/archive/2026-04-29-add-future-annotations/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-28

--- a/openspec/changes/archive/2026-04-29-add-future-annotations/design.md
+++ b/openspec/changes/archive/2026-04-29-add-future-annotations/design.md
@@ -1,0 +1,37 @@
+## Context
+
+Python 3.14 supports PEP 604 union syntax (`X | Y`) and PEP 649 deferred annotation evaluation. However, `from __future__ import annotations` is still needed for:
+- Forward references without string quoting
+- Consistent behavior across Python versions
+- Enabling modern type syntax in all contexts
+
+Currently 36 of 52 files are missing this import.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Add `from __future__ import annotations` to all Python files
+- Document this requirement in CLAUDE.md
+- Maintain code quality (pass ruff, ty checks)
+
+**Non-Goals:**
+- Refactor any type annotations
+- Change any runtime behavior
+
+## Decisions
+
+### Add import at top of file
+
+Add `from __future__ import annotations` as the first import (after module docstring) in each file.
+
+**Rationale:** This is the standard location for future imports in Python.
+
+### Document in CLAUDE.md
+
+Add a note in the type annotation conventions section requiring this import.
+
+**Rationale:** Ensures future development follows the same convention.
+
+## Risks / Trade-offs
+
+None - this is a straightforward addition with no runtime impact.

--- a/openspec/changes/archive/2026-04-29-add-future-annotations/proposal.md
+++ b/openspec/changes/archive/2026-04-29-add-future-annotations/proposal.md
@@ -1,0 +1,23 @@
+## Why
+
+36 out of 52 Python files in `src/psi_agent/` are missing `from __future__ import annotations`. This import enables modern type annotation syntax (PEP 604) and allows forward references without string quoting. Additionally, this requirement should be documented in CLAUDE.md for future development.
+
+## What Changes
+
+- Add `from __future__ import annotations` to all 36 Python files missing it
+- Update CLAUDE.md to document this requirement in the type annotation conventions section
+
+## Capabilities
+
+### New Capabilities
+
+None
+
+### Modified Capabilities
+
+None - this is a code quality improvement with no spec-level behavior changes.
+
+## Impact
+
+- 36 Python files in `src/psi_agent/` - add future annotations import
+- `CLAUDE.md` - document the requirement

--- a/openspec/changes/archive/2026-04-29-add-future-annotations/specs/no-specs-needed/spec.md
+++ b/openspec/changes/archive/2026-04-29-add-future-annotations/specs/no-specs-needed/spec.md
@@ -1,0 +1,3 @@
+## Note
+
+This change has no spec-level behavior changes. It only adds `from __future__ import annotations` imports and updates documentation.

--- a/openspec/changes/archive/2026-04-29-add-future-annotations/tasks.md
+++ b/openspec/changes/archive/2026-04-29-add-future-annotations/tasks.md
@@ -1,0 +1,46 @@
+## 1. Add future annotations to all Python files
+
+- [x] 1.1 Add `from __future__ import annotations` to `src/psi_agent/__init__.py`
+- [x] 1.2 Add `from __future__ import annotations` to `src/psi_agent/workspace/manifest.py`
+- [x] 1.3 Add `from __future__ import annotations` to `src/psi_agent/session/config.py`
+- [x] 1.4 Add `from __future__ import annotations` to `src/psi_agent/session/history.py`
+- [x] 1.5 Add `from __future__ import annotations` to `src/psi_agent/session/server.py`
+- [x] 1.6 Add `from __future__ import annotations` to `src/psi_agent/session/tool_executor.py`
+- [x] 1.7 Add `from __future__ import annotations` to `src/psi_agent/session/tool_loader.py`
+- [x] 1.8 Add `from __future__ import annotations` to `src/psi_agent/session/types.py`
+- [x] 1.9 Add `from __future__ import annotations` to `src/psi_agent/session/runner.py`
+- [x] 1.10 Add `from __future__ import annotations` to `src/psi_agent/ai/openai_completions/__init__.py`
+- [x] 1.11 Add `from __future__ import annotations` to `src/psi_agent/ai/openai_completions/config.py`
+- [x] 1.12 Add `from __future__ import annotations` to `src/psi_agent/ai/openai_completions/server.py`
+- [x] 1.13 Add `from __future__ import annotations` to `src/psi_agent/ai/openai_completions/client.py`
+- [x] 1.14 Add `from __future__ import annotations` to `src/psi_agent/ai/anthropic_messages/__init__.py`
+- [x] 1.15 Add `from __future__ import annotations` to `src/psi_agent/ai/anthropic_messages/config.py`
+- [x] 1.16 Add `from __future__ import annotations` to `src/psi_agent/ai/anthropic_messages/client.py`
+- [x] 1.17 Add `from __future__ import annotations` to `src/psi_agent/ai/anthropic_messages/server.py`
+- [x] 1.18 Add `from __future__ import annotations` to `src/psi_agent/ai/anthropic_messages/translator.py`
+- [x] 1.19 Add `from __future__ import annotations` to `src/psi_agent/workspace/pack/__init__.py`
+- [x] 1.20 Add `from __future__ import annotations` to `src/psi_agent/workspace/pack/api.py`
+- [x] 1.21 Add `from __future__ import annotations` to `src/psi_agent/workspace/unpack/__init__.py`
+- [x] 1.22 Add `from __future__ import annotations` to `src/psi_agent/workspace/unpack/api.py`
+- [x] 1.23 Add `from __future__ import annotations` to `src/psi_agent/workspace/mount/__init__.py`
+- [x] 1.24 Add `from __future__ import annotations` to `src/psi_agent/workspace/mount/api.py`
+- [x] 1.25 Add `from __future__ import annotations` to `src/psi_agent/workspace/umount/__init__.py`
+- [x] 1.26 Add `from __future__ import annotations` to `src/psi_agent/workspace/umount/api.py`
+- [x] 1.27 Add `from __future__ import annotations` to `src/psi_agent/workspace/snapshot/__init__.py`
+- [x] 1.28 Add `from __future__ import annotations` to `src/psi_agent/workspace/snapshot/api.py`
+- [x] 1.29 Add `from __future__ import annotations` to `src/psi_agent/channel/repl/__init__.py`
+- [x] 1.30 Add `from __future__ import annotations` to `src/psi_agent/channel/repl/client.py`
+- [x] 1.31 Add `from __future__ import annotations` to `src/psi_agent/channel/repl/config.py`
+- [x] 1.32 Add `from __future__ import annotations` to `src/psi_agent/channel/repl/repl.py`
+- [x] 1.33 Add `from __future__ import annotations` to `src/psi_agent/channel/telegram/__init__.py`
+- [x] 1.34 Add `from __future__ import annotations` to `src/psi_agent/channel/telegram/bot.py`
+- [x] 1.35 Add `from __future__ import annotations` to `src/psi_agent/channel/telegram/client.py`
+- [x] 1.36 Add `from __future__ import annotations` to `src/psi_agent/channel/telegram/config.py`
+
+## 2. Update CLAUDE.md documentation
+
+- [x] 2.1 Add requirement for `from __future__ import annotations` in the type annotation conventions section
+
+## 3. Verification
+
+- [x] 3.1 Run `uv run ruff check && uv run ruff format && uv run ty check` to verify all checks pass

--- a/src/psi_agent/__init__.py
+++ b/src/psi_agent/__init__.py
@@ -1,5 +1,7 @@
 """psi-agent: A portable and componentized agent framework."""
 
+from __future__ import annotations
+
 from importlib.metadata import version
 
 __version__ = version("psi-agent")

--- a/src/psi_agent/ai/anthropic_messages/__init__.py
+++ b/src/psi_agent/ai/anthropic_messages/__init__.py
@@ -1,5 +1,7 @@
 """Anthropic Messages server and client."""
 
+from __future__ import annotations
+
 from psi_agent.ai.anthropic_messages.client import AnthropicMessagesClient
 from psi_agent.ai.anthropic_messages.config import AnthropicMessagesConfig
 from psi_agent.ai.anthropic_messages.server import AnthropicMessagesServer

--- a/src/psi_agent/ai/anthropic_messages/client.py
+++ b/src/psi_agent/ai/anthropic_messages/client.py
@@ -1,5 +1,7 @@
 """Anthropic Messages API client for forwarding requests."""
 
+from __future__ import annotations
+
 import json
 from collections.abc import AsyncGenerator
 from typing import Any

--- a/src/psi_agent/ai/anthropic_messages/config.py
+++ b/src/psi_agent/ai/anthropic_messages/config.py
@@ -1,5 +1,7 @@
 """Configuration for Anthropic Messages server."""
 
+from __future__ import annotations
+
 from dataclasses import dataclass
 from pathlib import Path
 

--- a/src/psi_agent/ai/anthropic_messages/server.py
+++ b/src/psi_agent/ai/anthropic_messages/server.py
@@ -1,5 +1,7 @@
 """HTTP server for Anthropic Messages over Unix socket."""
 
+from __future__ import annotations
+
 import json
 from typing import Any
 

--- a/src/psi_agent/ai/anthropic_messages/translator.py
+++ b/src/psi_agent/ai/anthropic_messages/translator.py
@@ -1,5 +1,7 @@
 """Protocol translation between OpenAI and Anthropic message formats."""
 
+from __future__ import annotations
+
 import json
 from collections.abc import AsyncGenerator
 from typing import Any

--- a/src/psi_agent/ai/openai_completions/__init__.py
+++ b/src/psi_agent/ai/openai_completions/__init__.py
@@ -1,5 +1,7 @@
 """OpenAI completions server and client."""
 
+from __future__ import annotations
+
 from psi_agent.ai.openai_completions.client import OpenAICompletionsClient
 from psi_agent.ai.openai_completions.config import OpenAICompletionsConfig
 from psi_agent.ai.openai_completions.server import OpenAICompletionsServer

--- a/src/psi_agent/ai/openai_completions/client.py
+++ b/src/psi_agent/ai/openai_completions/client.py
@@ -1,5 +1,7 @@
 """OpenAI API client for forwarding requests."""
 
+from __future__ import annotations
+
 import json
 from collections.abc import AsyncGenerator
 from typing import Any

--- a/src/psi_agent/ai/openai_completions/config.py
+++ b/src/psi_agent/ai/openai_completions/config.py
@@ -1,5 +1,7 @@
 """Configuration for OpenAI completions server."""
 
+from __future__ import annotations
+
 from dataclasses import dataclass
 from pathlib import Path
 

--- a/src/psi_agent/ai/openai_completions/server.py
+++ b/src/psi_agent/ai/openai_completions/server.py
@@ -1,5 +1,7 @@
 """HTTP server for OpenAI completions over Unix socket."""
 
+from __future__ import annotations
+
 import json
 from typing import Any
 

--- a/src/psi_agent/channel/repl/__init__.py
+++ b/src/psi_agent/channel/repl/__init__.py
@@ -1,5 +1,7 @@
 """REPL channel for interactive conversation."""
 
+from __future__ import annotations
+
 from psi_agent.channel.repl.client import ReplClient
 from psi_agent.channel.repl.config import ReplConfig
 from psi_agent.channel.repl.repl import Repl

--- a/src/psi_agent/channel/repl/client.py
+++ b/src/psi_agent/channel/repl/client.py
@@ -1,5 +1,7 @@
 """HTTP client for communicating with psi-session."""
 
+from __future__ import annotations
+
 from typing import Any
 
 import aiohttp

--- a/src/psi_agent/channel/repl/config.py
+++ b/src/psi_agent/channel/repl/config.py
@@ -1,5 +1,7 @@
 """Configuration for REPL channel."""
 
+from __future__ import annotations
+
 from dataclasses import dataclass
 from pathlib import Path
 

--- a/src/psi_agent/channel/repl/repl.py
+++ b/src/psi_agent/channel/repl/repl.py
@@ -1,5 +1,7 @@
 """REPL interface for interactive conversation."""
 
+from __future__ import annotations
+
 from pathlib import Path
 
 from loguru import logger

--- a/src/psi_agent/channel/telegram/__init__.py
+++ b/src/psi_agent/channel/telegram/__init__.py
@@ -1,1 +1,3 @@
 """Telegram channel for psi-agent."""
+
+from __future__ import annotations

--- a/src/psi_agent/channel/telegram/bot.py
+++ b/src/psi_agent/channel/telegram/bot.py
@@ -1,5 +1,7 @@
 """Telegram bot handler for psi-agent."""
 
+from __future__ import annotations
+
 from typing import Any
 
 from loguru import logger

--- a/src/psi_agent/channel/telegram/client.py
+++ b/src/psi_agent/channel/telegram/client.py
@@ -1,5 +1,7 @@
 """HTTP client for communicating with psi-session."""
 
+from __future__ import annotations
+
 from typing import Any
 
 import aiohttp

--- a/src/psi_agent/channel/telegram/config.py
+++ b/src/psi_agent/channel/telegram/config.py
@@ -1,5 +1,7 @@
 """Configuration for Telegram channel."""
 
+from __future__ import annotations
+
 from dataclasses import dataclass
 from pathlib import Path
 

--- a/src/psi_agent/session/config.py
+++ b/src/psi_agent/session/config.py
@@ -1,5 +1,7 @@
 """Configuration for psi-session."""
 
+from __future__ import annotations
+
 from dataclasses import dataclass
 from pathlib import Path
 

--- a/src/psi_agent/session/history.py
+++ b/src/psi_agent/session/history.py
@@ -1,5 +1,7 @@
 """Conversation history management and persistence."""
 
+from __future__ import annotations
+
 import json
 from pathlib import Path
 from typing import Any

--- a/src/psi_agent/session/runner.py
+++ b/src/psi_agent/session/runner.py
@@ -1,5 +1,7 @@
 """Core session runner - message processing and tool call handling."""
 
+from __future__ import annotations
+
 import importlib.util
 import json
 import sys

--- a/src/psi_agent/session/server.py
+++ b/src/psi_agent/session/server.py
@@ -1,5 +1,7 @@
 """HTTP server for psi-session on Unix socket."""
 
+from __future__ import annotations
+
 import json
 from typing import Any
 

--- a/src/psi_agent/session/tool_executor.py
+++ b/src/psi_agent/session/tool_executor.py
@@ -1,5 +1,7 @@
 """Tool execution and result formatting."""
 
+from __future__ import annotations
+
 import json
 from typing import Any
 

--- a/src/psi_agent/session/tool_loader.py
+++ b/src/psi_agent/session/tool_loader.py
@@ -1,5 +1,7 @@
 """Tool dynamic loading and registry management."""
 
+from __future__ import annotations
+
 import hashlib
 import importlib.util
 import inspect

--- a/src/psi_agent/session/types.py
+++ b/src/psi_agent/session/types.py
@@ -1,5 +1,7 @@
 """Type definitions for psi-session."""
 
+from __future__ import annotations
+
 from collections.abc import Callable, Coroutine
 from dataclasses import dataclass, field
 from typing import Any

--- a/src/psi_agent/workspace/manifest.py
+++ b/src/psi_agent/workspace/manifest.py
@@ -1,5 +1,7 @@
 """Manifest data structure for workspace squashfs images."""
 
+from __future__ import annotations
+
 import json
 from dataclasses import dataclass, field
 from uuid import UUID

--- a/src/psi_agent/workspace/mount/__init__.py
+++ b/src/psi_agent/workspace/mount/__init__.py
@@ -1,5 +1,7 @@
 """Mount workspace squashfs as overlayfs."""
 
+from __future__ import annotations
+
 from psi_agent.workspace.mount.api import mount
 
 __all__ = ["mount"]

--- a/src/psi_agent/workspace/mount/api.py
+++ b/src/psi_agent/workspace/mount/api.py
@@ -1,5 +1,7 @@
 """Mount API for mounting squashfs as overlayfs."""
 
+from __future__ import annotations
+
 import asyncio
 import tempfile
 from pathlib import Path

--- a/src/psi_agent/workspace/pack/__init__.py
+++ b/src/psi_agent/workspace/pack/__init__.py
@@ -1,5 +1,7 @@
 """Pack workspace directory into squashfs image."""
 
+from __future__ import annotations
+
 from psi_agent.workspace.pack.api import pack
 
 __all__ = ["pack"]

--- a/src/psi_agent/workspace/pack/api.py
+++ b/src/psi_agent/workspace/pack/api.py
@@ -1,5 +1,7 @@
 """Pack API for creating squashfs from workspace directory."""
 
+from __future__ import annotations
+
 import asyncio
 import tempfile
 from pathlib import Path

--- a/src/psi_agent/workspace/snapshot/__init__.py
+++ b/src/psi_agent/workspace/snapshot/__init__.py
@@ -1,5 +1,7 @@
 """Snapshot workspace changes."""
 
+from __future__ import annotations
+
 from psi_agent.workspace.snapshot.api import snapshot
 
 __all__ = ["snapshot"]

--- a/src/psi_agent/workspace/snapshot/api.py
+++ b/src/psi_agent/workspace/snapshot/api.py
@@ -1,5 +1,7 @@
 """Snapshot API for creating workspace snapshots."""
 
+from __future__ import annotations
+
 import asyncio
 import shutil
 import tempfile

--- a/src/psi_agent/workspace/umount/__init__.py
+++ b/src/psi_agent/workspace/umount/__init__.py
@@ -1,5 +1,7 @@
 """Umount workspace overlayfs."""
 
+from __future__ import annotations
+
 from psi_agent.workspace.umount.api import umount
 
 __all__ = ["umount"]

--- a/src/psi_agent/workspace/umount/api.py
+++ b/src/psi_agent/workspace/umount/api.py
@@ -1,5 +1,7 @@
 """Umount API for unmounting overlayfs workspace."""
 
+from __future__ import annotations
+
 import asyncio
 from pathlib import Path
 

--- a/src/psi_agent/workspace/unpack/__init__.py
+++ b/src/psi_agent/workspace/unpack/__init__.py
@@ -1,5 +1,7 @@
 """Unpack workspace squashfs to directory."""
 
+from __future__ import annotations
+
 from psi_agent.workspace.unpack.api import unpack
 
 __all__ = ["unpack"]

--- a/src/psi_agent/workspace/unpack/api.py
+++ b/src/psi_agent/workspace/unpack/api.py
@@ -1,5 +1,7 @@
 """Unpack API for extracting squashfs to directory."""
 
+from __future__ import annotations
+
 import asyncio
 from pathlib import Path
 


### PR DESCRIPTION
## Summary

- Add `from __future__ import annotations` to all Python files for modern type syntax
- Update CLAUDE.md to document the future annotations requirement
- Add ty configuration to ignore false positive `no-matching-overload` error with tyro
- Fix channel CLI tests structure and imports

## Changes

1. **Future annotations**: All 52 Python files now have `from __future__ import annotations` after docstrings
2. **CLAUDE.md documentation**: Added requirement for future annotations in type annotation conventions section
3. **ty configuration**: Added `[tool.ty.rules]` to ignore tyro type checker limitation
4. **Test structure**: Moved `tests/channel/test_cli.py` to `tests/channel/cli/test_cli.py` for consistency

## Test plan

- [x] `uv run ruff check && uv run ruff format` - lint/format pass
- [x] `uv run ty check` - type check passes
- [x] `uv run pytest tests/` - 160 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)