### PR TITLE
Implement OpenClaw-like history compaction with LLM summarization

### DIFF
--- a/examples/a-simple-bash-only-workspace/systems/system.py
+++ b/examples/a-simple-bash-only-workspace/systems/system.py
@@ -1,7 +1,12 @@
 """Async system configuration for the workspace."""
 
 import re
+from collections.abc import Awaitable, Callable
 from pathlib import Path
+from typing import Any
+
+# Type aliases
+CompleteFn = Callable[[list[dict[str, Any]]], Awaitable[str]]
 
 
 async def build_system_prompt() -> str:
@@ -84,35 +89,69 @@ async def _parse_skill_description(skill_md_path: Path) -> str | None:
     return None
 
 
-async def compact_history(
-    history: list[dict[str, str]], max_tokens: int = 4000
-) -> list[dict[str, str]]:
-    """Compact conversation history using LLM summarization.
+def _estimate_tokens(message: dict[str, Any]) -> int:
+    """Estimate token count for a message using chars/4 heuristic.
 
-    This function compresses long conversation histories by summarizing
-    older messages while preserving recent context.
+    This is a conservative estimate (overestimates tokens).
+
+    Args:
+        message: A conversation message with role and content.
+
+    Returns:
+        Estimated token count.
+    """
+    chars = 0
+    content = message.get("content", "")
+
+    if isinstance(content, str):
+        chars = len(content)
+    elif isinstance(content, list):
+        for block in content:
+            if isinstance(block, dict):
+                if block.get("type") == "text":
+                    chars += len(block.get("text", ""))
+                elif block.get("type") == "image":
+                    chars += 4800  # Estimate images as 1200 tokens
+
+    return max(1, chars // 4)
+
+
+async def compact_history(
+    history: list[dict[str, Any]],
+    complete_fn: CompleteFn,
+    max_tokens: int = 4000,
+) -> list[dict[str, Any]]:
+    """Compact conversation history by keeping recent messages.
+
+    This simple implementation ignores the complete_fn parameter and uses
+    simple truncation. It accepts complete_fn for interface compatibility
+    with other workspaces.
 
     Args:
         history: List of conversation messages with role and content.
+        complete_fn: Async function for single-turn LLM conversation.
+            Ignored in this simple implementation.
         max_tokens: Maximum tokens to keep in history.
 
     Returns:
-        Compacted history list.
-
-    Note:
-        This is a framework implementation. The actual LLM summarization
-        logic should be implemented based on the specific agent's needs.
+        Compacted history list with recent messages only.
     """
-    # Framework implementation - placeholder for LLM summarization
-    # In production, this would:
-    # 1. Count tokens in history
-    # 2. If over limit, summarize older messages via LLM API (async)
-    # 3. Return compacted history with summary + recent messages
+    _ = complete_fn  # Ignored: simple workspace uses truncation, not LLM summarization
 
-    # Simple implementation: keep last N messages
-    # (This should be replaced with proper LLM summarization)
-    max_messages = 20  # Approximate message limit
-    if len(history) > max_messages:
-        return history[-max_messages:]
+    # Calculate total tokens in history
+    total_tokens = sum(_estimate_tokens(msg) for msg in history)
 
-    return history
+    if total_tokens <= max_tokens:
+        return history
+
+    # Walk backwards to find cut point
+    accumulated = 0
+    cut_index = len(history)
+
+    for i in range(len(history) - 1, -1, -1):
+        accumulated += _estimate_tokens(history[i])
+        if accumulated >= max_tokens:
+            cut_index = i
+            break
+
+    return history[cut_index:]

--- a/examples/an-openclaw-like-workspace/systems/system.py
+++ b/examples/an-openclaw-like-workspace/systems/system.py
@@ -3,15 +3,72 @@
 import os
 import platform
 import sys
+from collections.abc import Awaitable, Callable
 from datetime import datetime
 from pathlib import Path
 from typing import Any
 
 import anyio
 
+# Type aliases
+CompleteFn = Callable[[list[dict[str, Any]]], Awaitable[str]]
+
 # Constants
 SILENT_TOKEN = "SILENT_TOKEN"
 CACHE_BOUNDARY = "\n<!-- OPENCLAW_CACHE_BOUNDARY -->\n"
+
+_SUMMARIZATION_SYSTEM_PROMPT = """You are summarizing a conversation for context preservation."""
+
+_HISTORY_SUMMARY_PROMPT = """The messages above are a conversation to summarize. \
+Create a structured context checkpoint summary that another LLM will use to continue the work.
+
+Use this EXACT format:
+
+## Goal
+[What is the user trying to accomplish? Can be multiple items if the session \
+covers different tasks.]
+
+## Constraints & Preferences
+- [Any constraints, preferences, or requirements mentioned by user]
+- [Or "(none)" if none were mentioned]
+
+## Progress
+### Done
+- [x] [Completed tasks/changes]
+
+### In Progress
+- [ ] [Current work]
+
+### Blocked
+- [Issues preventing progress, if any]
+
+## Key Decisions
+- **[Decision]**: [Brief rationale]
+
+## Next Steps
+1. [Ordered list of what should happen next]
+
+## Critical Context
+- [Any data, examples, or references needed to continue]
+- [Or "(none)" if not applicable]
+
+Keep each section concise. Preserve exact file paths, function names, and error messages."""
+
+_TURN_PREFIX_SUMMARY_PROMPT = """This is the PREFIX of a turn that was too large to keep. \
+The SUFFIX (recent work) is retained.
+
+Summarize the prefix to provide context for the retained suffix:
+
+## Original Request
+[What did the user ask for in this turn?]
+
+## Early Progress
+- [Key decisions and work done in the prefix]
+
+## Context for Suffix
+- [Information needed to understand the retained recent work]
+
+Be concise. Focus on what's needed to understand the kept suffix."""
 
 
 def _strip_frontmatter(content: str) -> str:
