### PR TITLE
Fix standalone CLI entry points not executing

### DIFF
--- a/openspec/changes/archive/2026-04-29-fix-ai-component-immediate-exit/.openspec.yaml
+++ b/openspec/changes/archive/2026-04-29-fix-ai-component-immediate-exit/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-28

--- a/openspec/changes/archive/2026-04-29-fix-ai-component-immediate-exit/design.md
+++ b/openspec/changes/archive/2026-04-29-fix-ai-component-immediate-exit/design.md
@@ -1,0 +1,48 @@
+## Context
+
+During the recent CLI refactor to support `psi-agent` as a unified entry point, all standalone CLI entry points were updated to use tyro. However, a critical bug was introduced: `tyro.cli()` returns a callable dataclass instance, but the standalone `main()` functions never call it.
+
+The unified CLI in `__main__.py` works correctly because it explicitly calls the result:
+```python
+result = tyro.cli(top_commands, prog_name="psi-agent")
+result()  # <-- This call is present
+```
+
+But all standalone entry points defined in `pyproject.toml` are missing this call:
+```python
+def main() -> None:
+    tyro.cli(SomeCommand)  # <-- Missing () to call the result
+```
+
+## Goals / Non-Goals
+
+**Goals:**
+- Fix all 11 standalone CLI entry points to call the returned object
+- Ensure backward compatibility - existing command-line usage should work as before
+- Minimal code change - single line fix per file
+
+**Non-Goals:**
+- Refactoring CLI structure
+- Adding new features
+- Changing the unified `psi-agent` CLI (it already works)
+
+## Decisions
+
+### Decision 1: Add `()` call to each `main()` function
+
+**Rationale:** This is the simplest and most direct fix. It matches the pattern used in `__main__.py` which already works correctly.
+
+**Alternatives considered:**
+- Use `tyro.cli(..., call=True)` - tyro doesn't support this parameter
+- Change `main()` to return the callable and let the entry point call it - more complex, changes semantics
+
+**Chosen approach:** Add `()` after each `tyro.cli()` call:
+```python
+def main() -> None:
+    tyro.cli(SomeCommand)()
+```
+
+## Risks / Trade-offs
+
+- **Risk: Tests may need updates** → Mitigation: Run existing tests after fix, update if needed
+- **Risk: Behavior change visible to users** → Mitigation: This restores expected behavior, not a breaking change

--- a/openspec/changes/archive/2026-04-29-fix-ai-component-immediate-exit/proposal.md
+++ b/openspec/changes/archive/2026-04-29-fix-ai-component-immediate-exit/proposal.md
@@ -1,0 +1,37 @@
+## Why
+
+All standalone CLI entry points (e.g., `psi-ai-openai-completions`, `psi-session`, `psi-channel-*`, `psi-workspace-*`) immediately exit without executing any code. This is caused by a bug introduced during the recent CLI refactor: `tyro.cli()` returns a callable dataclass instance but the code never calls it.
+
+The unified `psi-agent` CLI works correctly because `__main__.py` explicitly calls the result: `result()`. However, all standalone entry points defined in `pyproject.toml` are broken.
+
+## What Changes
+
+- Fix all standalone CLI `main()` functions to call the returned object from `tyro.cli()`
+- Affected entry points:
+  - `psi-ai-openai-completions`
+  - `psi-ai-anthropic-messages`
+  - `psi-session`
+  - `psi-channel-cli`
+  - `psi-channel-repl`
+  - `psi-channel-telegram`
+  - `psi-workspace-pack`
+  - `psi-workspace-unpack`
+  - `psi-workspace-mount`
+  - `psi-workspace-umount`
+  - `psi-workspace-snapshot`
+
+## Capabilities
+
+### New Capabilities
+
+None - this is a bug fix, no new capabilities are introduced.
+
+### Modified Capabilities
+
+None - this is a bug fix at the implementation level, no spec-level behavior changes.
+
+## Impact
+
+- **Affected files**: All CLI modules in `src/psi_agent/`
+- **User impact**: Standalone commands like `uv run psi-ai-openai-completions` will work again
+- **No breaking changes**: The fix restores expected behavior

