### PR TITLE
Update CLI documentation to prefer subcommand interface

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -599,10 +599,15 @@ async def tool(file_path: str) -> str:
 
 ### 启动命令示例
 
+psi-agent 提供两种 CLI 接口：
+
+1. **子命令接口（推荐）**：`psi-agent <组件> <子命令>`
+2. **独立命令**：`psi-<组件>-<子命令>`
+
 启动 session：
 
 ```bash
-uv run psi-session \
+psi-agent session \
   --workspace ./workspace \
   --channel-socket ./channel.sock \
   --ai-socket ./ai.sock
@@ -611,16 +616,16 @@ uv run psi-session \
 启动 AI 组件（OpenRouter 示例）：
 
 ```bash
-uv run psi-ai-openai-completions \
+psi-agent ai openai-completions \
   --session-socket ./ai.sock \
   --model tencent/hy3-preview:free \
   --api-key sk-or-v1-xxxxxx \
   --base-url https://openrouter.ai/api/v1
 ```
 
-启动 channel（TUI 示例）：
+启动 channel（REPL 示例）：
 
 ```bash
-uv run psi-channel-tui \
+psi-agent channel repl \
   --session-socket ./channel.sock
 ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -604,10 +604,12 @@ psi-agent 提供两种 CLI 接口：
 1. **子命令接口（推荐）**：`psi-agent <组件> <子命令>`
 2. **独立命令**：`psi-<组件>-<子命令>`
 
+> **开发时运行方式**：在开发过程中，使用 `uv run psi-agent ...` 来运行命令。安装后可直接使用 `psi-agent ...`。
+
 启动 session：
 
 ```bash
-psi-agent session \
+uv run psi-agent session \
   --workspace ./workspace \
   --channel-socket ./channel.sock \
   --ai-socket ./ai.sock
@@ -616,7 +618,7 @@ psi-agent session \
 启动 AI 组件（OpenRouter 示例）：
 
 ```bash
-psi-agent ai openai-completions \
+uv run psi-agent ai openai-completions \
   --session-socket ./ai.sock \
   --model tencent/hy3-preview:free \
   --api-key sk-or-v1-xxxxxx \
@@ -626,6 +628,6 @@ psi-agent ai openai-completions \
 启动 channel（REPL 示例）：
 
 ```bash
-psi-agent channel repl \
+uv run psi-agent channel repl \
   --session-socket ./channel.sock
 ```

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ mkdir -p workspace/{tools,skills,systems}
 2. Start the session with an AI provider:
 
 ```bash
-uv run psi-session \
+psi-agent session \
   --workspace ./workspace \
   --channel-socket ./channel.sock \
   --ai-socket ./ai.sock
@@ -54,7 +54,7 @@ uv run psi-session \
 3. Start an AI component (e.g., OpenAI-compatible):
 
 ```bash
-uv run psi-ai-openai-completions \
+psi-agent ai openai-completions \
   --session-socket ./ai.sock \
   --model <model-name> \
   --api-key <your-api-key> \
@@ -64,8 +64,24 @@ uv run psi-ai-openai-completions \
 4. Start a channel to interact with your agent:
 
 ```bash
-uv run psi-channel-repl --session-socket ./channel.sock
+psi-agent channel repl --session-socket ./channel.sock
 ```
+
+## CLI Interfaces
+
+psi-agent provides two CLI interfaces:
+
+1. **Subcommand interface (preferred)**: `psi-agent <component> <subcommand>`
+   - Works with `uvx` without cloning the repository
+   - Single entry point, easier to discover
+   - Examples: `psi-agent ai openai-completions`, `psi-agent channel repl`
+
+2. **Standalone commands**: `psi-<component>-<subcommand>`
+   - Shorter to type
+   - Useful in scripts
+   - Examples: `psi-ai-openai-completions`, `psi-channel-repl`
+
+Both interfaces are functionally identical. The subcommand interface is recommended for general use.
 
 ## Components
 
@@ -78,20 +94,35 @@ psi-agent consists of four component types:
 | `psi-channel-*` | Message channels (REPL, Telegram, Feishu, etc.) |
 | `psi-workspace-*` | Workspace packaging and mounting tools |
 
