### PR TITLE
Fix Anthropic Messages API missing max_tokens and model placeholder

### DIFF
--- a/openspec/changes/archive/2026-04-29-fix-anthropic-messages-max-tokens/.openspec.yaml
+++ b/openspec/changes/archive/2026-04-29-fix-anthropic-messages-max-tokens/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-28

--- a/openspec/changes/archive/2026-04-29-fix-anthropic-messages-max-tokens/design.md
+++ b/openspec/changes/archive/2026-04-29-fix-anthropic-messages-max-tokens/design.md
@@ -1,0 +1,46 @@
+## Context
+
+The psi-ai-anthropic-messages component translates OpenAI-format requests to Anthropic Messages API format. Two issues cause requests to fail:
+
+1. The Anthropic API requires `max_tokens` as a mandatory parameter, but the current translator only passes it through if provided by the caller. The session layer does not set `max_tokens`.
+
+2. The session layer passes `model: "session"` as a placeholder, but the client's model injection logic only triggers when `model` is **absent**, not when it equals `"session"`.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Ensure all Anthropic Messages API requests include the required `max_tokens` parameter
+- Make `max_tokens` configurable via CLI with a sensible default
+- Properly replace the `"session"` model placeholder with the configured model name
+- Maintain backward compatibility with callers that provide their own values
+
+**Non-Goals:**
+- Changing the session layer to send `max_tokens` or real model names
+- Supporting different default values for different models
+
+## Decisions
+
+**Decision 1: Add `max_tokens` as CLI parameter**
+
+Add `max_tokens` as an optional CLI parameter with default value 4096, stored in config and passed to the translator.
+
+- **Rationale**: Making it a CLI parameter allows users to override the default without code changes. The default 4096 works for most conversational use cases.
+- **Alternative considered**: Hardcode default in translator. Rejected because it's less flexible for different use cases.
+
+**Decision 2: Replace model placeholder in client**
+
+Modify the client's model injection logic to replace `"session"` placeholder with the configured model name, in addition to injecting when absent.
+
+- **Rationale**: The session layer uses `"session"` as a provider-agnostic placeholder. The AI provider component should replace it with the actual model.
+- **Alternative considered**: Have session send no model. Rejected because it would require changing the session layer.
+
+## Risks / Trade-offs
+
+- **Risk**: 4096 may be too small for some use cases requiring longer responses.
+  - **Mitigation**: Users can override via `--max-tokens` CLI argument.
+
+- **Risk**: Some models may have different token limits.
+  - **Mitigation**: Users can configure appropriate value via CLI.
+
+- **Risk**: The `"session"` placeholder is a magic string.
+  - **Mitigation**: This is already the established convention in the codebase.

--- a/openspec/changes/archive/2026-04-29-fix-anthropic-messages-max-tokens/proposal.md
+++ b/openspec/changes/archive/2026-04-29-fix-anthropic-messages-max-tokens/proposal.md
@@ -1,0 +1,31 @@
+## Why
+
+The Anthropic Messages API requires `max_tokens` as a mandatory parameter, but the current implementation does not provide a default value when translating OpenAI-format requests to Anthropic format. Additionally, the session layer passes `model: "session"` as a placeholder, but the client only replaces the model when it's **absent**, not when it's the placeholder value. This causes all requests to fail with the error: "Missing required arguments; Expected either ('max_tokens', 'messages' and 'model') or ('max_tokens', 'messages', 'model' and 'stream') arguments to be given."
+
+## What Changes
+
+- Add `max_tokens` as a CLI parameter with default value 4096 in `cli.py` and `config.py`
+- Pass `max_tokens` through config to the translator, which will use it as default when not provided by the caller
+- Fix model replacement logic in client to replace `"session"` placeholder with the configured model name
+- This ensures compatibility with the Anthropic Messages API without requiring changes to the session layer
+
+## Capabilities
+
+### New Capabilities
+
+- `anthropic-request-defaults`: Ensures Anthropic Messages API requests always include the required `max_tokens` parameter (configurable via CLI with sensible default), and properly replaces the session model placeholder with the configured model name
+
+### Modified Capabilities
+
+- None
+
+## Impact
+
+- **Affected Code**: 
+  - `src/psi_agent/ai/anthropic_messages/cli.py` - add `max_tokens` parameter with default
+  - `src/psi_agent/ai/anthropic_messages/config.py` - add `max_tokens` field
+  - `src/psi_agent/ai/anthropic_messages/translator.py` - use config's `max_tokens` as default
+  - `src/psi_agent/ai/anthropic_messages/client.py` - fix model placeholder replacement
+- **APIs**: CLI gains optional `--max-tokens` argument (default: 4096)
+- **Dependencies**: None
+- **Systems**: psi-ai-anthropic-messages component

