### PR TITLE
Migrate pathlib.Path to anyio.Path for async file operations

### DIFF
--- a/examples/a-simple-bash-only-workspace/systems/system.py
+++ b/examples/a-simple-bash-only-workspace/systems/system.py
@@ -5,11 +5,13 @@ from collections.abc import Awaitable, Callable
 from pathlib import Path
 from typing import Any
 
+import anyio
+
 # Type aliases
 CompleteFn = Callable[[list[dict[str, Any]]], Awaitable[str]]
 
 
-async def _parse_skill_description(skill_md_path: Path) -> str | None:
+async def _parse_skill_description(skill_md_path: Path | anyio.Path) -> str | None:
     """Parse SKILL.md to extract description from YAML frontmatter.
 
     Args:
@@ -18,7 +20,7 @@ async def _parse_skill_description(skill_md_path: Path) -> str | None:
     Returns:
         Description string if found, None otherwise.
     """
-    content = skill_md_path.read_text()
+    content = await anyio.Path(skill_md_path).read_text()
 
     # Match YAML frontmatter between --- markers
     frontmatter_match = re.match(r"^---\n(.*?)\n---", content, re.DOTALL)
@@ -86,11 +88,11 @@ class System:
         skills_dir = self._workspace_dir / "skills"
         skill_descriptions: list[str] = []
 
-        if skills_dir.exists():
-            for skill_path in skills_dir.iterdir():
-                if skill_path.is_dir():
+        if await anyio.Path(skills_dir).exists():
+            async for skill_path in anyio.Path(skills_dir).iterdir():
+                if await anyio.Path(skill_path).is_dir():
                     skill_md = skill_path / "SKILL.md"
-                    if skill_md.exists():
+                    if await anyio.Path(skill_md).exists():
                         description = await _parse_skill_description(skill_md)
                         if description:
                             skill_descriptions.append(f"- {skill_path.name}: {description}")

