### PR TITLE
Add sensitive argument masking for CLI entry points

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -513,6 +513,35 @@ def main() -> None:
     tyro.cli(run)
 ```
 
+### CLI 安全规范
+
+**敏感参数掩码：**
+
+所有接受敏感凭证（API keys、tokens、passwords）的 CLI 入口点，必须在参数解析后立即调用 `mask_sensitive_args()` 函数，将敏感值从进程标题中隐藏。
+
+- 使用 `psi_agent.utils.proctitle.mask_sensitive_args()` 函数
+- 在 `__call__` 方法的最开始处调用
+- 传入需要掩码的参数名列表（如 `["api_key"]`、`["token"]`）
+
+示例：
+
+```python
+from psi_agent.utils.proctitle import mask_sensitive_args
+
+@dataclass
+class MyCLI:
+    api_key: str
+
+    def __call__(self) -> None:
+        # 立即掩码敏感参数
+        mask_sensitive_args(["api_key"])
+        ...
+```
+
+**原因：** 命令行参数在进程列表（`ps aux`、`top`、`/proc/<pid>/cmdline`）中可见，暴露敏感凭证是安全风险。
+
+**注意：** 此方法在进程启动后有极短的时间窗口（毫秒级）参数仍可见，这是已知限制。
+
 ### 测试规范
 
 - 所有 Python API 必须编写单元测试

--- a/openspec/changes/archive/2026-04-29-hide-sensitive-args/.openspec.yaml
+++ b/openspec/changes/archive/2026-04-29-hide-sensitive-args/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-28

--- a/openspec/changes/archive/2026-04-29-hide-sensitive-args/design.md
+++ b/openspec/changes/archive/2026-04-29-hide-sensitive-args/design.md
@@ -1,0 +1,58 @@
+## Context
+
+Currently, all psi-agent CLI components accept sensitive credentials (API keys, tokens) via command line arguments. These are visible in:
+- `ps aux` output
+- `/proc/<pid>/cmdline`
+- Process monitoring tools
+
+This is a known security issue in multi-user environments. The `setproctitle` library provides a cross-platform solution to modify the process title at runtime, hiding the original command line arguments.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Hide sensitive CLI arguments from process listings after program starts
+- Provide a reusable utility for all CLI entry points
+- Document this as a security principle in CLAUDE.md
+
+**Non-Goals:**
+- Hide arguments during the brief window between process start and `setproctitle` call (this is a known limitation of the approach)
+- Encrypt or otherwise protect the arguments in memory
+- Replace CLI argument passing with environment variables or config files (those are separate concerns)
+
+## Decisions
+
+### 1. Use `setproctitle` library
+
+**Rationale:** This is the de-facto standard Python library for process title manipulation. It's cross-platform (Linux, macOS, Windows, FreeBSD) and actively maintained.
+
+**Alternatives considered:**
+- `python-prctl`: Linux-only, more complex, overkill for this use case
+- Manual `/proc/self/comm` manipulation: Platform-specific, fragile
+- Environment variables: Doesn't solve the problem (visible in `/proc/<pid>/environ`)
+
+### 2. Create utility module `psi_agent.utils.proctitle`
+
+**Rationale:** Centralize the masking logic for:
+- Consistent behavior across all CLI entry points
+- Easy testing
+- Single source of truth for sensitive parameter names
+
+**Interface:**
+```python
+def mask_sensitive_args(sensitive_keys: list[str]) -> None:
+    """Mask sensitive CLI arguments from process title.
+
+    Args:
+        sensitive_keys: List of argument names to mask (e.g., ['api_key', 'token'])
+    """
+```
+
+### 3. Call masking immediately after CLI parsing
+
+**Rationale:** Minimize the time window where arguments are visible. The `__call__` method in each CLI dataclass is the earliest point after tyro parsing where we have access to the parsed values.
+
+## Risks / Trade-offs
+
+- **Race condition**: There's a brief window (milliseconds) between process start and `setproctitle` call where arguments are visible. This is acceptable for our threat model.
+- **Platform compatibility**: `setproctitle` works on most platforms but may have edge cases. We should handle ImportError gracefully.
+- **Debugging**: Masked arguments may complicate debugging. Logs should still record that the program started (without the sensitive values).

--- a/openspec/changes/archive/2026-04-29-hide-sensitive-args/proposal.md
+++ b/openspec/changes/archive/2026-04-29-hide-sensitive-args/proposal.md
@@ -1,0 +1,37 @@
+## Why
+
+CLI arguments passed via command line are visible in process listings (`ps`, `top`, `/proc/<pid>/cmdline`), exposing sensitive credentials like API keys and tokens. This is a security risk in multi-user environments where other users can view running processes.
+
+## What Changes
+
+- Add `setproctitle` dependency for runtime process title modification
+- Create a utility module for masking sensitive arguments in process title
+- Update all CLI entry points to mask sensitive arguments immediately after parsing:
+  - `psi-ai-openai-completions`: mask `--api-key`
+  - `psi-ai-anthropic-messages`: mask `--api-key`
+  - `psi-channel-telegram`: mask `--token`
+- Document this security practice in CLAUDE.md as a coding principle
+
+## Capabilities
+
+### New Capabilities
+
+- `sensitive-args-masking`: Runtime masking of sensitive CLI arguments from process listings
+
+### Modified Capabilities
+
+- `psi-ai-openai-completions`: Add API key masking after CLI argument parsing
+- `anthropic-messages-server`: Add API key masking after CLI argument parsing
+- `telegram-channel`: Add token masking after CLI argument parsing
+- `claude-md`: Add security principle for sensitive argument handling
+
+## Impact
+
+- New dependency: `setproctitle` package
+- New module: `psi_agent.utils.proctitle` for process title manipulation
+- Modified files:
+  - `src/psi_agent/ai/openai_completions/cli.py`
+  - `src/psi_agent/ai/anthropic_messages/cli.py`
+  - `src/psi_agent/channel/telegram/cli.py`
+  - `CLAUDE.md`
+- Security posture improved: sensitive credentials no longer visible in process listings

--- a/openspec/changes/archive/2026-04-29-hide-sensitive-args/specs/anthropic-messages-server/spec.md
+++ b/openspec/changes/archive/2026-04-29-hide-sensitive-args/specs/anthropic-messages-server/spec.md
@@ -1,0 +1,10 @@
+## ADDED Requirements
+
+### Requirement: CLI masks sensitive API key from process title
+
+The Anthropic messages CLI SHALL mask the `--api-key` argument from the process title immediately after parsing.
+
+#### Scenario: API key masked in process title
+- **WHEN** `psi-ai-anthropic-messages` is started with `--api-key sk-ant-xxx`
+- **THEN** the process title SHALL NOT contain `sk-ant-xxx`
+- **AND** the process title SHALL show `--api-key ***`

--- a/openspec/changes/archive/2026-04-29-hide-sensitive-args/specs/claude-md/spec.md
+++ b/openspec/changes/archive/2026-04-29-hide-sensitive-args/specs/claude-md/spec.md
@@ -1,0 +1,10 @@
+## ADDED Requirements
+
+### Requirement: Sensitive argument masking principle
+
+CLAUDE.md SHALL document the security principle that all CLI entry points accepting sensitive credentials (API keys, tokens, passwords) MUST mask them from the process title.
+
+#### Scenario: New CLI with sensitive arguments
+- **WHEN** a new CLI entry point is created that accepts sensitive credentials
+- **THEN** the CLI SHALL call the masking utility immediately after argument parsing
+- **AND** this requirement SHALL be documented in CLAUDE.md coding principles

--- a/openspec/changes/archive/2026-04-29-hide-sensitive-args/specs/psi-ai-openai-completions/spec.md
+++ b/openspec/changes/archive/2026-04-29-hide-sensitive-args/specs/psi-ai-openai-completions/spec.md
@@ -1,0 +1,10 @@
+## ADDED Requirements
+
+### Requirement: CLI masks sensitive API key from process title
+
+The OpenAI completions CLI SHALL mask the `--api-key` argument from the process title immediately after parsing.
+
+#### Scenario: API key masked in process title
+- **WHEN** `psi-ai-openai-completions` is started with `--api-key sk-xxx`
+- **THEN** the process title SHALL NOT contain `sk-xxx`
+- **AND** the process title SHALL show `--api-key ***`

--- a/openspec/changes/archive/2026-04-29-hide-sensitive-args/specs/sensitive-args-masking/spec.md
+++ b/openspec/changes/archive/2026-04-29-hide-sensitive-args/specs/sensitive-args-masking/spec.md
@@ -1,0 +1,34 @@
+## ADDED Requirements
+
+### Requirement: Process title masking utility
+
+The system SHALL provide a utility function to mask sensitive CLI arguments from the process title.
+
+#### Scenario: Mask sensitive arguments
+- **WHEN** `mask_sensitive_args(['api_key', 'token'])` is called
+- **THEN** the process title SHALL be modified to hide values of those arguments
+- **AND** the process title SHALL show `***` in place of sensitive values
+
+#### Scenario: Graceful fallback on unsupported platforms
+- **WHEN** `setproctitle` is not available (ImportError)
+- **THEN** the function SHALL log a warning and continue without error
+- **AND** the process title SHALL remain unchanged
+
+### Requirement: CLI entry points must mask sensitive arguments
+
+All CLI entry points that accept sensitive credentials SHALL call the masking utility immediately after argument parsing.
+
+#### Scenario: OpenAI completions CLI masks API key
+- **WHEN** `psi-ai-openai-completions` is started with `--api-key sk-xxx`
+- **THEN** the process title SHALL NOT contain `sk-xxx`
+- **AND** the process title SHALL show `--api-key ***`
+
+#### Scenario: Anthropic messages CLI masks API key
+- **WHEN** `psi-ai-anthropic-messages` is started with `--api-key sk-ant-xxx`
+- **THEN** the process title SHALL NOT contain `sk-ant-xxx`
+- **AND** the process title SHALL show `--api-key ***`
+
+#### Scenario: Telegram channel CLI masks token
+- **WHEN** `psi-channel-telegram` is started with `--token 123456:ABC`
+- **THEN** the process title SHALL NOT contain the token value
+- **AND** the process title SHALL show `--token ***`

--- a/openspec/changes/archive/2026-04-29-hide-sensitive-args/specs/telegram-channel/spec.md
+++ b/openspec/changes/archive/2026-04-29-hide-sensitive-args/specs/telegram-channel/spec.md
@@ -1,0 +1,10 @@
+## ADDED Requirements
+
+### Requirement: CLI masks sensitive token from process title
+
+The Telegram channel CLI SHALL mask the `--token` argument from the process title immediately after parsing.
+
+#### Scenario: Token masked in process title
+- **WHEN** `psi-channel-telegram` is started with `--token 123456:ABC`
+- **THEN** the process title SHALL NOT contain the token value
+- **AND** the process title SHALL show `--token ***`

--- a/openspec/changes/archive/2026-04-29-hide-sensitive-args/tasks.md
+++ b/openspec/changes/archive/2026-04-29-hide-sensitive-args/tasks.md
@@ -1,0 +1,28 @@
+## 1. Setup
+
+- [x] 1.1 Add `setproctitle` dependency to pyproject.toml
+- [x] 1.2 Create `psi_agent/utils/` directory structure
+- [x] 1.3 Create `psi_agent/utils/__init__.py`
+- [x] 1.4 Create `psi_agent/utils/proctitle.py` with `mask_sensitive_args()` function
+
+## 2. Core Implementation
+
+- [x] 2.1 Implement `mask_sensitive_args()` function with graceful fallback
+- [x] 2.2 Add unit tests for `mask_sensitive_args()` in `tests/utils/test_proctitle.py`
+
+## 3. CLI Integration
+
+- [x] 3.1 Update `psi-ai-openai-completions` CLI to mask `--api-key`
+- [x] 3.2 Update `psi-ai-anthropic-messages` CLI to mask `--api-key`
+- [x] 3.3 Update `psi-channel-telegram` CLI to mask `--token`
+
+## 4. Documentation
+
+- [x] 4.1 Add security principle to CLAUDE.md for sensitive argument masking
+
+## 5. Verification
+
+- [x] 5.1 Run `ruff check` and `ruff format`
+- [x] 5.2 Run `ty check` for type checking
+- [x] 5.3 Run `pytest` to verify all tests pass
+- [x] 5.4 Manual test: verify process title masking with `ps aux`

--- a/openspec/specs/anthropic-messages-server/spec.md
+++ b/openspec/specs/anthropic-messages-server/spec.md
@@ -67,3 +67,12 @@ The server SHALL provide a CLI command `psi-ai-anthropic-messages` for starting 
 #### Scenario: CLI starts server
 - **WHEN** `psi-ai-anthropic-messages` is invoked with required arguments
 - **THEN** server SHALL start and log connection information
+
+### Requirement: CLI masks sensitive API key from process title
+
+The Anthropic messages CLI SHALL mask the `--api-key` argument from the process title immediately after parsing.
+
+#### Scenario: API key masked in process title
+- **WHEN** `psi-ai-anthropic-messages` is started with `--api-key sk-ant-xxx`
+- **THEN** the process title SHALL NOT contain `sk-ant-xxx`
+- **AND** the process title SHALL show `--api-key ***`

--- a/openspec/specs/claude-md/spec.md
+++ b/openspec/specs/claude-md/spec.md
@@ -100,3 +100,12 @@ CLAUDE.md SHALL 规定使用 Google style docstring 格式。
 #### Scenario: 编写模块文档字符串
 - **WHEN** 编写模块级文档字符串
 - **THEN** SHALL 使用单行或简短描述，说明模块用途
+
+### Requirement: Sensitive argument masking principle
+
+CLAUDE.md SHALL document the security principle that all CLI entry points accepting sensitive credentials (API keys, tokens, passwords) MUST mask them from the process title.
+
+#### Scenario: New CLI with sensitive arguments
+- **WHEN** a new CLI entry point is created that accepts sensitive credentials
+- **THEN** the CLI SHALL call the masking utility immediately after argument parsing
+- **AND** this requirement SHALL be documented in CLAUDE.md coding principles

--- a/openspec/specs/psi-ai-openai-completions/spec.md
+++ b/openspec/specs/psi-ai-openai-completions/spec.md
@@ -156,3 +156,12 @@ The refactored client SHALL maintain identical external behavior to the current 
 #### Scenario: Same response format
 - **WHEN** a request completes
 - **THEN** the response dict structure matches the current implementation
+
+### Requirement: CLI masks sensitive API key from process title
+
+The OpenAI completions CLI SHALL mask the `--api-key` argument from the process title immediately after parsing.
+
+#### Scenario: API key masked in process title
+- **WHEN** `psi-ai-openai-completions` is started with `--api-key sk-xxx`
+- **THEN** the process title SHALL NOT contain `sk-xxx`
+- **AND** the process title SHALL show `--api-key ***`

--- a/openspec/specs/sensitive-args-masking/spec.md
+++ b/openspec/specs/sensitive-args-masking/spec.md
@@ -1,0 +1,36 @@
+# sensitive-args-masking
+
+Process title masking utility for sensitive CLI arguments.
+
+### Requirement: Process title masking utility
+
+The system SHALL provide a utility function to mask sensitive CLI arguments from the process title.
+
+#### Scenario: Mask sensitive arguments
+- **WHEN** `mask_sensitive_args(['api_key', 'token'])` is called
+- **THEN** the process title SHALL be modified to hide values of those arguments
+- **AND** the process title SHALL show `***` in place of sensitive values
+
+#### Scenario: Graceful fallback on unsupported platforms
+- **WHEN** `setproctitle` is not available (ImportError)
+- **THEN** the function SHALL log a warning and continue without error
+- **AND** the process title SHALL remain unchanged
+
+### Requirement: CLI entry points must mask sensitive arguments
+
+All CLI entry points that accept sensitive credentials SHALL call the masking utility immediately after argument parsing.
+
+#### Scenario: OpenAI completions CLI masks API key
+- **WHEN** `psi-ai-openai-completions` is started with `--api-key sk-xxx`
+- **THEN** the process title SHALL NOT contain `sk-xxx`
+- **AND** the process title SHALL show `--api-key ***`
+
+#### Scenario: Anthropic messages CLI masks API key
+- **WHEN** `psi-ai-anthropic-messages` is started with `--api-key sk-ant-xxx`
+- **THEN** the process title SHALL NOT contain `sk-ant-xxx`
+- **AND** the process title SHALL show `--api-key ***`
+
+#### Scenario: Telegram channel CLI masks token
+- **WHEN** `psi-channel-telegram` is started with `--token 123456:ABC`
+- **THEN** the process title SHALL NOT contain the token value
+- **AND** the process title SHALL show `--token ***`

--- a/openspec/specs/telegram-channel/spec.md
+++ b/openspec/specs/telegram-channel/spec.md
@@ -132,3 +132,12 @@ The Telegram channel SHALL be available as a subcommand under `psi-agent channel
 #### Scenario: Help at channel level
 - **WHEN** user runs `psi-agent channel --help`
 - **THEN** the help text SHALL show `telegram` as an available subcommand