--- a/openspec/changes/archive/2026-04-29-fix-anthropic-messages-max-tokens/specs/anthropic-request-defaults/spec.md
+++ b/openspec/changes/archive/2026-04-29-fix-anthropic-messages-max-tokens/specs/anthropic-request-defaults/spec.md
@@ -1,0 +1,33 @@
+## ADDED Requirements
+
+### Requirement: Default max_tokens for Anthropic API
+
+The CLI SHALL provide a `max_tokens` parameter with default value 4096. The translator SHALL use this value when `max_tokens` is not provided in the request.
+
+#### Scenario: Request without max_tokens
+- **WHEN** an OpenAI-format request is translated to Anthropic format without `max_tokens`
+- **THEN** the translated request SHALL include `max_tokens` set to the configured value (default 4096)
+
+#### Scenario: Request with max_tokens provided
+- **WHEN** an OpenAI-format request is translated to Anthropic format with `max_tokens` already set
+- **THEN** the translator SHALL preserve the provided `max_tokens` value and NOT override it
+
+#### Scenario: CLI with custom max_tokens
+- **WHEN** the CLI is started with `--max-tokens 8192`
+- **THEN** requests without `max_tokens` SHALL use 8192 as the default
+
+### Requirement: Model placeholder replacement
+
+The client SHALL replace the `"session"` model placeholder with the configured model name.
+
+#### Scenario: Model is session placeholder
+- **WHEN** a request has `model` set to `"session"`
+- **THEN** the client SHALL replace it with the configured model name
+
+#### Scenario: Model is absent
+- **WHEN** a request does not have a `model` field
+- **THEN** the client SHALL inject the configured model name
+
+#### Scenario: Model is explicit value
+- **WHEN** a request has `model` set to a specific value (not `"session"`)
+- **THEN** the client SHALL preserve the provided model value

--- a/openspec/changes/archive/2026-04-29-fix-anthropic-messages-max-tokens/tasks.md
+++ b/openspec/changes/archive/2026-04-29-fix-anthropic-messages-max-tokens/tasks.md
@@ -1,0 +1,15 @@
+## 1. Implementation
+
+- [x] 1.1 Add `max_tokens` field to `AnthropicMessagesConfig` with default value 4096
+- [x] 1.2 Add `max_tokens` parameter to CLI dataclass with default value 4096
+- [x] 1.3 Pass `max_tokens` from config to translator and use as default when not provided in request
+- [x] 1.4 Fix model replacement logic in client to replace `"session"` placeholder
+- [x] 1.5 Add unit tests for translator with and without `max_tokens`
+- [x] 1.6 Add unit tests for model placeholder replacement
+
+## 2. Verification
+
+- [x] 2.1 Run `ruff check` and `ruff format` to ensure code quality
+- [x] 2.2 Run `ty check` for type checking
+- [x] 2.3 Run `pytest` to verify all tests pass
+- [x] 2.4 Manually test the fix with the provided commands

--- a/openspec/specs/anthropic-request-defaults/spec.md
+++ b/openspec/specs/anthropic-request-defaults/spec.md
@@ -1,0 +1,33 @@
+# anthropic-request-defaults
+
+## Requirement: Default max_tokens for Anthropic API
+
+The CLI SHALL provide a `max_tokens` parameter with default value 4096. The translator SHALL use this value when `max_tokens` is not provided in the request.
+
+### Scenario: Request without max_tokens
+- **WHEN** an OpenAI-format request is translated to Anthropic format without `max_tokens`
+- **THEN** the translated request SHALL include `max_tokens` set to the configured value (default 4096)
+
+### Scenario: Request with max_tokens provided
+- **WHEN** an OpenAI-format request is translated to Anthropic format with `max_tokens` already set
+- **THEN** the translator SHALL preserve the provided `max_tokens` value and NOT override it
+
+### Scenario: CLI with custom max_tokens
+- **WHEN** the CLI is started with `--max-tokens 8192`
+- **THEN** requests without `max_tokens` SHALL use 8192 as the default
+
+## Requirement: Model placeholder replacement
+
+The client SHALL replace the `"session"` model placeholder with the configured model name.
+
+### Scenario: Model is session placeholder
+- **WHEN** a request has `model` set to `"session"`
+- **THEN** the client SHALL replace it with the configured model name
+
+### Scenario: Model is absent
+- **WHEN** a request does not have a `model` field
+- **THEN** the client SHALL inject the configured model name
+
+### Scenario: Model is explicit value
+- **WHEN** a request has `model` set to a specific value (not `"session"`)
+- **THEN** the client SHALL preserve the provided model value