--- a/examples/an-openclaw-like-workspace/systems/system.py
+++ b/examples/an-openclaw-like-workspace/systems/system.py
@@ -163,7 +163,7 @@ async def _read_bootstrap_file(file_path: Path) -> str | None:
     Returns:
         File content with frontmatter stripped, or None if file doesn't exist.
     """
-    if not file_path.exists():
+    if not await anyio.Path(file_path).exists():
         return None
     try:
         async with await anyio.open_file(file_path, encoding="utf-8") as f:

--- a/openspec/changes/archive/2026-04-29-fix-pathlib-sync-operations/.openspec.yaml
+++ b/openspec/changes/archive/2026-04-29-fix-pathlib-sync-operations/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-28

--- a/openspec/changes/archive/2026-04-29-fix-pathlib-sync-operations/design.md
+++ b/openspec/changes/archive/2026-04-29-fix-pathlib-sync-operations/design.md
@@ -1,0 +1,66 @@
+## Context
+
+The psi-agent framework follows an async-first design where all I/O operations should use async methods to avoid blocking the event loop. The project's CLAUDE.md explicitly states:
+
+> **禁止使用 `pathlib.Path` 进行文件 IO 操作** — 所有文件操作方法（`read_text()`, `exists()`, `iterdir()` 等）都是同步的，会阻塞事件循环。必须使用 `anyio.Path` 的 async 方法。
+
+Two example workspace files currently violate this guideline by using synchronous `pathlib.Path` methods for file I/O operations:
+
+1. `examples/a-simple-bash-only-workspace/systems/system.py` - The `_parse_skill_description()` function uses `Path.read_text()` synchronously, and `build_system_prompt()` uses `Path.exists()`, `Path.iterdir()`, and `Path.is_dir()` synchronously.
+
+2. `examples/an-openclaw-like-workspace/systems/system.py` - The `_read_bootstrap_file()` function uses `Path.exists()` synchronously.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Replace all synchronous `pathlib.Path` I/O operations with async `anyio.Path` equivalents
+- Maintain functional equivalence - the code should behave identically after the change
+- Follow the project's async coding standards as defined in CLAUDE.md
+
+**Non-Goals:**
+- Refactoring the overall structure of the system.py files
+- Adding new features or changing the logic of the existing code
+- Modifying test files (they already use appropriate async patterns where needed)
+
+## Decisions
+
+### Decision 1: Use `anyio.Path` for all file I/O
+
+**Rationale:** `anyio.Path` provides an async-compatible wrapper around `pathlib.Path` that works with any async framework. This is the recommended approach in CLAUDE.md.
+
+**Implementation pattern:**
+```python
+# Before (synchronous - blocking)
+content = path.read_text()
+if path.exists():
+    ...
+for item in path.iterdir():
+    if item.is_dir():
+        ...
+
+# After (async - non-blocking)
+content = await anyio.Path(path).read_text()
+if await anyio.Path(path).exists():
+    ...
+async for item in anyio.Path(path).iterdir():
+    if await anyio.Path(item).is_dir():
+        ...
+```
+
+### Decision 2: Keep `pathlib.Path` for type annotations and path manipulation
+
+**Rationale:** `pathlib.Path` can still be used for:
+- Type annotations (e.g., `def __init__(self, workspace_dir: Path)`)
+- Path manipulation without I/O (e.g., `workspace / "skills"`)
+- Getting path properties like `.name`, `.stem`, `.suffix`
+
+This is explicitly allowed by CLAUDE.md:
+> `pathlib.Path` 可用于类型注解和路径拼接（无 IO 操作时）
+
+## Risks / Trade-offs
+
+**Risk: Breaking existing functionality** → Mitigation: The async operations are functionally equivalent to their sync counterparts. All existing tests should pass without modification.
+
+**Risk: Missing some sync operations** → Mitigation: Careful code review to identify all sync operations. The grep pattern `pathlib.Path|from pathlib import` was used to find all relevant files.
+
+**Trade-off: Slightly more verbose code** → The async versions require `await` and `async for`, but this is the correct pattern for async code and matches the rest of the codebase.

--- a/openspec/changes/archive/2026-04-29-fix-pathlib-sync-operations/proposal.md
+++ b/openspec/changes/archive/2026-04-29-fix-pathlib-sync-operations/proposal.md
@@ -1,0 +1,38 @@
+## Why
+
+The codebase contains several files that use `pathlib.Path` for file I/O operations, which are synchronous and block the event loop. According to the project's CLAUDE.md guidelines, all I/O operations must use async methods from `anyio.Path` to avoid blocking the async event loop. This is a code quality and performance issue that affects the responsiveness of the psi-agent framework.
+
+## What Changes
+
+- Replace synchronous `pathlib.Path` I/O operations with async `anyio.Path` equivalents in:
+  - `examples/a-simple-bash-only-workspace/systems/system.py` - Uses `Path.read_text()`, `Path.exists()`, `Path.iterdir()`, `Path.is_dir()` synchronously
+  - `examples/an-openclaw-like-workspace/systems/system.py` - Uses `Path.exists()` synchronously in `_read_bootstrap_file()`
+
+- Specific operations to migrate:
+  - `path.read_text()` → `await anyio.Path(path).read_text()`
+  - `path.exists()` → `await anyio.Path(path).exists()`
+  - `path.iterdir()` → `async for item in anyio.Path(path).iterdir()`
+  - `path.is_dir()` → `await anyio.Path(path).is_dir()`
+  - `path.is_file()` → `await anyio.Path(path).is_file()`
+
+## Capabilities
+
+### New Capabilities
+
+- `async-file-operations`: Ensure all file I/O operations in example workspace system.py files use async anyio.Path methods
+
+### Modified Capabilities
+
+None - This is a code quality fix that doesn't change the external behavior or requirements.
+
+## Impact
+
+- **Affected Files**:
+  - `examples/a-simple-bash-only-workspace/systems/system.py`
+  - `examples/an-openclaw-like-workspace/systems/system.py`
+
+- **Dependencies**: Already imports `anyio` in the affected files or needs to add it
+
+- **Testing**: Existing tests should continue to pass; the async operations are functionally equivalent
+
+- **Performance**: Improves async performance by not blocking the event loop during file operations

--- a/openspec/changes/archive/2026-04-29-fix-pathlib-sync-operations/specs/async-file-operations/spec.md
+++ b/openspec/changes/archive/2026-04-29-fix-pathlib-sync-operations/specs/async-file-operations/spec.md
@@ -1,0 +1,35 @@
+## ADDED Requirements
+
+### Requirement: All file I/O operations use async methods
+All file I/O operations in workspace system.py files SHALL use async methods from `anyio.Path` instead of synchronous `pathlib.Path` methods.
+
+#### Scenario: Reading file content asynchronously
+- **WHEN** a system.py file reads file content
+- **THEN** it SHALL use `await anyio.Path(path).read_text()` instead of `path.read_text()`
+
+#### Scenario: Checking file existence asynchronously
+- **WHEN** a system.py file checks if a file or directory exists
+- **THEN** it SHALL use `await anyio.Path(path).exists()` instead of `path.exists()`
+
+#### Scenario: Iterating directory contents asynchronously
+- **WHEN** a system.py file iterates over directory contents
+- **THEN** it SHALL use `async for item in anyio.Path(path).iterdir()` instead of `for item in path.iterdir()`
+
+#### Scenario: Checking if path is directory asynchronously
+- **WHEN** a system.py file checks if a path is a directory
+- **THEN** it SHALL use `await anyio.Path(path).is_dir()` instead of `path.is_dir()`
+
+#### Scenario: Checking if path is file asynchronously
+- **WHEN** a system.py file checks if a path is a file
+- **THEN** it SHALL use `await anyio.Path(path).is_file()` instead of `path.is_file()`
+
+### Requirement: pathlib.Path allowed for non-I/O operations
+The `pathlib.Path` class MAY still be used for type annotations and path manipulation that does not involve I/O operations.
+
+#### Scenario: Path type annotations
+- **WHEN** a function parameter or return type represents a file path
+- **THEN** it MAY use `pathlib.Path` for the type annotation
+
+#### Scenario: Path manipulation without I/O
+- **WHEN** code constructs new paths by joining or manipulating existing paths
+- **THEN** it MAY use `pathlib.Path` operators like `/` for path concatenation

--- a/openspec/changes/archive/2026-04-29-fix-pathlib-sync-operations/tasks.md
+++ b/openspec/changes/archive/2026-04-29-fix-pathlib-sync-operations/tasks.md
@@ -1,0 +1,20 @@
+## 1. Fix a-simple-bash-only-workspace/systems/system.py
+
+- [x] 1.1 Replace `skill_md_path.read_text()` in `_parse_skill_description()` with `await anyio.Path(skill_md_path).read_text()`
+- [x] 1.2 Replace `skills_dir.exists()` in `build_system_prompt()` with `await anyio.Path(skills_dir).exists()`
+- [x] 1.3 Replace `skills_dir.iterdir()` in `build_system_prompt()` with `async for skill_path in anyio.Path(skills_dir).iterdir()`
+- [x] 1.4 Replace `skill_path.is_dir()` in `build_system_prompt()` with `await anyio.Path(skill_path).is_dir()`
+- [x] 1.5 Replace `skill_md.exists()` in `build_system_prompt()` with `await anyio.Path(skill_md).exists()`
+- [x] 1.6 Add `import anyio` if not already present
+
+## 2. Fix an-openclaw-like-workspace/systems/system.py
+
+- [x] 2.1 Replace `file_path.exists()` in `_read_bootstrap_file()` with `await anyio.Path(file_path).exists()`
+- [x] 2.2 Verify `anyio` is already imported (it is present in this file)
+
+## 3. Verification
+
+- [x] 3.1 Run `ruff check` on modified files
+- [x] 3.2 Run `ruff format` on modified files
+- [x] 3.3 Run `ty check` on modified files
+- [x] 3.4 Run `pytest` to verify all tests pass

--- a/openspec/specs/async-file-operations/spec.md
+++ b/openspec/specs/async-file-operations/spec.md
@@ -1,0 +1,35 @@
+## ADDED Requirements
+
+### Requirement: All file I/O operations use async methods
+All file I/O operations in workspace system.py files SHALL use async methods from `anyio.Path` instead of synchronous `pathlib.Path` methods.
+
+#### Scenario: Reading file content asynchronously
+- **WHEN** a system.py file reads file content
+- **THEN** it SHALL use `await anyio.Path(path).read_text()` instead of `path.read_text()`
+
+#### Scenario: Checking file existence asynchronously
+- **WHEN** a system.py file checks if a file or directory exists
+- **THEN** it SHALL use `await anyio.Path(path).exists()` instead of `path.exists()`
+
+#### Scenario: Iterating directory contents asynchronously
+- **WHEN** a system.py file iterates over directory contents
+- **THEN** it SHALL use `async for item in anyio.Path(path).iterdir()` instead of `for item in path.iterdir()`
+
+#### Scenario: Checking if path is directory asynchronously
+- **WHEN** a system.py file checks if a path is a directory
+- **THEN** it SHALL use `await anyio.Path(path).is_dir()` instead of `path.is_dir()`
+
+#### Scenario: Checking if path is file asynchronously
+- **WHEN** a system.py file checks if a path is a file
+- **THEN** it SHALL use `await anyio.Path(path).is_file()` instead of `path.is_file()`
+
+### Requirement: pathlib.Path allowed for non-I/O operations
+The `pathlib.Path` class MAY still be used for type annotations and path manipulation that does not involve I/O operations.
+
+#### Scenario: Path type annotations
+- **WHEN** a function parameter or return type represents a file path
+- **THEN** it MAY use `pathlib.Path` for the type annotation
+
+#### Scenario: Path manipulation without I/O
+- **WHEN** code constructs new paths by joining or manipulating existing paths
+- **THEN** it MAY use `pathlib.Path` operators like `/` for path concatenation


### PR DESCRIPTION
## Summary

- Replace synchronous `pathlib.Path` I/O operations with async `anyio.Path` equivalents in example workspace system.py files
- Ensures all file operations are non-blocking to maintain async event loop responsiveness
- Follows project's CLAUDE.md guideline requiring async file I/O

## Changes

- `examples/a-simple-bash-only-workspace/systems/system.py`:
  - Added `import anyio`
  - Converted `read_text()`, `exists()`, `iterdir()`, `is_dir()` to async versions
  - Updated type annotation to accept `Path | anyio.Path`

- `examples/an-openclaw-like-workspace/systems/system.py`:
  - Converted `exists()` to async in `_read_bootstrap_file()`

## Test plan

- [x] `ruff check` passes
- [x] `ruff format` passes
- [x] `ty check` passes
- [x] All 243 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)