-### Available Scripts
+### Available Commands
 
-After installation, these CLI tools are available:
+After installation, these commands are available:
 
-- `psi-ai-openai-completions` - OpenAI-compatible completion server
-- `psi-ai-anthropic-messages` - Anthropic messages server
-- `psi-session` - Agent session runtime
-- `psi-channel-repl` - Interactive REPL interface
-- `psi-channel-cli` - CLI channel interface
-- `psi-workspace-pack` - Package workspace to squashfs
-- `psi-workspace-unpack` - Extract squashfs to directory
-- `psi-workspace-mount` - Mount squashfs as overlayfs
-- `psi-workspace-umount` - Unmount workspace
-- `psi-workspace-snapshot` - Create workspace snapshot
+**Subcommand format (preferred):**
+- `psi-agent ai openai-completions` - OpenAI-compatible completion server
+- `psi-agent ai anthropic-messages` - Anthropic messages server
+- `psi-agent session` - Agent session runtime
+- `psi-agent channel repl` - Interactive REPL interface
+- `psi-agent channel cli` - CLI channel interface
+- `psi-agent channel telegram` - Telegram bot channel
+- `psi-agent workspace pack` - Package workspace to squashfs
+- `psi-agent workspace unpack` - Extract squashfs to directory
+- `psi-agent workspace mount` - Mount squashfs as overlayfs
+- `psi-agent workspace umount` - Unmount workspace
+- `psi-agent workspace snapshot` - Create workspace snapshot
+
+**Standalone format (also available):**
+- `psi-ai-openai-completions`
+- `psi-ai-anthropic-messages`
+- `psi-session`
+- `psi-channel-repl`
+- `psi-channel-cli`
+- `psi-channel-telegram`
+- `psi-workspace-pack`
+- `psi-workspace-unpack`
+- `psi-workspace-mount`
+- `psi-workspace-umount`
+- `psi-workspace-snapshot`
 
 ## Documentation
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -45,7 +45,7 @@ mkdir -p workspace/{tools,skills,systems}
 2. 启动 session 和 AI provider：
 
 ```bash
-uv run psi-session \
+psi-agent session \
   --workspace ./workspace \
   --channel-socket ./channel.sock \
   --ai-socket ./ai.sock
@@ -54,7 +54,7 @@ uv run psi-session \
 3. 启动 AI 组件（例如 OpenAI 兼容接口）：
 
 ```bash
-uv run psi-ai-openai-completions \
+psi-agent ai openai-completions \
   --session-socket ./ai.sock \
   --model <模型名称> \
   --api-key <你的-api-key> \
@@ -64,8 +64,24 @@ uv run psi-ai-openai-completions \
 4. 启动 channel 与 agent 交互：
 
 ```bash
-uv run psi-channel-repl --session-socket ./channel.sock
+psi-agent channel repl --session-socket ./channel.sock
 ```
+
+## CLI 接口
+
+psi-agent 提供两种 CLI 接口：
+
+1. **子命令接口（推荐）**：`psi-agent <组件> <子命令>`
+   - 无需克隆仓库即可通过 `uvx` 使用
+   - 单一入口点，更易发现
+   - 示例：`psi-agent ai openai-completions`、`psi-agent channel repl`
+
+2. **独立命令**：`psi-<组件>-<子命令>`
+   - 输入更短
+   - 适合脚本中使用
+   - 示例：`psi-ai-openai-completions`、`psi-channel-repl`
+
+两种接口功能完全相同。推荐使用子命令接口。
 
 ## 组件
 
@@ -78,20 +94,35 @@ psi-agent 包含四种组件类型：
 | `psi-channel-*` | 消息通道（REPL、Telegram、飞书等） |
 | `psi-workspace-*` | Workspace 打包和挂载工具 |
 
-### 可用脚本
+### 可用命令
 
-安装后，以下 CLI 工具可用：
+安装后，以下命令可用：
 