--- a/openspec/changes/archive/2026-04-29-fix-ai-component-immediate-exit/specs/no-spec-changes.md
+++ b/openspec/changes/archive/2026-04-29-fix-ai-component-immediate-exit/specs/no-spec-changes.md
@@ -1,0 +1,3 @@
+This is a bug fix with no spec-level behavior changes. No new or modified capabilities are introduced.
+
+The fix restores the expected behavior defined in existing CLI specifications.

--- a/openspec/changes/archive/2026-04-29-fix-ai-component-immediate-exit/tasks.md
+++ b/openspec/changes/archive/2026-04-29-fix-ai-component-immediate-exit/tasks.md
@@ -1,0 +1,30 @@
+## 1. Fix AI Component CLIs
+
+- [x] 1.1 Fix `src/psi_agent/ai/openai_completions/cli.py` - add `()` to `tyro.cli(OpenaiCompletions)`
+- [x] 1.2 Fix `src/psi_agent/ai/anthropic_messages/cli.py` - add `()` to `tyro.cli(AnthropicMessages)`
+
+## 2. Fix Session CLI
+
+- [x] 2.1 Fix `src/psi_agent/session/cli.py` - add `()` to `tyro.cli(Session)`
+
+## 3. Fix Channel CLIs
+
+- [x] 3.1 Fix `src/psi_agent/channel/cli/cli.py` - add `()` to `tyro.cli(Cli)`
+- [x] 3.2 Fix `src/psi_agent/channel/repl/cli.py` - add `()` to `tyro.cli(Repl)`
+- [x] 3.3 Fix `src/psi_agent/channel/telegram/cli.py` - add `()` to `tyro.cli(Telegram)`
+
+## 4. Fix Workspace CLIs
+
+- [x] 4.1 Fix `src/psi_agent/workspace/pack/cli.py` - add `()` to `tyro.cli(Pack)`
+- [x] 4.2 Fix `src/psi_agent/workspace/unpack/cli.py` - add `()` to `tyro.cli(Unpack)`
+- [x] 4.3 Fix `src/psi_agent/workspace/mount/cli.py` - add `()` to `tyro.cli(Mount)`
+- [x] 4.4 Fix `src/psi_agent/workspace/umount/cli.py` - add `()` to `tyro.cli(Umount)`
+- [x] 4.5 Fix `src/psi_agent/workspace/snapshot/cli.py` - add `()` to `tyro.cli(Snapshot)`
+
+## 5. Verification
+
+- [x] 5.1 Run `uv run psi-ai-openai-completions --help` to verify CLI works
+- [x] 5.2 Run `uv run psi-session --help` to verify CLI works
+- [x] 5.3 Run `uv run psi-channel-telegram --help` to verify CLI works
+- [x] 5.4 Run `uv run psi-workspace-pack --help` to verify CLI works
+- [x] 5.5 Run existing tests to ensure no regressions

--- a/src/psi_agent/ai/anthropic_messages/cli.py
+++ b/src/psi_agent/ai/anthropic_messages/cli.py
@@ -52,7 +52,7 @@ class AnthropicMessages:
 
 def main() -> None:
     """Main entry point for CLI."""
-    tyro.cli(AnthropicMessages)
+    tyro.cli(AnthropicMessages)()
 
 
 if __name__ == "__main__":

--- a/src/psi_agent/ai/openai_completions/cli.py
+++ b/src/psi_agent/ai/openai_completions/cli.py
@@ -52,7 +52,7 @@ class OpenaiCompletions:
 
 def main() -> None:
     """Main entry point for CLI."""
-    tyro.cli(OpenaiCompletions)
+    tyro.cli(OpenaiCompletions)()
 
 
 if __name__ == "__main__":