+
+### Requirement: CLI masks sensitive token from process title
+
+The Telegram channel CLI SHALL mask the `--token` argument from the process title immediately after parsing.
+
+#### Scenario: Token masked in process title
+- **WHEN** `psi-channel-telegram` is started with `--token 123456:ABC`
+- **THEN** the process title SHALL NOT contain the token value
+- **AND** the process title SHALL show `--token ***`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
     "openai>=1.30.0",
     "prompt-toolkit>=3.0.51",
     "python-telegram-bot>=22.0",
+    "setproctitle>=1.3.4",
     "tyro>=1.0.13",
 ]
 

--- a/src/psi_agent/ai/anthropic_messages/cli.py
+++ b/src/psi_agent/ai/anthropic_messages/cli.py
@@ -10,6 +10,7 @@ from loguru import logger
 
 from psi_agent.ai.anthropic_messages.config import AnthropicMessagesConfig
 from psi_agent.ai.anthropic_messages.server import AnthropicMessagesServer
+from psi_agent.utils.proctitle import mask_sensitive_args
 
 
 @dataclass
@@ -22,6 +23,9 @@ class AnthropicMessages:
     base_url: str = "https://api.anthropic.com"
 
     def __call__(self) -> None:
+        # Mask sensitive arguments from process title
+        mask_sensitive_args(["api_key"])
+
         config = AnthropicMessagesConfig(
             session_socket=self.session_socket,
             model=self.model,

--- a/src/psi_agent/ai/openai_completions/cli.py
+++ b/src/psi_agent/ai/openai_completions/cli.py
@@ -10,6 +10,7 @@ from loguru import logger
 
 from psi_agent.ai.openai_completions.config import OpenAICompletionsConfig
 from psi_agent.ai.openai_completions.server import OpenAICompletionsServer
+from psi_agent.utils.proctitle import mask_sensitive_args
 
 
 @dataclass
@@ -22,6 +23,9 @@ class OpenaiCompletions:
     base_url: str = "https://api.openai.com/v1"
 
     def __call__(self) -> None:
+        # Mask sensitive arguments from process title
+        mask_sensitive_args(["api_key"])
+
         config = OpenAICompletionsConfig(
             session_socket=self.session_socket,
             model=self.model,

--- a/src/psi_agent/channel/telegram/cli.py
+++ b/src/psi_agent/channel/telegram/cli.py
@@ -10,6 +10,7 @@ from loguru import logger
 
 from psi_agent.channel.telegram.bot import TelegramBot
 from psi_agent.channel.telegram.config import TelegramConfig
+from psi_agent.utils.proctitle import mask_sensitive_args
 
 
 @dataclass
@@ -20,6 +21,9 @@ class Telegram:
     session_socket: str
 
     def __call__(self) -> None:
+        # Mask sensitive arguments from process title
+        mask_sensitive_args(["token"])
+
         logger.info("Starting psi-channel-telegram")
         logger.debug(f"Config: session_socket={self.session_socket}")
 

--- a/src/psi_agent/utils/__init__.py
+++ b/src/psi_agent/utils/__init__.py
@@ -1,0 +1,5 @@
+"""Utility modules for psi-agent."""
+
+from psi_agent.utils.proctitle import mask_sensitive_args
+
+__all__ = ["mask_sensitive_args"]

--- a/src/psi_agent/utils/proctitle.py
+++ b/src/psi_agent/utils/proctitle.py
@@ -1,0 +1,77 @@
+"""Process title manipulation for hiding sensitive CLI arguments."""
+
+from __future__ import annotations
+
+import sys
+from typing import TYPE_CHECKING
+
+from loguru import logger
+
+if TYPE_CHECKING:
+    pass
+
+# Try to import setproctitle, with graceful fallback
+try:
+    import setproctitle
+
+    _HAS_SETPROCTITLE = True
+except ImportError:
+    _HAS_SETPROCTITLE = False
+
+
+def mask_sensitive_args(sensitive_keys: list[str]) -> None:
+    """Mask sensitive CLI arguments from process title.
+
+    Replaces values of specified argument keys with '***' in the process title
+    to prevent sensitive information (API keys, tokens, passwords) from being
+    visible in process listings (ps, top, /proc/<pid>/cmdline).
+
+    Args:
+        sensitive_keys: List of argument names to mask (e.g., ['api_key', 'token']).
+                       Both underscore and hyphen variants are handled.
+
+    Note:
+        This uses the setproctitle library if available. On platforms where
+        setproctitle is not available, a warning is logged and no masking occurs.
+        There is a brief window between process start and this function call
+        where arguments may be visible.
+    """
+    if not _HAS_SETPROCTITLE:
+        logger.warning(
+            "setproctitle not available, sensitive arguments may be visible in process list"
+        )
+        return
+
+    # Get current argv
+    argv = sys.argv
+    masked_argv = list(argv)
+
+    # Build both underscore and hyphen variants for each key
+    key_variants: set[str] = set()
+    for key in sensitive_keys:
+        key_variants.add(key)
+        key_variants.add(key.replace("_", "-"))
+        key_variants.add(key.replace("-", "_"))
+
+    # Mask values for matching keys
+    i = 0
+    while i < len(masked_argv) - 1:
+        arg = masked_argv[i]
+        # Handle --key=value format
+        if arg.startswith("--"):
+            if "=" in arg:
+                key_part, _ = arg.split("=", 1)
+                key_name = key_part[2:]  # Remove '--'
+                if key_name in key_variants:
+                    masked_argv[i] = f"{key_part}=***"
+            else:
+                # Handle --key value format
+                key_name = arg[2:]  # Remove '--'
+                if key_name in key_variants:
+                    masked_argv[i + 1] = "***"
+        i += 1
+
+    # Set the new process title
+    new_title = " ".join(masked_argv)
+    setproctitle.setproctitle(new_title)
+    logger.debug("Masked sensitive arguments in process title")

--- a/tests/utils/__init__.py
+++ b/tests/utils/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for process title manipulation utilities."""

--- a/tests/utils/test_proctitle.py
+++ b/tests/utils/test_proctitle.py
@@ -1,0 +1,100 @@
+"""Tests for mask_sensitive_args function."""
+
+from __future__ import annotations
+
+import sys
+from unittest import mock
+
+import pytest
+
+from psi_agent.utils.proctitle import mask_sensitive_args
+
+
+class TestMaskSensitiveArgs:
+    """Tests for mask_sensitive_args function."""
+
+    def test_mask_single_argument_with_underscore(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Test masking a single argument with underscore in key name."""
+        monkeypatch.setattr(sys, "argv", ["program", "--api-key", "secret123", "--other", "value"])
+
+        with (
+            mock.patch("psi_agent.utils.proctitle.setproctitle") as mock_setproctitle,
+            mock.patch("psi_agent.utils.proctitle._HAS_SETPROCTITLE", True),
+        ):
+            mask_sensitive_args(["api_key"])
+
+        # Check that setproctitle was called with masked value
+        mock_setproctitle.setproctitle.assert_called_once()
+        call_arg = mock_setproctitle.setproctitle.call_args[0][0]
+        assert "secret123" not in call_arg
+        assert "***" in call_arg
+
+    def test_mask_single_argument_with_hyphen(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Test masking a single argument with hyphen in key name."""
+        monkeypatch.setattr(sys, "argv", ["program", "--api-key", "secret123", "--other", "value"])
+
+        with (
+            mock.patch("psi_agent.utils.proctitle.setproctitle") as mock_setproctitle,
+            mock.patch("psi_agent.utils.proctitle._HAS_SETPROCTITLE", True),
+        ):
+            mask_sensitive_args(["api-key"])
+
+        call_arg = mock_setproctitle.setproctitle.call_args[0][0]
+        assert "secret123" not in call_arg
+        assert "***" in call_arg
+
+    def test_mask_equals_format(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Test masking argument in --key=value format."""
+        monkeypatch.setattr(sys, "argv", ["program", "--api-key=secret123", "--other", "value"])
+
+        with (
+            mock.patch("psi_agent.utils.proctitle.setproctitle") as mock_setproctitle,
+            mock.patch("psi_agent.utils.proctitle._HAS_SETPROCTITLE", True),
+        ):
+            mask_sensitive_args(["api_key"])
+
+        call_arg = mock_setproctitle.setproctitle.call_args[0][0]
+        assert "secret123" not in call_arg
+        assert "--api-key=***" in call_arg
+
+    def test_mask_multiple_arguments(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Test masking multiple sensitive arguments."""
+        monkeypatch.setattr(
+            sys, "argv", ["program", "--api-key", "secret123", "--token", "token456"]
+        )
+
+        with (
+            mock.patch("psi_agent.utils.proctitle.setproctitle") as mock_setproctitle,
+            mock.patch("psi_agent.utils.proctitle._HAS_SETPROCTITLE", True),
+        ):
+            mask_sensitive_args(["api_key", "token"])
+
+        call_arg = mock_setproctitle.setproctitle.call_args[0][0]
+        assert "secret123" not in call_arg
+        assert "token456" not in call_arg
+        assert call_arg.count("***") == 2
+
+    def test_no_setproctitle_available(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Test graceful fallback when setproctitle is not available."""
+        monkeypatch.setattr(sys, "argv", ["program", "--api-key", "secret123"])
+
+        with mock.patch("psi_agent.utils.proctitle._HAS_SETPROCTITLE", False):
+            # Should not raise, just log warning
+            mask_sensitive_args(["api_key"])
+
+    def test_non_sensitive_args_unchanged(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Test that non-sensitive arguments are not masked."""
+        monkeypatch.setattr(
+            sys, "argv", ["program", "--api-key", "secret", "--model", "gpt-4", "--port", "8080"]
+        )
+
+        with (
+            mock.patch("psi_agent.utils.proctitle.setproctitle") as mock_setproctitle,
+            mock.patch("psi_agent.utils.proctitle._HAS_SETPROCTITLE", True),
+        ):
+            mask_sensitive_args(["api_key"])
+
+        call_arg = mock_setproctitle.setproctitle.call_args[0][0]
+        assert "gpt-4" in call_arg
+        assert "8080" in call_arg
+        assert "secret" not in call_arg

--- a/uv.lock
+++ b/uv.lock
@@ -142,18 +142,6 @@ wheels = [
 ]
 
 [[package]]
-name = "croniter"
-version = "6.2.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "python-dateutil" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/df/de/5832661ed55107b8a09af3f0a2e71e0957226a59eb1dcf0a445cce6daf20/croniter-6.2.2.tar.gz", hash = "sha256:ba60832a5ec8e12e51b8691c3309a113d1cf6526bdf1a48150ce8ec7a532d0ab", size = 113762, upload-time = "2026-03-15T08:43:48.112Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d0/39/783980e78cb92c2d7bdb1fc7dbc86e94ccc6d58224d76a7f1f51b6c51e30/croniter-6.2.2-py3-none-any.whl", hash = "sha256:a5d17b1060974d36251ea4faf388233eca8acf0d09cbd92d35f4c4ac8f279960", size = 45422, upload-time = "2026-03-15T08:43:46.626Z" },
-]
-
-[[package]]
 name = "distro"
 version = "1.9.0"
 source = { registry = "https://pypi.org/simple" }
@@ -455,11 +443,11 @@ dependencies = [
     { name = "aiohttp" },
     { name = "anthropic" },
     { name = "anyio" },
-    { name = "croniter" },
     { name = "loguru" },
     { name = "openai" },
     { name = "prompt-toolkit" },
     { name = "python-telegram-bot" },
+    { name = "setproctitle" },
     { name = "tyro" },
 ]
 
@@ -476,7 +464,6 @@ requires-dist = [
     { name = "aiohttp", specifier = ">=3.13.5" },
     { name = "anthropic", specifier = ">=0.57.1" },
     { name = "anyio", specifier = ">=4.13.0" },
-    { name = "croniter", specifier = ">=3.0.0" },
     { name = "loguru", specifier = ">=0.7.3" },
     { name = "openai", specifier = ">=1.30.0" },
     { name = "prompt-toolkit", specifier = ">=3.0.51" },
@@ -484,6 +471,7 @@ requires-dist = [
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=1.3.0" },
     { name = "python-telegram-bot", specifier = ">=22.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.15.12" },
+    { name = "setproctitle", specifier = ">=1.3.4" },
     { name = "ty", marker = "extra == 'dev'", specifier = ">=0.0.33" },
     { name = "tyro", specifier = ">=1.0.13" },
 ]
@@ -583,18 +571,6 @@ wheels = [
 ]
 
 [[package]]
-name = "python-dateutil"
-version = "2.9.0.post0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "six" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
-]
-
-[[package]]
 name = "python-telegram-bot"
 version = "22.7"
 source = { registry = "https://pypi.org/simple" }
@@ -633,12 +609,31 @@ wheels = [
 ]
 
 [[package]]
-name = "six"
-version = "1.17.0"
+name = "setproctitle"
+version = "1.3.7"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/8d/48/49393a96a2eef1ab418b17475fb92b8fcfad83d099e678751b05472e69de/setproctitle-1.3.7.tar.gz", hash = "sha256:bc2bc917691c1537d5b9bca1468437176809c7e11e5694ca79a9ca12345dcb9e", size = 27002, upload-time = "2025-09-05T12:51:25.278Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+    { url = "https://files.pythonhosted.org/packages/89/c7/43ac3a98414f91d1b86a276bc2f799ad0b4b010e08497a95750d5bc42803/setproctitle-1.3.7-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:80c36c6a87ff72eabf621d0c79b66f3bdd0ecc79e873c1e9f0651ee8bf215c63", size = 18052, upload-time = "2025-09-05T12:50:17.928Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/2c/dc258600a25e1a1f04948073826bebc55e18dbd99dc65a576277a82146fa/setproctitle-1.3.7-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:b53602371a52b91c80aaf578b5ada29d311d12b8a69c0c17fbc35b76a1fd4f2e", size = 13071, upload-time = "2025-09-05T12:50:19.061Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/26/8e3bb082992f19823d831f3d62a89409deb6092e72fc6940962983ffc94f/setproctitle-1.3.7-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:fcb966a6c57cf07cc9448321a08f3be6b11b7635be502669bc1d8745115d7e7f", size = 33180, upload-time = "2025-09-05T12:50:20.395Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/af/ae692a20276d1159dd0cf77b0bcf92cbb954b965655eb4a69672099bb214/setproctitle-1.3.7-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:46178672599b940368d769474fe13ecef1b587d58bb438ea72b9987f74c56ea5", size = 34043, upload-time = "2025-09-05T12:50:22.454Z" },
+    { url = "https://files.pythonhosted.org/packages/34/b2/6a092076324dd4dac1a6d38482bedebbff5cf34ef29f58585ec76e47bc9d/setproctitle-1.3.7-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:7f9e9e3ff135cbcc3edd2f4cf29b139f4aca040d931573102742db70ff428c17", size = 35892, upload-time = "2025-09-05T12:50:23.937Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/1a/8836b9f28cee32859ac36c3df85aa03e1ff4598d23ea17ca2e96b5845a8f/setproctitle-1.3.7-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:14c7eba8d90c93b0e79c01f0bd92a37b61983c27d6d7d5a3b5defd599113d60e", size = 32898, upload-time = "2025-09-05T12:50:25.617Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/22/8fabdc24baf42defb599714799d8445fe3ae987ec425a26ec8e80ea38f8e/setproctitle-1.3.7-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:9e64e98077fb30b6cf98073d6c439cd91deb8ebbf8fc62d9dbf52bd38b0c6ac0", size = 34308, upload-time = "2025-09-05T12:50:26.827Z" },
+    { url = "https://files.pythonhosted.org/packages/15/1b/b9bee9de6c8cdcb3b3a6cb0b3e773afdb86bbbc1665a3bfa424a4294fda2/setproctitle-1.3.7-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:b91387cc0f02a00ac95dcd93f066242d3cca10ff9e6153de7ee07069c6f0f7c8", size = 32536, upload-time = "2025-09-05T12:50:28.5Z" },
+    { url = "https://files.pythonhosted.org/packages/37/0c/75e5f2685a5e3eda0b39a8b158d6d8895d6daf3ba86dec9e3ba021510272/setproctitle-1.3.7-cp314-cp314-win32.whl", hash = "sha256:52b054a61c99d1b72fba58b7f5486e04b20fefc6961cd76722b424c187f362ed", size = 12731, upload-time = "2025-09-05T12:50:43.955Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/ae/acddbce90d1361e1786e1fb421bc25baeb0c22ef244ee5d0176511769ec8/setproctitle-1.3.7-cp314-cp314-win_amd64.whl", hash = "sha256:5818e4080ac04da1851b3ec71e8a0f64e3748bf9849045180566d8b736702416", size = 13464, upload-time = "2025-09-05T12:50:45.057Z" },
+    { url = "https://files.pythonhosted.org/packages/01/6d/20886c8ff2e6d85e3cabadab6aab9bb90acaf1a5cfcb04d633f8d61b2626/setproctitle-1.3.7-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:6fc87caf9e323ac426910306c3e5d3205cd9f8dcac06d233fcafe9337f0928a3", size = 18062, upload-time = "2025-09-05T12:50:29.78Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/60/26dfc5f198715f1343b95c2f7a1c16ae9ffa45bd89ffd45a60ed258d24ea/setproctitle-1.3.7-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:6134c63853d87a4897ba7d5cc0e16abfa687f6c66fc09f262bb70d67718f2309", size = 13075, upload-time = "2025-09-05T12:50:31.604Z" },
+    { url = "https://files.pythonhosted.org/packages/21/9c/980b01f50d51345dd513047e3ba9e96468134b9181319093e61db1c47188/setproctitle-1.3.7-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:1403d2abfd32790b6369916e2313dffbe87d6b11dca5bbd898981bcde48e7a2b", size = 34744, upload-time = "2025-09-05T12:50:32.777Z" },
+    { url = "https://files.pythonhosted.org/packages/86/b4/82cd0c86e6d1c4538e1a7eb908c7517721513b801dff4ba3f98ef816a240/setproctitle-1.3.7-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e7c5bfe4228ea22373e3025965d1a4116097e555ee3436044f5c954a5e63ac45", size = 35589, upload-time = "2025-09-05T12:50:34.13Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/4f/9f6b2a7417fd45673037554021c888b31247f7594ff4bd2239918c5cd6d0/setproctitle-1.3.7-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:585edf25e54e21a94ccb0fe81ad32b9196b69ebc4fc25f81da81fb8a50cca9e4", size = 37698, upload-time = "2025-09-05T12:50:35.524Z" },
+    { url = "https://files.pythonhosted.org/packages/20/92/927b7d4744aac214d149c892cb5fa6dc6f49cfa040cb2b0a844acd63dcaf/setproctitle-1.3.7-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:96c38cdeef9036eb2724c2210e8d0b93224e709af68c435d46a4733a3675fee1", size = 34201, upload-time = "2025-09-05T12:50:36.697Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/0c/fd4901db5ba4b9d9013e62f61d9c18d52290497f956745cd3e91b0d80f90/setproctitle-1.3.7-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:45e3ef48350abb49cf937d0a8ba15e42cee1e5ae13ca41a77c66d1abc27a5070", size = 35801, upload-time = "2025-09-05T12:50:38.314Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/e3/54b496ac724e60e61cc3447f02690105901ca6d90da0377dffe49ff99fc7/setproctitle-1.3.7-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:1fae595d032b30dab4d659bece20debd202229fce12b55abab978b7f30783d73", size = 33958, upload-time = "2025-09-05T12:50:39.841Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/a8/c84bb045ebf8c6fdc7f7532319e86f8380d14bbd3084e6348df56bdfe6fd/setproctitle-1.3.7-cp314-cp314t-win32.whl", hash = "sha256:02432f26f5d1329ab22279ff863c83589894977063f59e6c4b4845804a08f8c2", size = 12745, upload-time = "2025-09-05T12:50:41.377Z" },
+    { url = "https://files.pythonhosted.org/packages/08/b6/3a5a4f9952972791a9114ac01dfc123f0df79903577a3e0a7a404a695586/setproctitle-1.3.7-cp314-cp314t-win_amd64.whl", hash = "sha256:cbc388e3d86da1f766d8fc2e12682e446064c01cea9f88a88647cfe7c011de6a", size = 13469, upload-time = "2025-09-05T12:50:42.67Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Hide API keys and tokens from process listings (`ps`, `top`, `/proc/<pid>/cmdline`) using `setproctitle`
- Prevents credential exposure in multi-user environments

## Changes

- Add `setproctitle` dependency to pyproject.toml
- Create `psi_agent.utils.proctitle.mask_sensitive_args()` utility function
- Update CLI entry points to mask sensitive arguments:
  - `psi-ai-openai-completions`: mask `--api-key`
  - `psi-ai-anthropic-messages`: mask `--api-key`
  - `psi-channel-telegram`: mask `--token`
- Add CLI security principle to CLAUDE.md
- Add unit tests for `mask_sensitive_args()`

## Test plan

- [x] `ruff check` and `ruff format` pass
- [x] `ty check` passes
- [x] `pytest` - 6 new tests pass
- [x] Manual test: verified process title shows `***` instead of sensitive values

🤖 Generated with [Claude Code](https://claude.com/claude-code)