-- `psi-ai-openai-completions` - OpenAI 兼容的 completion 服务器
-- `psi-ai-anthropic-messages` - Anthropic messages 服务器
-- `psi-session` - Agent session 运行时
-- `psi-channel-repl` - 交互式 REPL 界面
-- `psi-channel-cli` - CLI channel 接口
-- `psi-workspace-pack` - 将 workspace 打包为 squashfs
-- `psi-workspace-unpack` - 将 squashfs 解压为目录
-- `psi-workspace-mount` - 将 squashfs 挂载为 overlayfs
-- `psi-workspace-umount` - 卸载 workspace
-- `psi-workspace-snapshot` - 创建 workspace 快照
+**子命令格式（推荐）：**
+- `psi-agent ai openai-completions` - OpenAI 兼容的 completion 服务器
+- `psi-agent ai anthropic-messages` - Anthropic messages 服务器
+- `psi-agent session` - Agent session 运行时
+- `psi-agent channel repl` - 交互式 REPL 界面
+- `psi-agent channel cli` - CLI channel 接口
+- `psi-agent channel telegram` - Telegram bot channel
+- `psi-agent workspace pack` - 将 workspace 打包为 squashfs
+- `psi-agent workspace unpack` - 将 squashfs 解压为目录
+- `psi-agent workspace mount` - 将 squashfs 挂载为 overlayfs
+- `psi-agent workspace umount` - 卸载 workspace
+- `psi-agent workspace snapshot` - 创建 workspace 快照
+
+**独立命令格式（同样可用）：**
+- `psi-ai-openai-completions`
+- `psi-ai-anthropic-messages`
+- `psi-session`
+- `psi-channel-repl`
+- `psi-channel-cli`
+- `psi-channel-telegram`
+- `psi-workspace-pack`
+- `psi-workspace-unpack`
+- `psi-workspace-mount`
+- `psi-workspace-umount`
+- `psi-workspace-snapshot`
 
 ## 文档
 

--- a/openspec/changes/archive/2026-04-29-add-uv-run-cli-examples/.openspec.yaml
+++ b/openspec/changes/archive/2026-04-29-add-uv-run-cli-examples/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-28