--- a/src/psi_agent/channel/cli/cli.py
+++ b/src/psi_agent/channel/cli/cli.py
@@ -133,7 +133,7 @@ class Cli:
 
 def main() -> None:
     """Main entry point for CLI."""
-    tyro.cli(Cli)
+    tyro.cli(Cli)()
 
 
 if __name__ == "__main__":

--- a/src/psi_agent/channel/repl/cli.py
+++ b/src/psi_agent/channel/repl/cli.py
@@ -30,7 +30,7 @@ class Repl:
 
 def main() -> None:
     """Main entry point for CLI."""
-    tyro.cli(Repl)
+    tyro.cli(Repl)()
 
 
 if __name__ == "__main__":

--- a/src/psi_agent/channel/telegram/cli.py
+++ b/src/psi_agent/channel/telegram/cli.py
@@ -31,7 +31,7 @@ class Telegram:
 
 def main() -> None:
     """Main entry point for CLI."""
-    tyro.cli(Telegram)
+    tyro.cli(Telegram)()
 
 
 if __name__ == "__main__":

--- a/src/psi_agent/session/cli.py
+++ b/src/psi_agent/session/cli.py
@@ -52,7 +52,7 @@ class Session:
 
 def main() -> None:
     """Main entry point for CLI."""
-    tyro.cli(Session)
+    tyro.cli(Session)()
 
 
 if __name__ == "__main__":

--- a/src/psi_agent/workspace/mount/cli.py
+++ b/src/psi_agent/workspace/mount/cli.py
@@ -24,7 +24,7 @@ class Mount:
 
 def main() -> None:
     """CLI entry point."""
-    tyro.cli(Mount)
+    tyro.cli(Mount)()
 
 
 if __name__ == "__main__":

--- a/src/psi_agent/workspace/pack/cli.py
+++ b/src/psi_agent/workspace/pack/cli.py
@@ -24,7 +24,7 @@ class Pack:
 
 def main() -> None:
     """CLI entry point."""
-    tyro.cli(Pack)
+    tyro.cli(Pack)()
 
 
 if __name__ == "__main__":

--- a/src/psi_agent/workspace/snapshot/cli.py
+++ b/src/psi_agent/workspace/snapshot/cli.py
@@ -25,7 +25,7 @@ class Snapshot:
 
 def main() -> None:
     """CLI entry point."""
-    tyro.cli(Snapshot)
+    tyro.cli(Snapshot)()
 
 
 if __name__ == "__main__":

--- a/src/psi_agent/workspace/umount/cli.py
+++ b/src/psi_agent/workspace/umount/cli.py
@@ -22,7 +22,7 @@ class Umount:
 
 def main() -> None:
     """CLI entry point."""
-    tyro.cli(Umount)
+    tyro.cli(Umount)()
 
 
 if __name__ == "__main__":

--- a/src/psi_agent/workspace/unpack/cli.py
+++ b/src/psi_agent/workspace/unpack/cli.py
@@ -23,7 +23,7 @@ class Unpack:
 
 def main() -> None:
     """CLI entry point."""
-    tyro.cli(Unpack)
+    tyro.cli(Unpack)()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Fix all standalone CLI entry points (psi-ai-*, psi-session, psi-channel-*, psi-workspace-*) that were immediately exiting without executing
- Root cause: `tyro.cli()` returns a callable dataclass instance but the code never called it
- Add `()` to call the returned object in all 11 standalone `main()` functions

## Problem
Commands like `uv run psi-ai-openai-completions --session-socket ./sock --model test --api-key test` would exit silently without any error message.

The unified `psi-agent` CLI worked correctly because `__main__.py` explicitly calls the result: `result()`. All standalone entry points were missing this call.

## Test plan
- [x] `uv run psi-ai-openai-completions --help` shows help
- [x] `uv run psi-session --help` shows help
- [x] `uv run psi-channel-telegram --help` shows help
- [x] `uv run psi-workspace-pack --help` shows help
- [x] All 160 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)