--- a/src/psi_agent/ai/anthropic_messages/cli.py
+++ b/src/psi_agent/ai/anthropic_messages/cli.py
@@ -21,6 +21,7 @@ class AnthropicMessages:
     model: str
     api_key: str
     base_url: str = "https://api.anthropic.com"
+    max_tokens: int = 4096
 
     def __call__(self) -> None:
         # Mask sensitive arguments from process title
@@ -31,6 +32,7 @@ class AnthropicMessages:
             model=self.model,
             api_key=self.api_key,
             base_url=self.base_url,
+            max_tokens=self.max_tokens,
         )
 
         logger.info("Starting psi-ai-anthropic-messages")

--- a/src/psi_agent/ai/anthropic_messages/client.py
+++ b/src/psi_agent/ai/anthropic_messages/client.py
@@ -61,8 +61,8 @@ class AnthropicMessagesClient:
         if self._client is None:
             raise RuntimeError("Client not initialized. Use async context manager.")
 
-        # Inject model if not present
-        if "model" not in request_body:
+        # Inject model if not present or if it's the session placeholder
+        if "model" not in request_body or request_body["model"] == "session":
             request_body["model"] = self.config.model
 
         logger.info(f"Sending request to Anthropic API with model {request_body['model']}")

--- a/src/psi_agent/ai/anthropic_messages/config.py
+++ b/src/psi_agent/ai/anthropic_messages/config.py
@@ -15,12 +15,14 @@ class AnthropicMessagesConfig:
         model: The model name to use for messages (e.g., "claude-sonnet-4-20250514").
         api_key: The API key for authentication.
         base_url: The base URL for the Anthropic API.
+        max_tokens: The maximum number of tokens to generate (default: 4096).
     """
 
     session_socket: str
     model: str
     api_key: str
     base_url: str = "https://api.anthropic.com"
+    max_tokens: int = 4096
 
     def socket_path(self) -> Path:
         """Get the socket path as a Path object."""

--- a/src/psi_agent/ai/anthropic_messages/server.py
+++ b/src/psi_agent/ai/anthropic_messages/server.py
@@ -54,7 +54,7 @@ class AnthropicMessagesServer:
             return web.Response(status=400, text="Invalid JSON body")
 
         # Translate OpenAI format to Anthropic format
-        anthropic_body = translate_openai_to_anthropic(body)
+        anthropic_body = translate_openai_to_anthropic(body, max_tokens=self.config.max_tokens)
 
         stream = anthropic_body.get("stream", False)
         body_summary = {

--- a/src/psi_agent/ai/anthropic_messages/translator.py
+++ b/src/psi_agent/ai/anthropic_messages/translator.py
@@ -7,11 +7,14 @@ from collections.abc import AsyncGenerator
 from typing import Any
 
 
-def translate_openai_to_anthropic(openai_request: dict[str, Any]) -> dict[str, Any]:
+def translate_openai_to_anthropic(
+    openai_request: dict[str, Any], max_tokens: int = 4096
+) -> dict[str, Any]:
     """Translate OpenAI chat completions request to Anthropic Messages format.
 
     Args:
         openai_request: OpenAI chat completions request format.
+        max_tokens: Default max_tokens to use if not provided in request.
 
     Returns:
         Anthropic Messages request format.