@@ -418,24 +475,192 @@ async def build_system_prompt(
     return prompt
 
 
-async def compact_history(
-    history: list[dict[str, Any]], max_tokens: int = 4000
-) -> list[dict[str, Any]]:
-    """Compact conversation history by keeping recent messages.
+def _estimate_tokens(message: dict[str, Any]) -> int:
+    """Estimate token count for a message using chars/4 heuristic.
 
-    This is a simple implementation that keeps the last N messages.
-    In production, this could use LLM summarization for better context preservation.
+    This is a conservative estimate (overestimates tokens).
+
+    Args:
+        message: A conversation message with role and content.
+
+    Returns:
+        Estimated token count.
+    """
+    chars = 0
+    content = message.get("content", "")
+
+    if isinstance(content, str):
+        chars = len(content)
+    elif isinstance(content, list):
+        for block in content:
+            if isinstance(block, dict):
+                if block.get("type") == "text":
+                    chars += len(block.get("text", ""))
+                elif block.get("type") == "image":
+                    chars += 4800  # Estimate images as 1200 tokens
+
+    return max(1, chars // 4)
+
+
+def _find_turn_start(history: list[dict[str, Any]], cut_index: int) -> int:
+    """Find the user message that starts the turn containing cut_index.
+
+    Args:
+        history: List of conversation messages.
+        cut_index: The index where the cut point is.
+
+    Returns:
+        Index of the user message that starts the turn, or 0 if not found.
+    """
+    for i in range(cut_index, -1, -1):
+        if history[i].get("role") == "user":
+            return i
+    return 0
+
+
+def _find_cut_point(
+    history: list[dict[str, Any]],
+    keep_recent_tokens: int,
+) -> tuple[int, bool]:
+    """Find the cut point in history.
+
+    Walks backwards from newest messages, accumulating estimated token sizes.
+    Stops when accumulated tokens >= keep_recent_tokens.
+
+    Args:
+        history: List of conversation messages.
+        keep_recent_tokens: Number of recent tokens to keep.
+
+    Returns:
+        A tuple of (cut_index, is_split_turn):
+        - cut_index: Index of first message to keep.
+        - is_split_turn: True if cut point is at an assistant message.
+    """
+    accumulated = 0
+    cut_index = len(history)
+
+    for i in range(len(history) - 1, -1, -1):
+        accumulated += _estimate_tokens(history[i])
+        if accumulated >= keep_recent_tokens:
+            cut_index = i
+            break
+
+    # Determine if this is a split turn (cut at assistant message)
+    is_split_turn = (
+        cut_index > 0 and cut_index < len(history) and history[cut_index].get("role") == "assistant"
+    )
+
+    return cut_index, is_split_turn
+
+
+def _build_summarization_prompt(messages: list[dict[str, Any]]) -> str:
+    """Build the summarization prompt from a list of messages.
+
+    Args:
+        messages: List of conversation messages to summarize.
+
+    Returns:
+        A formatted prompt string for the summarization LLM call.
+    """
+    lines = ["<conversation>"]
+    for msg in messages:
+        role = msg.get("role", "unknown")
+        content = msg.get("content", "")
+        if isinstance(content, list):
+            content = " ".join(
+                block.get("text", "") for block in content if isinstance(block, dict)
+            )
+        lines.append(f"[{role}]: {content}")
+    lines.append("</conversation>")
+    return "\n".join(lines)
+
+
+async def compact_history(
+    history: list[dict[str, Any]],
+    complete_fn: CompleteFn,
+    max_tokens: int = 4000,
+    keep_recent_tokens: int | None = None,
+) -> list[dict[str, Any]]:
+    """Compact conversation history using LLM summarization.
+
+    Implements OpenClaw's compaction algorithm:
+    1. Calculate total tokens in history
+    2. If under max_tokens, return unchanged
+    3. Find cut point by walking backwards, accumulating tokens
+    4. Handle split turn (cut at assistant message) if needed
+    5. Generate summaries for old messages
 
     Args:
         history: List of conversation messages with role and content.
-        max_tokens: Maximum tokens to keep in history (approximate).
+        complete_fn: Async function that takes a list of messages (single turn)
+            and returns the LLM response string.
+        max_tokens: Maximum tokens to keep in history.
+        keep_recent_tokens: Number of recent tokens to preserve unchanged.
+            Defaults to half of max_tokens.
 
     Returns:
-        Compacted history list with recent messages.
+        Compacted history list with summary message(s) and recent messages.
     """
-    # Simple implementation: keep last N messages
-    # Approximate 4 tokens per message on average
-    max_messages = max(20, max_tokens // 4)
-    if len(history) > max_messages:
-        return history[-max_messages:]
-    return history
+    if keep_recent_tokens is None:
+        keep_recent_tokens = max_tokens // 2
+
+    # Calculate total tokens in history
+    total_tokens = sum(_estimate_tokens(msg) for msg in history)
+
+    if total_tokens <= max_tokens:
+        return history
+
+    # Find cut point
+    cut_index, is_split_turn = _find_cut_point(history, keep_recent_tokens)
+
+    if cut_index <= 0:
+        # Everything gets summarized
+        messages_to_summarize = history
+        turn_prefix_messages = []
+        recent_messages = []
+    else:
+        # Determine history end for summarization
+        if is_split_turn:
+            turn_start_index = _find_turn_start(history, cut_index)
+            messages_to_summarize = history[:turn_start_index]
+            turn_prefix_messages = history[turn_start_index:cut_index]
+            recent_messages = history[cut_index:]
+        else:
+            messages_to_summarize = history[:cut_index]
+            turn_prefix_messages = []
+            recent_messages = history[cut_index:]
+
+    # Generate history summary
+    summary_parts: list[str] = []
+
+    if messages_to_summarize:
+        prompt = _build_summarization_prompt(messages_to_summarize)
+        history_summary = await complete_fn(
+            [
+                {"role": "system", "content": _SUMMARIZATION_SYSTEM_PROMPT},
+                {"role": "user", "content": prompt + "\n\n" + _HISTORY_SUMMARY_PROMPT},
+            ]
+        )
+        summary_parts.append(history_summary)
+
+    # Generate turn prefix summary if split turn
+    if is_split_turn and turn_prefix_messages:
+        prompt = _build_summarization_prompt(turn_prefix_messages)
+        turn_prefix_summary = await complete_fn(
+            [
+                {"role": "system", "content": _SUMMARIZATION_SYSTEM_PROMPT},
+                {"role": "user", "content": prompt + "\n\n" + _TURN_PREFIX_SUMMARY_PROMPT},
+            ]
+        )
+        summary_parts.append(f"\n\n---\n\n**Turn Context (split turn):**\n\n{turn_prefix_summary}")
+
+    # Build result
+    if summary_parts:
+        combined_summary = "".join(summary_parts)
+        summary_message = {
+            "role": "assistant",
+            "content": f"[Conversation Summary]\n{combined_summary}",
+        }
+        return [summary_message] + recent_messages
+
+    return recent_messages

--- a/openspec/changes/archive/2026-04-29-compact-history-interface/.openspec.yaml
+++ b/openspec/changes/archive/2026-04-29-compact-history-interface/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-28

--- a/openspec/changes/archive/2026-04-29-compact-history-interface/design.md
+++ b/openspec/changes/archive/2026-04-29-compact-history-interface/design.md
@@ -1,0 +1,243 @@
+## Context
+
+psi-agent 的 workspace 中有 `compact_history()` 函数，用于压缩对话历史以避免超出模型的上下文窗口限制。当前实现只是简单地保留最近的 N 条消息，这会丢失早期对话的重要上下文。
+
+OpenClaw 的实现使用 LLM 生成摘要来压缩历史：
+1. 将旧消息发送给 LLM 生成摘要
+2. 用摘要替换旧消息
+3. 保留最近的消息不变
+
+这需要 workspace 能够调用 LLM，但 workspace 本身不应该知道如何调用 LLM（这是 psi-ai-* 组件的职责）。
+
+## Goals / Non-Goals
+
+**Goals:**
+- 设计一个接口，让 session 能够将 LLM 调用能力传递给 workspace
+- 修改 `compact_history()` 支持使用 LLM 生成摘要
+- OpenClaw-like workspace 使用 LLM 摘要，simple workspace 直接截断
+
+**Non-Goals:**
+- 不修改 psi-ai-* 组件
+- 不实现复杂的分块摘要策略（OpenClaw 的高级功能）
+- 不处理 tool_use/tool_result 的配对修复
+
+## OpenClaw Compaction 机制调研
+
+### 关于"保留所有用户输入"
+
+**结论：OpenClaw 不保留所有用户输入。**
+
+OpenClaw 的 `findCutPoint` 函数可以在 user 或 assistant 消息处切割（代码注释："Can cut at user OR assistant messages (never tool results)"）。用户消息和 assistant 消息都会被压缩。
+
+### 关于"保留最近几轮会话"
+
+**结论：OpenClaw 基于 token 数量而非轮数保留最近内容。**
+
+核心参数：
+- `keepRecentTokens`: 默认 20000 tokens，决定保留多少最近内容
+- `reserveTokens`: 默认 16384 tokens，用于 prompt + LLM response
+
+算法：
+- 从后往前遍历消息，累积 token 数量
+- 当累积达到 `keepRecentTokens` 时，在该位置切割
+- 切割点可以是 user 或 assistant 消息
+
+### Split Turn 处理
+
+当切割点在 assistant 消息（而非 user 消息）时，称为 "split turn"：
+- 会生成一个额外的 "turn prefix summary"
+- 将该 turn 的前半部分（user request + 部分 assistant response）摘要化
+- 保留后半部分（最近的 assistant response）
+
+这是为了处理单个 turn 过长的情况。
+
+## Decisions
+
+### 1. 接口设计
+
+**决定：** 使用 Callable 类型作为必需参数，命名为 `complete_fn`
+
+```python
+from collections.abc import Awaitable, Callable
+
+CompleteFn = Callable[[list[dict[str, Any]]], Awaitable[str]]
+
+async def compact_history(
+    history: list[dict[str, Any]],
+    complete_fn: CompleteFn,
+    max_tokens: int = 4000,
+    keep_recent_tokens: int = 2000,
+) -> list[dict[str, Any]]:
+    ...
+```
+
+**参数说明：**
+- `complete_fn`: 单轮对话接口，用于调用 LLM
+- `max_tokens`: 最大 token 限制（用于判断是否需要压缩）
+- `keep_recent_tokens`: 保留的最近 token 数量（默认为 max_tokens 的一半）
+
+**理由：**
+- `complete_fn` 更准确描述其功能：单轮对话接口
+- 必需参数确保 session 必须提供此能力
+- workspace 决定是否使用：openclaw-like 使用它生成摘要，simple workspace 忽略它直接截断
+- workspace 不需要知道 LLM 的具体实现
+
+### 2. Token 估算
+
+使用 OpenClaw 的 `chars / 4` 启发式方法：
+
+```python
+def _estimate_tokens(message: dict[str, Any]) -> int:
+    chars = 0
+    content = message.get("content", "")
+
+    if isinstance(content, str):
+        chars = len(content)
+    elif isinstance(content, list):
+        for block in content:
+            if isinstance(block, dict):
+                if block.get("type") == "text":
+                    chars += len(block.get("text", ""))
+                elif block.get("type") == "image":
+                    chars += 4800  # 估算图片为 1200 tokens
+
+    return max(1, chars // 4)
+```
+
+### 3. 切割点算法
+
+实现 OpenClaw 的 `findCutPoint` 逻辑：
+
+1. 计算历史总 token 数
+2. 如果未超过 `max_tokens`，直接返回原历史
+3. 从后往前遍历消息，累积 token 数量
+4. 当累积达到 `keep_recent_tokens` 时，记录切割点
+5. 判断是否为 "split turn"（切割点在 assistant 消息）
+
+```python
+def _find_cut_point(
+    history: list[dict[str, Any]],
+    keep_recent_tokens: int,
+) -> tuple[int, bool]:
+    """Find the cut point in history.
+
+    Returns:
+        (cut_index, is_split_turn)
+        - cut_index: 第一个保留的消息索引
+        - is_split_turn: 是否在 turn 中间切割
+    """
+    accumulated = 0
+    cut_index = len(history)
+
+    for i in range(len(history) - 1, -1, -1):
+        accumulated += _estimate_tokens(history[i])
+        if accumulated >= keep_recent_tokens:
+            cut_index = i
+            break
+
+    # 判断是否为 split turn
+    is_split_turn = (
+        cut_index > 0 and
+        history[cut_index].get("role") == "assistant"
+    )
+
+    return cut_index, is_split_turn
+```
+
+### 4. Split Turn 处理
+
+当切割点在 assistant 消息时：
+
+1. 找到该 turn 的起始 user 消息
+2. 生成两个摘要：
+   - **History Summary**: 切割点之前的所有消息
+   - **Turn Prefix Summary**: 该 turn 的前半部分（user request + 部分 assistant response）
+3. 合并两个摘要
+
+```python
+def _find_turn_start(history: list[dict[str, Any]], cut_index: int) -> int:
+    """Find the user message that starts the turn containing cut_index."""
+    for i in range(cut_index, -1, -1):
+        if history[i].get("role") == "user":
+            return i
+    return 0
+```
+
+### 5. 摘要提示词
+
+参考 OpenClaw 的实现，使用结构化的摘要格式：
+
+**History Summary Prompt:**
+```
+## Goal
+[What is the user trying to accomplish?]
+
+## Constraints & Preferences
+- [Any constraints, preferences, or requirements mentioned by user]
+
+## Progress
+### Done
+- [x] [Completed tasks/changes]
+
+### In Progress
+- [ ] [Current work]
+
+### Blocked
+- [Issues preventing progress, if any]
+
+## Key Decisions
+- **[Decision]**: [Brief rationale]
+
+## Next Steps
+1. [Ordered list of what should happen next]
+
+## Critical Context
+- [Any data, examples, or references needed to continue]
+```
+
+**Turn Prefix Summary Prompt:**
+```
+## Original Request
+[What did the user ask for in this turn?]
+
+## Early Progress
+- [Key decisions and work done in the prefix]
+
+## Context for Suffix
+- [Information needed to understand the retained recent work]
+```
+
+### 6. Workspace 行为差异
+
+**OpenClaw-like workspace:**
+- 使用 `complete_fn` 生成摘要
+- 实现 split turn 处理
+- 保留最近消息不压缩
+
+**Simple workspace:**
+- 接受 `complete_fn` 参数但忽略它
+- 基于 token 数量直接截断
+- 不生成摘要
+
+### 7. Session 侧的实现
+
+Session 需要提供一个函数，该函数：
+- 接收消息列表（单轮对话）
+- 调用 psi-ai-* 组件
+- 返回响应字符串
+
+```python
+async def create_complete_fn(ai_client) -> CompleteFn:
+    async def complete(messages: list[dict]) -> str:
+        # 调用 LLM
+        response = await ai_client.complete(messages)
+        return response.content
+    return complete
+```
+
+## Risks / Trade-offs
+
+- **摘要质量不稳定** → 使用结构化提示词
+- **LLM 调用失败** → OpenClaw-like 可 fallback 到截断
+- **摘要丢失细节** → 保留最近的消息不压缩，只压缩旧消息
+- **Split turn 处理复杂** → 先实现基础版本，后续优化

--- a/openspec/changes/archive/2026-04-29-compact-history-interface/proposal.md
+++ b/openspec/changes/archive/2026-04-29-compact-history-interface/proposal.md
@@ -1,0 +1,31 @@
+## Why
+
+当前的 `compact_history()` 函数只是一个简单的截断实现，保留最近的 N 条消息。OpenClaw 使用 LLM 生成摘要来压缩历史，这能更好地保留上下文信息。我们需要设计一个接口，让 workspace 的 `compact_history()` 能够使用 session 提供的 LLM 调用能力来生成摘要。
+
+## What Changes
+
+- 修改 `compact_history()` 函数签名，接受一个必需的 `complete_fn` 参数
+- `complete_fn` 是一个单轮对话接口，session 通过它提供 LLM 调用能力
+- 实现 OpenClaw 的 compaction 算法：
+  - 基于 token 数量而非消息数量决定切割点
+  - 从后往前遍历，累积 token 直到达到 `keep_recent_tokens` 阈值
+  - 切割点可以是 user 或 assistant 消息
+  - 支持 "split turn" 处理：当切割点在 assistant 消息时，生成额外的 turn prefix summary
+- OpenClaw-like workspace 使用 `complete_fn` 生成对话摘要
+- Simple workspace 接受但不使用 `complete_fn`，直接截断
+
+## Capabilities
+
+### New Capabilities
+
+- `history-compaction`: 对话历史压缩功能，支持 LLM 摘要生成，与 OpenClaw 算法一致
+
+### Modified Capabilities
+
+无。
+
+## Impact
+
+- `examples/an-openclaw-like-workspace/systems/system.py` - 修改 `compact_history()` 函数，实现 OpenClaw compaction 算法
+- `examples/a-simple-bash-only-workspace/systems/system.py` - 修改 `compact_history()` 函数签名，接受但不使用 `complete_fn`
+- `src/psi_agent/session/` - Session 需要提供单轮对话接口

--- a/openspec/changes/archive/2026-04-29-compact-history-interface/specs/history-compaction/spec.md
+++ b/openspec/changes/archive/2026-04-29-compact-history-interface/specs/history-compaction/spec.md
@@ -1,0 +1,37 @@
+## ADDED Requirements
+
+### Requirement: compact_history accepts complete function
+
+The `compact_history()` function SHALL accept a required `complete_fn` parameter that provides a single-turn conversation interface to an LLM.
+
+#### Scenario: complete function signature
+- **WHEN** a complete function is provided
+- **THEN** it accepts `list[dict[str, Any]]` as input (messages for a single turn)
+- **AND** it returns `Awaitable[str]` as output (the LLM response)
+
+### Requirement: OpenClaw-like workspace uses LLM summarization
+
+The OpenClaw-like workspace's `compact_history()` function SHALL use `complete_fn` to generate conversation summaries.
+
+#### Scenario: Summary replaces old messages
+- **WHEN** LLM summarization is used in OpenClaw-like workspace
+- **THEN** old messages are replaced by a single summary message
+- **AND** recent messages are preserved unchanged
+
+### Requirement: Simple workspace ignores complete function
+
+The simple workspace's `compact_history()` function SHALL accept `complete_fn` but ignore it, using simple truncation instead.
+
+#### Scenario: Simple truncation
+- **WHEN** compacting history in simple workspace
+- **THEN** the function ignores `complete_fn`
+- **AND** only recent messages are kept
+
+### Requirement: recent messages preserved
+
+The `compact_history()` function SHALL preserve a configurable number of recent messages without summarization.
+
+#### Scenario: Recent messages not summarized
+- **WHEN** compacting history with LLM summarization
+- **THEN** the most recent messages (based on `max_tokens` or message count) are kept as-is
+- **AND** only older messages are summarized

--- a/openspec/changes/archive/2026-04-29-compact-history-interface/tasks.md
+++ b/openspec/changes/archive/2026-04-29-compact-history-interface/tasks.md
@@ -1,0 +1,37 @@
+## 1. 类型定义
+
+- [x] 1.1 在 `examples/an-openclaw-like-workspace/systems/system.py` 中定义 `CompleteFn` 类型别名
+
+## 2. Token 估算
+
+- [x] 2.1 添加 `_estimate_tokens()` 函数，使用 chars/4 启发式方法
+
+## 3. 切割点算法
+
+- [x] 3.1 添加 `_find_cut_point()` 函数，从后往前累积 token
+- [x] 3.2 添加 `_find_turn_start()` 函数，找到 turn 起始的 user 消息
+
+## 4. 摘要提示词
+
+- [x] 4.1 添加 `_HISTORY_SUMMARY_PROMPT` 常量
+- [x] 4.2 添加 `_TURN_PREFIX_SUMMARY_PROMPT` 常量
+- [x] 4.3 添加 `_build_summarization_prompt()` 函数
+
+## 5. compact_history 函数修改 (OpenClaw-like)
+
+- [x] 5.1 修改函数签名，添加 `complete_fn` 和 `keep_recent_tokens` 参数
+- [x] 5.2 实现切割点检测逻辑
+- [x] 5.3 实现 split turn 检测和处理
+- [x] 5.4 实现历史摘要生成
+- [x] 5.5 实现 turn prefix 摘要生成（split turn 时）
+
+## 6. compact_history 函数修改 (Simple)
+
+- [x] 6.1 修改 simple workspace 的函数签名，添加 `complete_fn` 参数
+- [x] 6.2 实现基于 token 的简单截断逻辑
+
+## 7. 验证
+
+- [x] 7.1 运行 `ruff check` 验证代码风格
+- [x] 7.2 运行 `ruff format` 格式化代码
+- [x] 7.3 运行 `ty check` 验证类型

--- a/openspec/specs/history-compaction/spec.md
+++ b/openspec/specs/history-compaction/spec.md
@@ -1,0 +1,37 @@
+## ADDED Requirements
+
+### Requirement: compact_history accepts complete function
+
+The `compact_history()` function SHALL accept a required `complete_fn` parameter that provides a single-turn conversation interface to an LLM.
+
+#### Scenario: complete function signature
+- **WHEN** a complete function is provided
+- **THEN** it accepts `list[dict[str, Any]]` as input (messages for a single turn)
+- **AND** it returns `Awaitable[str]` as output (the LLM response)
+
+### Requirement: OpenClaw-like workspace uses LLM summarization
+
+The OpenClaw-like workspace's `compact_history()` function SHALL use `complete_fn` to generate conversation summaries.
+
+#### Scenario: Summary replaces old messages
+- **WHEN** LLM summarization is used in OpenClaw-like workspace
+- **THEN** old messages are replaced by a single summary message
+- **AND** recent messages are preserved unchanged
+
+### Requirement: Simple workspace ignores complete function
+
+The simple workspace's `compact_history()` function SHALL accept `complete_fn` but ignore it, using simple truncation instead.
+
+#### Scenario: Simple truncation
+- **WHEN** compacting history in simple workspace
+- **THEN** the function ignores `complete_fn`
+- **AND** only recent messages are kept
+
+### Requirement: recent messages preserved
+
+The `compact_history()` function SHALL preserve a configurable number of recent messages without summarization.
+
+#### Scenario: Recent messages not summarized
+- **WHEN** compacting history with LLM summarization
+- **THEN** the most recent messages (based on `max_tokens` or message count) are kept as-is
+- **AND** only older messages are summarized


### PR DESCRIPTION
## Summary

- Add `CompleteFn` type alias for single-turn LLM conversation interface
- Implement token estimation using `chars/4` heuristic (matching OpenClaw)
- Add cut point detection algorithm: walk backwards, accumulate tokens
- Add split turn handling: generate turn prefix summary when cutting at assistant message
- Add structured summary prompts (history + turn prefix) following OpenClaw format

## Changes

**OpenClaw-like workspace:**
- Full LLM summarization implementation
- `compact_history()` accepts `complete_fn` and `keep_recent_tokens` parameters
- Generates structured summaries with Goal, Progress, Key Decisions, etc.

**Simple workspace:**
- Accepts `complete_fn` for interface compatibility
- Uses simple token-based truncation

**New capability:**
- `history-compaction` spec added to main specs

## Test plan

- [x] `ruff check` passes
- [x] `ruff format` passes
- [x] `ty check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)