--- a/openspec/changes/archive/2026-04-29-add-uv-run-cli-examples/design.md
+++ b/openspec/changes/archive/2026-04-29-add-uv-run-cli-examples/design.md
@@ -1,0 +1,31 @@
+## Context
+
+CLAUDE.md serves as the developer guide for the project. Currently, the "启动命令示例" section shows commands like `psi-agent session ...` without explaining that during development, `uv run` prefix is needed.
+
+Developers working on the project typically:
+1. Clone the repository
+2. Run commands with `uv run psi-agent ...` during development
+3. Use `psi-agent ...` directly only after installing the package
+
+## Goals / Non-Goals
+
+**Goals:**
+- Add `uv run` prefix to CLI examples in CLAUDE.md
+- Explain when to use `uv run` vs direct command
+
+**Non-Goals:**
+- Change README.md (that's for end users who install the package)
+- Change any CLI behavior
+
+## Decisions
+
+### Decision 1: Use `uv run psi-agent ...` in CLAUDE.md examples
+
+**Rationale:**
+- CLAUDE.md is for developers working on the project
+- During development, `uv run` is the standard way to run commands
+- Makes examples directly copy-pasteable for developers
+
+## Risks / Trade-offs
+
+- **Risk: Confusion between README and CLAUDE.md** → Mitigation: Add clear note explaining the difference

--- a/openspec/changes/archive/2026-04-29-add-uv-run-cli-examples/proposal.md
+++ b/openspec/changes/archive/2026-04-29-add-uv-run-cli-examples/proposal.md
@@ -1,0 +1,24 @@
+## Why
+
+CLAUDE.md currently shows CLI examples without the `uv run` prefix, but during development the most common way to run commands is `uv run psi-agent ...`. This should be explicitly documented for developers working on the project.
+
+## What Changes
+
+- Update CLAUDE.md "启动命令示例" section to show `uv run psi-agent ...` as the development-time running method
+- Explain that `uv run` is used during development, while `psi-agent` (without prefix) is used after installation
+
+## Capabilities
+
+### New Capabilities
+
+None - this is documentation improvement only.
+
+### Modified Capabilities
+
+None - no spec-level behavior changes.
+
+## Impact
+
+- **Affected files**: CLAUDE.md
+- **User impact**: Developers will have clearer guidance on how to run commands during development
+- **No breaking changes**: Documentation only

--- a/openspec/changes/archive/2026-04-29-add-uv-run-cli-examples/specs/no-spec-changes.md
+++ b/openspec/changes/archive/2026-04-29-add-uv-run-cli-examples/specs/no-spec-changes.md
@@ -1,0 +1,1 @@
+This is a documentation update with no spec-level behavior changes. No new or modified capabilities are introduced.

--- a/openspec/changes/archive/2026-04-29-add-uv-run-cli-examples/tasks.md
+++ b/openspec/changes/archive/2026-04-29-add-uv-run-cli-examples/tasks.md
@@ -1,0 +1,8 @@
+## 1. Update CLAUDE.md
+
+- [x] 1.1 Update "启动命令示例" section to add `uv run` prefix to all examples
+- [x] 1.2 Add note explaining that `uv run` is used during development, while direct `psi-agent` command is used after installation
+
+## 2. Verification
+
+- [x] 2.1 Verify CLAUDE.md renders correctly

--- a/openspec/changes/archive/2026-04-29-update-cli-docs-prefer-subcommand/.openspec.yaml
+++ b/openspec/changes/archive/2026-04-29-update-cli-docs-prefer-subcommand/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-28

--- a/openspec/changes/archive/2026-04-29-update-cli-docs-prefer-subcommand/design.md
+++ b/openspec/changes/archive/2026-04-29-update-cli-docs-prefer-subcommand/design.md
@@ -1,0 +1,52 @@
+## Context
+
+psi-agent now has two CLI interfaces:
+1. **Unified subcommand interface**: `psi-agent <component> <subcommand>` (e.g., `psi-agent ai openai-completions`)
+2. **Standalone commands**: `psi-<component>-<subcommand>` (e.g., `psi-ai-openai-completions`)
+
+The unified interface was introduced to support `uvx psi-agent` without requiring repository clone. Both interfaces work identically, but documentation currently shows standalone commands as primary examples.
+
+Current state:
+- README.md Quick Start uses standalone commands
+- CLAUDE.md examples use standalone commands
+- central-cli spec mentions equivalence but doesn't state preference
+- user-readme spec doesn't mention unified interface
+
+## Goals / Non-Goals
+
+**Goals:**
+- Document both CLI interfaces clearly
+- State that subcommand interface is preferred
+- Update all examples in README and CLAUDE.md to use subcommand style
+- Update specs to reflect preference
+
+**Non-Goals:**
+- Remove standalone commands (they remain for backward compatibility)
+- Change any CLI behavior
+- Update tests (no functional changes)
+
+## Decisions
+
+### Decision 1: Subcommand interface is preferred
+
+**Rationale:**
+- Works with `uvx psi-agent` without cloning repository
+- Single entry point is easier to discover
+- Consistent with modern CLI patterns (e.g., `git`, `docker`)
+- Better for users who just want to try the tool
+
+**Alternatives considered:**
+- Keep standalone as preferred: Doesn't support uvx workflow well
+- Remove standalone entirely: Breaking change, unnecessary
+
+### Decision 2: Keep standalone commands documented
+
+**Rationale:**
+- Backward compatibility
+- Some users may prefer shorter commands
+- Useful in scripts where subcommand nesting is verbose
+
+## Risks / Trade-offs
+
+- **Risk: User confusion about which to use** → Mitigation: Clear documentation stating preference
+- **Risk: Existing docs/tutorials become outdated** → Mitigation: Both interfaces work, just preference change

--- a/openspec/changes/archive/2026-04-29-update-cli-docs-prefer-subcommand/proposal.md
+++ b/openspec/changes/archive/2026-04-29-update-cli-docs-prefer-subcommand/proposal.md
@@ -1,0 +1,28 @@
+## Why
+
+The CLI documentation currently uses standalone commands (e.g., `psi-ai-openai-completions`) as the primary examples, but the unified subcommand interface (`psi-agent ai openai-completions`) is now the preferred way. Documentation needs to be updated to reflect this preference and clearly explain both interfaces.
+
+## What Changes
+
+- Update README.md to document both CLI interfaces with subcommand style as preferred
+- Update README_zh.md (if exists) with same changes
+- Update CLAUDE.md examples to use subcommand style
+- Update central-cli spec to clarify subcommand is preferred over standalone commands
+- Add clear explanation of both interfaces and when to use each
+
+## Capabilities
+
+### New Capabilities
+
+None - this is documentation update only.
+
+### Modified Capabilities
+
+- `central-cli`: Add requirement that subcommand interface is preferred
+- `user-readme`: Update to document both CLI interfaces with preference guidance
+
+## Impact
+
+- **Affected files**: README.md, README_zh.md, CLAUDE.md, openspec/specs/central-cli/spec.md, openspec/specs/user-readme/spec.md
+- **User impact**: Clearer documentation on which CLI interface to use
+- **No breaking changes**: Both interfaces continue to work

--- a/openspec/changes/archive/2026-04-29-update-cli-docs-prefer-subcommand/specs/central-cli/spec.md
+++ b/openspec/changes/archive/2026-04-29-update-cli-docs-prefer-subcommand/specs/central-cli/spec.md
@@ -1,0 +1,25 @@
+## MODIFIED Requirements
+
+### Requirement: README documentation
+The system SHALL have brief documentation in README files mentioning the unified CLI interface as the preferred method.
+
+#### Scenario: README mentions unified CLI
+- **WHEN** user reads README.md or README_CN.md
+- **THEN** there is a sentence explaining `uvx psi-agent <subcommand>` usage
+- **AND** the subcommand interface is marked as preferred over standalone commands
+
+## ADDED Requirements
+
+### Requirement: Subcommand interface is preferred
+The system SHALL document that `psi-agent <component> <subcommand>` is the preferred CLI interface over standalone commands like `psi-ai-openai-completions`.
+
+#### Scenario: Documentation shows preference
+- **WHEN** user reads documentation (README, CLAUDE.md)
+- **THEN** examples primarily use subcommand format
+- **AND** there is a note explaining standalone commands are also available for backward compatibility
+
+#### Scenario: Both interfaces documented
+- **WHEN** user reads the CLI documentation
+- **THEN** they understand both interfaces exist
+- **AND** they know subcommand interface works with `uvx` without cloning
+- **AND** they know standalone commands are shorter but less discoverable

--- a/openspec/changes/archive/2026-04-29-update-cli-docs-prefer-subcommand/specs/user-readme/spec.md
+++ b/openspec/changes/archive/2026-04-29-update-cli-docs-prefer-subcommand/specs/user-readme/spec.md
@@ -1,11 +1,4 @@
-## ADDED Requirements
-
-### Requirement: README.md exists with user-facing content
-The project SHALL have a README.md file in the root directory that provides a user-friendly introduction to the project.
-
-#### Scenario: User views README.md
-- **WHEN** a user opens the repository or PyPI page
-- **THEN** they see a README.md with project introduction, installation instructions, and quick start guide
+## MODIFIED Requirements
 
 ### Requirement: README.md contains essential sections
 The README.md SHALL include the following sections:
@@ -22,29 +15,6 @@ The README.md SHALL include the following sections:
 - **THEN** they can quickly understand what psi-agent is, how to install it, and how to get started
 - **AND** they can switch to the Chinese version via the language link
 - **AND** they understand that `psi-agent <component> <subcommand>` is the preferred interface
-
-### Requirement: pyproject.toml references README.md
-The pyproject.toml file SHALL reference README.md in the `readme` field.
-
-#### Scenario: PyPI displays README.md
-- **WHEN** the package is published to PyPI
-- **THEN** the README.md content is displayed on the package page
-
-### Requirement: Chinese README uses common naming convention
-The Chinese README SHALL be named `README_zh.md` following common conventions.
-
-#### Scenario: User accesses Chinese README
-- **WHEN** a user wants to read the Chinese documentation
-- **THEN** they can find it at `README_zh.md`
-
-### Requirement: Language switch links are provided
-Both README.md and README_zh.md SHALL provide language switch links at the top of the file.
-
-#### Scenario: User switches language
-- **WHEN** a user is reading README.md
-- **THEN** they see a link to README_zh.md at the top
-- **WHEN** a user is reading README_zh.md
-- **THEN** they see a link to README.md at the top
 
 ### Requirement: README.md documents both CLI interfaces
 The README.md SHALL document both the unified subcommand interface and standalone commands, clearly stating that the subcommand interface is preferred.

--- a/openspec/changes/archive/2026-04-29-update-cli-docs-prefer-subcommand/tasks.md
+++ b/openspec/changes/archive/2026-04-29-update-cli-docs-prefer-subcommand/tasks.md
@@ -1,0 +1,22 @@
+## 1. Update README.md
+
+- [x] 1.1 Update Quick Start section to use subcommand format (`psi-agent session`, `psi-agent ai openai-completions`, `psi-agent channel repl`)
+- [x] 1.2 Add note explaining both CLI interfaces and that subcommand is preferred
+- [x] 1.3 Update Available Scripts section to show both interfaces with preference note
+
+## 2. Update README_zh.md
+
+- [x] 2.1 Update Quick Start section to use subcommand format (same as README.md)
+- [x] 2.2 Add note explaining both CLI interfaces and that subcommand is preferred
+- [x] 2.3 Update Available Scripts section to show both interfaces with preference note
+
+## 3. Update CLAUDE.md
+
+- [x] 3.1 Update "启动命令示例" section to use subcommand format
+- [x] 3.2 Update any other CLI examples throughout the document
+
+## 4. Verification
+
+- [x] 4.1 Verify README.md renders correctly
+- [x] 4.2 Verify README_zh.md renders correctly
+- [x] 4.3 Verify CLAUDE.md examples are consistent

--- a/openspec/specs/central-cli/spec.md
+++ b/openspec/specs/central-cli/spec.md
@@ -41,11 +41,12 @@ The system SHALL be invocable via `uvx psi-agent <subcommand>` without requiring
 - **THEN** system displays help text and exits successfully
 
 ### Requirement: README documentation
-The system SHALL have brief documentation in README files mentioning the unified CLI interface.
+The system SHALL have brief documentation in README files mentioning the unified CLI interface as the preferred method.
 
 #### Scenario: README mentions unified CLI
 - **WHEN** user reads README.md or README_CN.md
 - **THEN** there is a sentence explaining `uvx psi-agent <subcommand>` usage
+- **AND** the subcommand interface is marked as preferred over standalone commands
 
 ### Requirement: Intermediate help support
 The system SHALL provide help text at all command levels using tyro's native subcommand mechanism.
@@ -57,3 +58,17 @@ The system SHALL provide help text at all command levels using tyro's native sub
 #### Scenario: Subcommand-level help
 - **WHEN** user runs `psi-agent ai openai-completions --help`
 - **THEN** system displays the full help for openai-completions command
+
+### Requirement: Subcommand interface is preferred
+The system SHALL document that `psi-agent <component> <subcommand>` is the preferred CLI interface over standalone commands like `psi-ai-openai-completions`.
+
+#### Scenario: Documentation shows preference
+- **WHEN** user reads documentation (README, CLAUDE.md)
+- **THEN** examples primarily use subcommand format
+- **AND** there is a note explaining standalone commands are also available for backward compatibility
+
+#### Scenario: Both interfaces documented
+- **WHEN** user reads the CLI documentation
+- **THEN** they understand both interfaces exist
+- **AND** they know subcommand interface works with `uvx` without cloning
+- **AND** they know standalone commands are shorter but less discoverable


### PR DESCRIPTION
## Summary
- Update README.md, README_zh.md, and CLAUDE.md to use subcommand interface as primary examples
- Add "CLI Interfaces" section explaining both interfaces
- State that `psi-agent <component> <subcommand>` is preferred over standalone commands
- Update specs (central-cli, user-readme) to reflect the preference

## Changes
- Quick Start examples now use `psi-agent session`, `psi-agent ai openai-completions`, `psi-agent channel repl`
- Document both interfaces with clear preference guidance
- Subcommand interface works with `uvx` without cloning repository

## Test plan
- [x] README.md renders correctly
- [x] README_zh.md renders correctly
- [x] CLAUDE.md examples are consistent

🤖 Generated with [Claude Code](https://claude.com/claude-code)