@@ -62,6 +65,10 @@ def translate_openai_to_anthropic(openai_request: dict[str, Any]) -> dict[str, A
     for param in ["model", "max_tokens", "temperature", "stream", "top_p", "stop"]:
         if param in openai_request:
             anthropic_request[param] = openai_request[param]
+
+    # Add default max_tokens if not provided
+    if "max_tokens" not in anthropic_request:
+        anthropic_request["max_tokens"] = max_tokens
 
     return anthropic_request
 

--- a/tests/ai/anthropic_messages/test_client.py
+++ b/tests/ai/anthropic_messages/test_client.py
@@ -111,6 +111,72 @@ class TestAnthropicMessagesClient:
                 assert call_kwargs[1]["model"] == "claude-sonnet-4-20250514"
 
     @pytest.mark.asyncio
+    async def test_model_session_placeholder_replacement(
+        self, client: AnthropicMessagesClient
+    ) -> None:
+        """Test model 'session' placeholder is replaced with configured model."""
+        mock_response = MagicMock()
+        mock_response.id = "msg_123"
+        mock_response.model_dump = MagicMock(
+            return_value={
+                "id": "msg_123",
+                "content": [{"type": "text", "text": "Response"}],
+            }
+        )
+
+        with patch("psi_agent.ai.anthropic_messages.client.AsyncAnthropic") as mock_anthropic:
+            mock_instance = AsyncMock()
+            mock_instance.messages.create = AsyncMock(return_value=mock_response)
+            mock_instance.close = AsyncMock()
+            mock_anthropic.return_value = mock_instance
+
+            async with client:
+                await client.messages(
+                    {
+                        "model": "session",  # Placeholder should be replaced
+                        "messages": [{"role": "user", "content": "Hello"}],
+                        "max_tokens": 1024,
+                    },
+                    stream=False,
+                )
+
+                # Check that model was replaced
+                call_kwargs = mock_instance.messages.create.call_args
+                assert call_kwargs[1]["model"] == "claude-sonnet-4-20250514"
+
+    @pytest.mark.asyncio
+    async def test_model_not_replaced_when_explicit(self, client: AnthropicMessagesClient) -> None:
+        """Test model is not replaced when explicit value (not 'session')."""
+        mock_response = MagicMock()
+        mock_response.id = "msg_123"
+        mock_response.model_dump = MagicMock(
+            return_value={
+                "id": "msg_123",
+                "content": [{"type": "text", "text": "Response"}],
+            }
+        )
+
+        with patch("psi_agent.ai.anthropic_messages.client.AsyncAnthropic") as mock_anthropic:
+            mock_instance = AsyncMock()
+            mock_instance.messages.create = AsyncMock(return_value=mock_response)
+            mock_instance.close = AsyncMock()
+            mock_anthropic.return_value = mock_instance
+
+            async with client:
+                await client.messages(
+                    {
+                        "model": "claude-opus-4",  # Explicit model should be preserved
+                        "messages": [{"role": "user", "content": "Hello"}],
+                        "max_tokens": 1024,
+                    },
+                    stream=False,
+                )
+
+                # Check that model was preserved
+                call_kwargs = mock_instance.messages.create.call_args
+                assert call_kwargs[1]["model"] == "claude-opus-4"
+
+    @pytest.mark.asyncio
     async def test_authentication_error(self, client: AnthropicMessagesClient) -> None:
         """Test authentication error handling."""
         from anthropic import AuthenticationError

--- a/tests/ai/anthropic_messages/test_translator.py
+++ b/tests/ai/anthropic_messages/test_translator.py
@@ -93,6 +93,37 @@ class TestTranslateOpenAIToAnthropic:
 
         assert result["messages"][0]["content"] == [{"type": "text", "text": "Hello"}]
 
+    def test_default_max_tokens(self) -> None:
+        """Test default max_tokens is added when not provided."""
+        openai_request = {
+            "messages": [{"role": "user", "content": "Hello"}],
+        }
+
+        result = translate_openai_to_anthropic(openai_request)
+
+        assert result["max_tokens"] == 4096
+
+    def test_custom_max_tokens_default(self) -> None:
+        """Test custom max_tokens default is used when not provided."""
+        openai_request = {
+            "messages": [{"role": "user", "content": "Hello"}],
+        }
+
+        result = translate_openai_to_anthropic(openai_request, max_tokens=8192)
+
+        assert result["max_tokens"] == 8192
+
+    def test_max_tokens_not_overridden(self) -> None:
+        """Test max_tokens is not overridden when provided in request."""
+        openai_request = {
+            "messages": [{"role": "user", "content": "Hello"}],
+            "max_tokens": 2048,
+        }
+
+        result = translate_openai_to_anthropic(openai_request, max_tokens=8192)
+
+        assert result["max_tokens"] == 2048
+
 
 class TestTranslateAnthropicToOpenAI:
     """Tests for Anthropic to OpenAI response translation."""


### PR DESCRIPTION
## Summary

- Add `max_tokens` CLI parameter with default 4096 for Anthropic API compatibility
- Fix model replacement to replace `"session"` placeholder with configured model name
- Add unit tests for both features

## Problem

The Anthropic Messages API requires `max_tokens` as a mandatory parameter, but the translator did not provide a default value. Additionally, the session layer passes `model: "session"` as a placeholder, but the client only replaced the model when it was absent, not when it was the placeholder value.

## Solution

1. **max_tokens**: Added as a CLI parameter (`--max-tokens`) with default 4096, passed through config to the translator
2. **Model placeholder**: Fixed client logic to also replace `"session"` with the configured model name

## Test plan

- [x] Unit tests for translator with and without `max_tokens`
- [x] Unit tests for model placeholder replacement
- [x] `ruff check` and `ruff format` pass
- [x] `ty check` passes
- [x] All 35 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)