### PR TITLE
Complete full anyio.Path migration for all path operations

### DIFF
--- a/openspec/changes/archive/2026-04-29-full-anyio-path-migration/.openspec.yaml
+++ b/openspec/changes/archive/2026-04-29-full-anyio-path-migration/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-28

--- a/openspec/changes/archive/2026-04-29-full-anyio-path-migration/design.md
+++ b/openspec/changes/archive/2026-04-29-full-anyio-path-migration/design.md
@@ -1,0 +1,93 @@
+## Context
+
+当前代码库使用 `pathlib.Path` 和 `anyio.Path` 混合模式：
+- IO 操作使用 `anyio.Path` (正确)
+- 类型注解使用 `pathlib.Path`
+- 数据类字段使用 `pathlib.Path`
+- 路径操作使用 `pathlib.Path`
+
+用户希望统一使用 `anyio.Path`，实现完全一致的代码风格。
+
+### anyio.Path 特性
+
+`anyio.Path` 是 `pathlib.Path` 的异步封装，支持：
+- 所有路径操作：`.parent`, `.name`, `.suffix`, `/` 操作符
+- 所有 IO 操作（异步）：`.exists()`, `.read_text()`, `.iterdir()` 等
+- 类型注解：可以作为类型使用
+
+## Goals / Non-Goals
+
+**Goals:**
+- 完全移除 `pathlib.Path` 的 import
+- 所有路径相关代码统一使用 `anyio.Path`
+- 类型注解使用 `anyio.Path`
+- 数据类字段使用 `anyio.Path`
+- 保持所有测试通过
+
+**Non-Goals:**
+- 修改外部 API 行为
+- 修改测试逻辑
+
+## Decisions
+
+### Decision 1: 使用 `anyio.Path` 作为唯一的路径类型
+
+**Rationale:** 统一代码风格，避免混用两种 Path 类型。`anyio.Path` 支持所有 `pathlib.Path` 的操作，包括非 IO 操作。
+
+**实现方式:**
+```python
+# 之前
+from pathlib import Path
+def foo(path: Path) -> Path:
+    return path.parent / "child"
+
+# 之后
+import anyio
+def foo(path: anyio.Path) -> anyio.Path:
+    return path.parent / "child"
+```
+
+### Decision 2: 数据类字段类型改为 `anyio.Path`
+
+**Rationale:** 保持类型一致性。`anyio.Path` 对象可以直接存储在数据类中。
+
+**实现方式:**
+```python
+# 之前
+@dataclass
+class Schedule:
+    task_dir: Path
+
+# 之后
+@dataclass
+class Schedule:
+    task_dir: anyio.Path
+```
+
+### Decision 3: Config 类返回 `anyio.Path`
+
+**Rationale:** Config 类的属性方法返回路径对象，应使用统一类型。
+
+**实现方式:**
+```python
+# 之前
+@property
+def socket_path(self) -> Path:
+    return Path(self.session_socket)
+
+# 之后
+@property
+def socket_path(self) -> anyio.Path:
+    return anyio.Path(self.session_socket)
+```
+
+## Risks / Trade-offs
+
+### Risk: 类型检查器兼容性
+**Mitigation:** `anyio.Path` 是 `pathlib.Path` 的子类，类型检查应该兼容。运行 `ty check` 验证。
+
+### Risk: 第三方库兼容性
+**Mitigation:** 检查所有使用 Path 的地方，确保 `anyio.Path` 可以正常工作。大多数接受 `Path` 的地方也接受 `anyio.Path`。
+
+### Risk: 性能影响
+**Mitigation:** `anyio.Path` 的非 IO 操作（如 `.parent`, `.name`）是同步的，性能影响可忽略。

--- a/openspec/changes/archive/2026-04-29-full-anyio-path-migration/proposal.md
+++ b/openspec/changes/archive/2026-04-29-full-anyio-path-migration/proposal.md
@@ -1,0 +1,52 @@
+## Why
+
+当前代码库混合使用 `pathlib.Path` 和 `anyio.Path`，虽然 IO 操作已使用 `anyio.Path`，但类型注解、路径操作和数据类存储仍使用 `pathlib.Path`。为了代码一致性和未来维护性，应该统一使用 `anyio.Path`。
+
+## What Changes
+
+- 将所有 `pathlib.Path` 类型注解替换为 `anyio.Path`
+- 将所有 `from pathlib import Path` 替换为 `import anyio` 并使用 `anyio.Path`
+- 将数据类中的 `Path` 类型字段改为 `anyio.Path`
+- 更新所有路径操作使用 `anyio.Path` 的方法
+
+### 受影响的文件：
+
+**Config 文件** (类型注解):
+- `src/psi_agent/channel/telegram/config.py`
+- `src/psi_agent/channel/repl/config.py`
+- `src/psi_agent/session/config.py`
+- `src/psi_agent/ai/anthropic_messages/config.py`
+- `src/psi_agent/ai/openai_completions/config.py`
+
+**Session 文件** (类型注解和数据类):
+- `src/psi_agent/session/schedule.py` - `Schedule.task_dir: Path`
+- `src/psi_agent/session/workspace_watcher.py` - 返回类型和参数类型
+- `src/psi_agent/session/tool_loader.py` - 返回类型和参数类型
+- `src/psi_agent/session/runner.py` - 参数类型
+
+**Workspace 文件** (类型注解):
+- `src/psi_agent/workspace/snapshot/api.py`
+- `src/psi_agent/workspace/umount/api.py`
+- `src/psi_agent/workspace/mount/api.py`
+- `src/psi_agent/workspace/unpack/api.py`
+- `src/psi_agent/workspace/pack/api.py`
+
+**AI 文件**:
+- `src/psi_agent/ai/openai_completions/server.py`
+
+## Capabilities
+
+### New Capabilities
+
+None - this is an internal refactoring for code consistency.
+
+### Modified Capabilities
+
+- `async-file-operations`: Update to require `anyio.Path` for ALL path-related code, including type annotations and data class fields.
+
+## Impact
+
+- **Breaking change for internal APIs**: Function signatures will change from `Path` to `anyio.Path`
+- **No external API changes**: All public interfaces remain the same
+- **Type checking**: May require updates to type annotations in tests
+- **All tests must pass**: `ruff check`, `ruff format`, `ty check`, `pytest`

--- a/openspec/changes/archive/2026-04-29-full-anyio-path-migration/specs/async-file-operations/spec.md
+++ b/openspec/changes/archive/2026-04-29-full-anyio-path-migration/specs/async-file-operations/spec.md
@@ -1,0 +1,63 @@
+## MODIFIED Requirements
+
+### Requirement: All file I/O operations must use async methods
+
+All file system I/O operations in the psi-agent codebase SHALL use async methods from `anyio.Path` or `anyio.open_file()` to prevent blocking the async event loop.
+
+#### Scenario: Reading file content
+- **WHEN** code needs to read file content
+- **THEN** it SHALL use `await anyio.Path(path).read_text()` or `await anyio.open_file(path)` instead of `pathlib.Path.read_text()`
+
+#### Scenario: Checking file existence
+- **WHEN** code needs to check if a file exists
+- **THEN** it SHALL use `await anyio.Path(path).exists()` instead of `pathlib.Path.exists()`
+
+#### Scenario: Deleting a file
+- **WHEN** code needs to delete a file
+- **THEN** it SHALL use `await anyio.Path(path).unlink()` instead of `pathlib.Path.unlink()`
+
+#### Scenario: Iterating directory contents
+- **WHEN** code needs to iterate over directory contents
+- **THEN** it SHALL use `async for item in anyio.Path(path).iterdir()` instead of `for item in pathlib.Path(path).iterdir()`
+
+#### Scenario: Creating directories
+- **WHEN** code needs to create a directory
+- **THEN** it SHALL use `await anyio.Path(path).mkdir()` instead of `pathlib.Path.mkdir()`
+
+#### Scenario: Resolving paths
+- **WHEN** code needs to resolve a path to its absolute form
+- **THEN** it SHALL use `await anyio.Path(path).resolve()` instead of `pathlib.Path.resolve()` when the operation involves I/O
+
+### Requirement: pathlib.Path may be used for type annotations and path manipulation
+
+**REMOVED** - `pathlib.Path` SHALL NOT be used anywhere in the codebase. All path-related code SHALL use `anyio.Path`.
+
+**Reason**: Code consistency - using a single path type throughout the codebase.
+
+**Migration**: Replace all `pathlib.Path` with `anyio.Path`:
+- Type annotations: `Path` → `anyio.Path`
+- Data class fields: `task_dir: Path` → `task_dir: anyio.Path`
+- Import statements: `from pathlib import Path` → `import anyio` (use `anyio.Path`)
+- Path construction: `Path(path)` → `anyio.Path(path)`
+
+## ADDED Requirements
+
+### Requirement: All path types must be anyio.Path
+
+All path-related types in the psi-agent codebase SHALL use `anyio.Path`, including type annotations, data class fields, and function parameters/returns.
+
+#### Scenario: Type annotation for path parameters
+- **WHEN** a function accepts a path parameter
+- **THEN** it SHALL use `anyio.Path` as the type annotation
+
+#### Scenario: Type annotation for path returns
+- **WHEN** a function returns a path
+- **THEN** it SHALL use `anyio.Path` as the return type
+
+#### Scenario: Data class path fields
+- **WHEN** a data class stores a path
+- **THEN** the field type SHALL be `anyio.Path`
+
+#### Scenario: Config class path properties
+- **WHEN** a config class provides a path property
+- **THEN** the return type SHALL be `anyio.Path`

--- a/openspec/changes/archive/2026-04-29-full-anyio-path-migration/tasks.md
+++ b/openspec/changes/archive/2026-04-29-full-anyio-path-migration/tasks.md
@@ -1,0 +1,34 @@
+## 1. Config Files Migration
+
+- [x] 1.1 Migrate `src/psi_agent/channel/telegram/config.py` - Replace `from pathlib import Path` with `import anyio`, change return type to `anyio.Path`
+- [x] 1.2 Migrate `src/psi_agent/channel/repl/config.py` - Replace `from pathlib import Path` with `import anyio`, change return types to `anyio.Path`
+- [x] 1.3 Migrate `src/psi_agent/session/config.py` - Replace `from pathlib import Path` with `import anyio`, change return types to `anyio.Path`
+- [x] 1.4 Migrate `src/psi_agent/ai/anthropic_messages/config.py` - Replace `from pathlib import Path` with `import anyio`, change return type to `anyio.Path`
+- [x] 1.5 Migrate `src/psi_agent/ai/openai_completions/config.py` - Replace `from pathlib import Path` with `import anyio`, change return type to `anyio.Path`
+
+## 2. Session Files Migration
+
+- [x] 2.1 Migrate `src/psi_agent/session/schedule.py` - Replace `from pathlib import Path` with `import anyio`, change `Schedule.task_dir` type to `anyio.Path`, update all `Path()` usages
+- [x] 2.2 Migrate `src/psi_agent/session/workspace_watcher.py` - Replace `from pathlib import Path` with `import anyio`, change all type annotations and `Path()` usages
+- [x] 2.3 Migrate `src/psi_agent/session/tool_loader.py` - Replace `from pathlib import Path` with `import anyio`, change all type annotations and `Path()` usages
+- [x] 2.4 Migrate `src/psi_agent/session/runner.py` - Replace `from pathlib import Path` with `import anyio`, change parameter types
+- [x] 2.5 Migrate `src/psi_agent/session/history.py` - Replace `from pathlib import Path` with `import anyio` if present, change parameter types
+
+## 3. Workspace Files Migration
+
+- [x] 3.1 Migrate `src/psi_agent/workspace/snapshot/api.py` - Replace `from pathlib import Path` with `import anyio`, change all type annotations and `Path()` usages
+- [x] 3.2 Migrate `src/psi_agent/workspace/umount/api.py` - Replace `from pathlib import Path` with `import anyio`, change all type annotations and `Path()` usages
+- [x] 3.3 Migrate `src/psi_agent/workspace/mount/api.py` - Replace `from pathlib import Path` with `import anyio`, change all type annotations and `Path()` usages
+- [x] 3.4 Migrate `src/psi_agent/workspace/unpack/api.py` - Replace `from pathlib import Path` with `import anyio`, change all type annotations and `Path()` usages
+- [x] 3.5 Migrate `src/psi_agent/workspace/pack/api.py` - Replace `from pathlib import Path` with `import anyio`, change all type annotations and `Path()` usages
+
+## 4. AI Files Migration
+
+- [x] 4.1 Migrate `src/psi_agent/ai/openai_completions/server.py` - Replace `from pathlib import Path` with `import anyio`, change all `Path()` usages
+
+## 5. Verification
+
+- [x] 5.1 Run `ruff check` to verify no lint errors
+- [x] 5.2 Run `ruff format` to verify formatting
+- [x] 5.3 Run `ty check` to verify type checking passes
+- [x] 5.4 Run `pytest` to verify all tests pass

--- a/src/psi_agent/ai/anthropic_messages/config.py
+++ b/src/psi_agent/ai/anthropic_messages/config.py
@@ -3,7 +3,8 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from pathlib import Path
+
+import anyio
 
 
 @dataclass
@@ -24,6 +25,6 @@ class AnthropicMessagesConfig:
     base_url: str = "https://api.anthropic.com"
     max_tokens: int = 4096
 
-    def socket_path(self) -> Path:
+    def socket_path(self) -> anyio.Path:
         """Get the socket path as a Path object."""
-        return Path(self.session_socket)
+        return anyio.Path(self.session_socket)

--- a/src/psi_agent/ai/openai_completions/config.py
+++ b/src/psi_agent/ai/openai_completions/config.py
@@ -3,7 +3,8 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from pathlib import Path
+
+import anyio
 
 
 @dataclass
@@ -22,6 +23,6 @@ class OpenAICompletionsConfig:
     api_key: str
     base_url: str = "https://api.openai.com/v1"
 
-    def socket_path(self) -> Path:
+    def socket_path(self) -> anyio.Path:
         """Get the socket path as a Path object."""
-        return Path(self.session_socket)
+        return anyio.Path(self.session_socket)

--- a/src/psi_agent/ai/openai_completions/server.py
+++ b/src/psi_agent/ai/openai_completions/server.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import json
-from pathlib import Path
 from typing import Any
 
 import anyio
@@ -153,12 +152,12 @@ class OpenAICompletionsServer:
 
     async def start(self) -> None:
         """Start the server on Unix socket."""
-        socket_path = Path(self.config.session_socket)
+        socket_path = anyio.Path(self.config.session_socket)
 
         # Remove existing socket file if present
-        if await anyio.Path(socket_path).exists():
+        if await socket_path.exists():
             logger.debug(f"Removing existing socket file: {socket_path}")
-            await anyio.Path(socket_path).unlink()
+            await socket_path.unlink()
 
         # Initialize client
         self.client = OpenAICompletionsClient(self.config)

--- a/src/psi_agent/channel/repl/config.py
+++ b/src/psi_agent/channel/repl/config.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from pathlib import Path
+from pathlib import Path as SyncPath
+
+import anyio
 
 
 @dataclass
@@ -18,16 +20,17 @@ class ReplConfig:
     session_socket: str
     history_file: str | None = None
 
-    def socket_path(self) -> Path:
+    def socket_path(self) -> anyio.Path:
         """Get the socket path as a Path object."""
-        return Path(self.session_socket)
+        return anyio.Path(self.session_socket)
 
-    def get_history_path(self) -> Path:
+    def get_history_path(self) -> anyio.Path:
         """Get the history file path.
 
         Returns the configured history file path or the default path
         at ~/.cache/psi-agent/repl_history.txt.
         """
         if self.history_file is not None:
-            return Path(self.history_file)
-        return Path.home() / ".cache" / "psi-agent" / "repl_history.txt"
+            return anyio.Path(self.history_file)
+        # Use SyncPath.home() for path construction (no IO), then convert to anyio.Path
+        return anyio.Path(SyncPath.home() / ".cache" / "psi-agent" / "repl_history.txt")

--- a/src/psi_agent/channel/repl/repl.py
+++ b/src/psi_agent/channel/repl/repl.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-from pathlib import Path
-
 import anyio
 from loguru import logger
 from prompt_toolkit import PromptSession
@@ -13,15 +11,15 @@ from psi_agent.channel.repl.client import ReplClient
 from psi_agent.channel.repl.config import ReplConfig
 
 
-async def _ensure_history_dir(history_path: Path) -> None:
+async def _ensure_history_dir(history_path: anyio.Path) -> None:
     """Ensure the directory for the history file exists.
 
     Args:
         history_path: Path to the history file.
     """
     history_dir = history_path.parent
-    if not await anyio.Path(history_dir).exists():
-        await anyio.Path(history_dir).mkdir(parents=True, exist_ok=True)
+    if not await history_dir.exists():
+        await history_dir.mkdir(parents=True, exist_ok=True)
         logger.debug(f"Created history directory: {history_dir}")
 
 

--- a/src/psi_agent/channel/telegram/config.py
+++ b/src/psi_agent/channel/telegram/config.py
@@ -3,7 +3,8 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from pathlib import Path
+
+import anyio
 
 
 @dataclass
@@ -18,6 +19,6 @@ class TelegramConfig:
     token: str
     session_socket: str
 
-    def socket_path(self) -> Path:
+    def socket_path(self) -> anyio.Path:
         """Get the socket path as a Path object."""
-        return Path(self.session_socket)
+        return anyio.Path(self.session_socket)

--- a/src/psi_agent/session/config.py
+++ b/src/psi_agent/session/config.py
@@ -3,7 +3,8 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from pathlib import Path
+
+import anyio
 
 
 @dataclass
@@ -22,26 +23,26 @@ class SessionConfig:
     workspace: str
     history_file: str | None = None
 
-    def channel_socket_path(self) -> Path:
+    def channel_socket_path(self) -> anyio.Path:
         """Get channel socket path as Path object."""
-        return Path(self.channel_socket)
+        return anyio.Path(self.channel_socket)
 
-    def ai_socket_path(self) -> Path:
+    def ai_socket_path(self) -> anyio.Path:
         """Get AI socket path as Path object."""
-        return Path(self.ai_socket)
+        return anyio.Path(self.ai_socket)
 
-    def workspace_path(self) -> Path:
+    def workspace_path(self) -> anyio.Path:
         """Get workspace path as Path object."""
-        return Path(self.workspace)
+        return anyio.Path(self.workspace)
 
-    def history_file_path(self) -> Path | None:
+    def history_file_path(self) -> anyio.Path | None:
         """Get history file path as Path object, or None."""
-        return Path(self.history_file) if self.history_file else None
+        return anyio.Path(self.history_file) if self.history_file else None
 
-    def tools_dir(self) -> Path:
+    def tools_dir(self) -> anyio.Path:
         """Get tools directory path."""
         return self.workspace_path() / "tools"
 
-    def systems_dir(self) -> Path:
+    def systems_dir(self) -> anyio.Path:
         """Get systems directory path."""
         return self.workspace_path() / "systems"

--- a/src/psi_agent/session/history.py
+++ b/src/psi_agent/session/history.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import json
-from pathlib import Path
 from typing import Any
 
 import anyio
@@ -12,7 +11,7 @@ from loguru import logger
 from psi_agent.session.types import History
 
 
-async def load_history_from_file(history_file: Path | anyio.Path) -> list[dict[str, Any]]:
+async def load_history_from_file(history_file: anyio.Path) -> list[dict[str, Any]]:
     """Load history from JSON file.
 
     Args:
@@ -21,12 +20,12 @@ async def load_history_from_file(history_file: Path | anyio.Path) -> list[dict[s
     Returns:
         List of messages, empty list if file doesn't exist or is corrupted.
     """
-    if not await anyio.Path(history_file).exists():
+    if not await history_file.exists():
         logger.debug(f"History file does not exist: {history_file}")
         return []
 
     try:
-        content = await anyio.Path(history_file).read_text()
+        content = await history_file.read_text()
         messages = json.loads(content)
         logger.info(f"Loaded {len(messages)} messages from history file")
         return messages
@@ -38,7 +37,7 @@ async def load_history_from_file(history_file: Path | anyio.Path) -> list[dict[s
         return []
 
 
-async def save_history_to_file(history: History, history_file: Path | anyio.Path) -> None:
+async def save_history_to_file(history: History, history_file: anyio.Path) -> None:
     """Save history to JSON file.
 
     Args:
@@ -47,7 +46,7 @@ async def save_history_to_file(history: History, history_file: Path | anyio.Path
     """
     try:
         content = json.dumps(history.messages, ensure_ascii=False, indent=2)
-        await anyio.Path(history_file).write_text(content)
+        await history_file.write_text(content)
         logger.debug(f"Saved {len(history.messages)} messages to history file")
     except Exception as e:
         logger.error(f"Failed to save history file: {e}")

--- a/src/psi_agent/session/runner.py
+++ b/src/psi_agent/session/runner.py
@@ -6,7 +6,6 @@ import importlib.util
 import json
 import sys
 from collections.abc import AsyncGenerator
-from pathlib import Path
 from typing import Any
 
 import aiohttp
@@ -22,7 +21,7 @@ from psi_agent.session.types import History, ToolRegistry
 from psi_agent.session.workspace_watcher import ChangeSummary, WorkspaceWatcher
 
 
-async def _load_system(workspace: Path) -> Any:
+async def _load_system(workspace: anyio.Path) -> Any:
     """Load System class from workspace systems.
 
     Args:
@@ -32,7 +31,7 @@ async def _load_system(workspace: Path) -> Any:
         System instance, or None if not available.
     """
     system_file = workspace / "systems" / "system.py"
-    if not await anyio.Path(system_file).exists():
+    if not await system_file.exists():
         logger.debug("No systems/system.py found, skipping system prompt")
         return None
 
@@ -62,7 +61,7 @@ async def _load_system(workspace: Path) -> Any:
         return None
 
 
-async def load_system_prompt(workspace: Path) -> str | None:
+async def load_system_prompt(workspace: anyio.Path) -> str | None:
     """Load system prompt from workspace systems.
 
     Args:
@@ -72,7 +71,7 @@ async def load_system_prompt(workspace: Path) -> str | None:
         System prompt string, or None if not available.
     """
     system_file = workspace / "systems" / "system.py"
-    if not await anyio.Path(system_file).exists():
+    if not await system_file.exists():
         logger.debug("No systems/system.py found, skipping system prompt")
         return None
 
@@ -201,7 +200,7 @@ class SessionRunner:
             for name in changes.schedules_removed:
                 await self._schedule_executor.remove_schedule(name)
 
-    async def _load_single_schedule(self, task_dir: Path) -> Schedule | None:
+    async def _load_single_schedule(self, task_dir: anyio.Path) -> Schedule | None:
         """Load a single schedule from a task directory.
 
         Args:

--- a/src/psi_agent/session/schedule.py
+++ b/src/psi_agent/session/schedule.py
@@ -6,7 +6,6 @@ import asyncio
 import re
 from dataclasses import dataclass, field
 from datetime import datetime
-from pathlib import Path
 from typing import TYPE_CHECKING, cast
 
 import anyio
@@ -32,7 +31,7 @@ class Schedule:
     name: str
     cron: str
     content: str
-    task_dir: Path
+    task_dir: anyio.Path
     description: str = ""
     _croniter: croniter.croniter | None = field(default=None, repr=False, compare=False)
 
@@ -92,7 +91,7 @@ def parse_frontmatter(content: str) -> tuple[dict[str, str], str]:
     return frontmatter, remaining
 
 
-async def load_schedule(task_dir: Path) -> Schedule | None:
+async def load_schedule(task_dir: anyio.Path) -> Schedule | None:
     """Load a schedule from a task directory.
 
     Args:
@@ -102,7 +101,7 @@ async def load_schedule(task_dir: Path) -> Schedule | None:
         Schedule object, or None if invalid.
     """
     task_file = task_dir / "TASK.md"
-    if not await anyio.Path(task_file).exists():
+    if not await task_file.exists():
         logger.debug(f"No TASK.md in {task_dir}")
         return None
 
@@ -133,7 +132,7 @@ async def load_schedule(task_dir: Path) -> Schedule | None:
         return None
 
 
-async def load_schedules(workspace: Path) -> list[Schedule]:
+async def load_schedules(workspace: anyio.Path) -> list[Schedule]:
     """Load all schedules from workspace.
 
     Args:
@@ -143,14 +142,14 @@ async def load_schedules(workspace: Path) -> list[Schedule]:
         List of valid Schedule objects.
     """
     schedules_dir = workspace / "schedules"
-    if not await anyio.Path(schedules_dir).exists():
+    if not await schedules_dir.exists():
         logger.debug("No schedules directory in workspace")
         return []
 
     schedules = []
-    async for entry in anyio.Path(schedules_dir).iterdir():
-        if await anyio.Path(entry).is_dir():
-            schedule = await load_schedule(Path(entry))
+    async for entry in schedules_dir.iterdir():
+        if await entry.is_dir():
+            schedule = await load_schedule(entry)
             if schedule is not None:
                 schedules.append(schedule)
                 logger.info(f"Loaded schedule: {schedule.name} (cron: {schedule.cron})")

--- a/src/psi_agent/session/tool_loader.py
+++ b/src/psi_agent/session/tool_loader.py
@@ -8,7 +8,6 @@ import inspect
 import re
 import sys
 from collections.abc import Callable, Coroutine
-from pathlib import Path
 from typing import Any
 
 import anyio
@@ -17,7 +16,7 @@ from loguru import logger
 from psi_agent.session.types import ToolRegistry, ToolSchema
 
 
-async def compute_file_hash(file_path: Path) -> str:
+async def compute_file_hash(file_path: anyio.Path) -> str:
     """Compute MD5 hash of a file.
 
     Args:
@@ -26,7 +25,7 @@ async def compute_file_hash(file_path: Path) -> str:
     Returns:
         MD5 hash string.
     """
-    content = await anyio.Path(file_path).read_bytes()
+    content = await file_path.read_bytes()
     return hashlib.md5(content).hexdigest()
 
 
@@ -155,7 +154,7 @@ def generate_tool_schema(
     }
 
 
-async def load_tool_from_file(file_path: Path) -> ToolSchema | None:
+async def load_tool_from_file(file_path: anyio.Path) -> ToolSchema | None:
     """Load a tool from a Python file.
 
     Args:
@@ -214,7 +213,7 @@ async def load_tool_from_file(file_path: Path) -> ToolSchema | None:
         return None
 
 
-async def scan_tools_directory(tools_dir: Path) -> dict[str, tuple[Path, str]]:
+async def scan_tools_directory(tools_dir: anyio.Path) -> dict[str, tuple[anyio.Path, str]]:
     """Scan tools directory and return file info.
 
     Args:
@@ -223,22 +222,22 @@ async def scan_tools_directory(tools_dir: Path) -> dict[str, tuple[Path, str]]:
     Returns:
         Dict mapping tool name to (file_path, file_hash).
     """
-    if not await anyio.Path(tools_dir).exists():
+    if not await tools_dir.exists():
         logger.debug(f"Tools directory does not exist: {tools_dir}")
         return {}
 
-    tool_files: dict[str, tuple[Path, str]] = {}
+    tool_files: dict[str, tuple[anyio.Path, str]] = {}
 
-    async for file_path in anyio.Path(tools_dir).iterdir():
-        if await anyio.Path(file_path).is_file() and file_path.suffix == ".py":
+    async for file_path in tools_dir.iterdir():
+        if await file_path.is_file() and file_path.suffix == ".py":
             tool_name = file_path.stem
-            file_hash = await compute_file_hash(Path(file_path))
-            tool_files[tool_name] = (Path(file_path), file_hash)
+            file_hash = await compute_file_hash(file_path)
+            tool_files[tool_name] = (file_path, file_hash)
 
     return tool_files
 
 
-async def load_all_tools(tools_dir: Path, registry: ToolRegistry) -> None:
+async def load_all_tools(tools_dir: anyio.Path, registry: ToolRegistry) -> None:
     """Load all tools from directory into registry.
 
     Args:
@@ -253,7 +252,7 @@ async def load_all_tools(tools_dir: Path, registry: ToolRegistry) -> None:
             registry.register(tool_schema)
 
 
-async def detect_and_update_tools(tools_dir: Path, registry: ToolRegistry) -> None:
+async def detect_and_update_tools(tools_dir: anyio.Path, registry: ToolRegistry) -> None:
     """Detect tool changes and update registry.
 
     Args:

--- a/src/psi_agent/session/workspace_watcher.py
+++ b/src/psi_agent/session/workspace_watcher.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import hashlib
 from dataclasses import dataclass, field
-from pathlib import Path
 from typing import Any
 
 import anyio
@@ -78,7 +77,7 @@ class ChangeSummary:
         }
 
 
-async def compute_file_hash(file_path: Path) -> str:
+async def compute_file_hash(file_path: anyio.Path) -> str:
     """Compute MD5 hash of a file.
 
     Args:
@@ -87,11 +86,11 @@ async def compute_file_hash(file_path: Path) -> str:
     Returns:
         MD5 hash string.
     """
-    content = await anyio.Path(file_path).read_bytes()
+    content = await file_path.read_bytes()
     return hashlib.md5(content).hexdigest()
 
 
-async def scan_tools_directory(tools_dir: Path) -> dict[str, tuple[Path, str]]:
+async def scan_tools_directory(tools_dir: anyio.Path) -> dict[str, tuple[anyio.Path, str]]:
     """Scan tools directory and return file info.
 
     Args:
@@ -100,21 +99,21 @@ async def scan_tools_directory(tools_dir: Path) -> dict[str, tuple[Path, str]]:
     Returns:
         Dict mapping tool name to (file_path, file_hash).
     """
-    if not await anyio.Path(tools_dir).exists():
+    if not await tools_dir.exists():
         return {}
 
-    tool_files: dict[str, tuple[Path, str]] = {}
+    tool_files: dict[str, tuple[anyio.Path, str]] = {}
 
-    async for file_path in anyio.Path(tools_dir).iterdir():
-        if await anyio.Path(file_path).is_file() and file_path.suffix == ".py":
+    async for file_path in tools_dir.iterdir():
+        if await file_path.is_file() and file_path.suffix == ".py":
             tool_name = file_path.stem
-            file_hash = await compute_file_hash(Path(file_path))
-            tool_files[tool_name] = (Path(file_path), file_hash)
+            file_hash = await compute_file_hash(file_path)
+            tool_files[tool_name] = (file_path, file_hash)
 
     return tool_files
 
 
-async def scan_skills_directory(skills_dir: Path) -> dict[str, tuple[Path, str]]:
+async def scan_skills_directory(skills_dir: anyio.Path) -> dict[str, tuple[anyio.Path, str]]:
     """Scan skills directory and return file info.
 
     Args:
@@ -123,23 +122,23 @@ async def scan_skills_directory(skills_dir: Path) -> dict[str, tuple[Path, str]]
     Returns:
         Dict mapping skill name to (skill_md_path, file_hash).
     """
-    if not await anyio.Path(skills_dir).exists():
+    if not await skills_dir.exists():
         return {}
 
-    skill_files: dict[str, tuple[Path, str]] = {}
+    skill_files: dict[str, tuple[anyio.Path, str]] = {}
 
-    async for entry in anyio.Path(skills_dir).iterdir():
-        if await anyio.Path(entry).is_dir():
+    async for entry in skills_dir.iterdir():
+        if await entry.is_dir():
             skill_md = entry / "SKILL.md"
-            if await anyio.Path(skill_md).exists():
+            if await skill_md.exists():
                 skill_name = entry.name
-                file_hash = await compute_file_hash(Path(skill_md))
-                skill_files[skill_name] = (Path(skill_md), file_hash)
+                file_hash = await compute_file_hash(skill_md)
+                skill_files[skill_name] = (skill_md, file_hash)
 
     return skill_files
 
 
-async def scan_schedules_directory(schedules_dir: Path) -> dict[str, tuple[Path, str]]:
+async def scan_schedules_directory(schedules_dir: anyio.Path) -> dict[str, tuple[anyio.Path, str]]:
     """Scan schedules directory and return file info.
 
     Args:
@@ -148,18 +147,18 @@ async def scan_schedules_directory(schedules_dir: Path) -> dict[str, tuple[Path,
     Returns:
         Dict mapping schedule name to (task_md_path, file_hash).
     """
-    if not await anyio.Path(schedules_dir).exists():
+    if not await schedules_dir.exists():
         return {}
 
-    schedule_files: dict[str, tuple[Path, str]] = {}
+    schedule_files: dict[str, tuple[anyio.Path, str]] = {}
 
-    async for entry in anyio.Path(schedules_dir).iterdir():
-        if await anyio.Path(entry).is_dir():
+    async for entry in schedules_dir.iterdir():
+        if await entry.is_dir():
             task_md = entry / "TASK.md"
-            if await anyio.Path(task_md).exists():
+            if await task_md.exists():
                 schedule_name = entry.name
-                file_hash = await compute_file_hash(Path(task_md))
-                schedule_files[schedule_name] = (Path(task_md), file_hash)
+                file_hash = await compute_file_hash(task_md)
+                schedule_files[schedule_name] = (task_md, file_hash)
 
     return schedule_files
 
@@ -167,7 +166,7 @@ async def scan_schedules_directory(schedules_dir: Path) -> dict[str, tuple[Path,
 class WorkspaceWatcher:
     """Watches workspace files for changes and detects modifications."""
 
-    def __init__(self, workspace: Path) -> None:
+    def __init__(self, workspace: anyio.Path) -> None:
         """Initialize the workspace watcher.
 
         Args:

--- a/src/psi_agent/workspace/mount/api.py
+++ b/src/psi_agent/workspace/mount/api.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import asyncio
 import tempfile
-from pathlib import Path
 from uuid import UUID
 
 import anyio
@@ -20,8 +19,8 @@ class MountError(Exception):
 
 
 async def mount(
-    input_file: str | Path,
-    output_dir: str | Path,
+    input_file: str | anyio.Path,
+    output_dir: str | anyio.Path,
     layer: str | None = None,
 ) -> None:
     """Mount a squashfs image as overlayfs to a directory.
@@ -34,13 +33,13 @@ async def mount(
     Raises:
         MountError: If mount operation fails.
     """
-    input_path = Path(await anyio.Path(input_file).resolve())
-    output_path = Path(await anyio.Path(output_dir).resolve())
+    input_path = anyio.Path(await anyio.Path(input_file).resolve())
+    output_path = anyio.Path(await anyio.Path(output_dir).resolve())
 
     # Validate input file
-    if not await anyio.Path(input_path).exists():
+    if not await input_path.exists():
         raise MountError(f"Input file does not exist: {input_path}")
-    if not await anyio.Path(input_path).is_file():
+    if not await input_path.is_file():
         raise MountError(f"Input path is not a file: {input_path}")
 
     logger.info(f"Mounting squashfs from {input_path} to {output_path}")
@@ -52,7 +51,7 @@ async def mount(
 
     # Read manifest
     manifest_path = squashfs_mount / "manifest.json"
-    if not await anyio.Path(manifest_path).exists():
+    if not await manifest_path.exists():
         raise MountError("manifest.json not found in squashfs")
 
     async with await anyio.open_file(manifest_path) as f:
@@ -76,7 +75,7 @@ async def mount(
     lowerdir = ":".join(lowerdirs)
 
     # Create output directory
-    await anyio.Path(output_path).mkdir(parents=True, exist_ok=True)
+    await output_path.mkdir(parents=True, exist_ok=True)
 
     # Mount overlayfs
     await _mount_overlayfs(output_path, lowerdir, upper_dir, work_dir)
@@ -130,7 +129,7 @@ def _resolve_target_layer(manifest: Manifest, layer: str | None) -> UUID:
     raise MountError(f"Layer '{layer}' not found. Available tags: {available_tags}")
 
 
-async def _create_temp_dir(prefix: str) -> Path:
+async def _create_temp_dir(prefix: str) -> anyio.Path:
     """Create a temporary directory.
 
     Args:
@@ -139,13 +138,13 @@ async def _create_temp_dir(prefix: str) -> Path:
     Returns:
         Path to the created directory.
     """
-    temp_base = Path(tempfile.gettempdir())
+    temp_base = anyio.Path(tempfile.gettempdir())
     temp_dir = temp_base / f"{prefix}{tempfile.mkdtemp(prefix='')}"
-    await anyio.Path(temp_dir).mkdir(parents=True, exist_ok=True)
+    await temp_dir.mkdir(parents=True, exist_ok=True)
     return temp_dir
 
 
-async def _mount_squashfs(squashfs_file: Path, mount_point: Path) -> None:
+async def _mount_squashfs(squashfs_file: anyio.Path, mount_point: anyio.Path) -> None:
     """Mount squashfs to directory.
 
     Args:
@@ -155,7 +154,7 @@ async def _mount_squashfs(squashfs_file: Path, mount_point: Path) -> None:
     Raises:
         MountError: If mount fails.
     """
-    await anyio.Path(mount_point).mkdir(parents=True, exist_ok=True)
+    await mount_point.mkdir(parents=True, exist_ok=True)
 
     cmd = ["mount", "-t", "squashfs", str(squashfs_file), str(mount_point), "-o", "loop"]
     logger.debug(f"Running: {' '.join(cmd)}")
@@ -176,10 +175,10 @@ async def _mount_squashfs(squashfs_file: Path, mount_point: Path) -> None:
 
 
 async def _mount_overlayfs(
-    mount_point: Path,
+    mount_point: anyio.Path,
     lowerdir: str,
-    upper_dir: Path,
-    work_dir: Path,
+    upper_dir: anyio.Path,
+    work_dir: anyio.Path,
 ) -> None:
     """Mount overlayfs to directory.
 
@@ -192,8 +191,8 @@ async def _mount_overlayfs(
     Raises:
         MountError: If mount fails.
     """
-    await anyio.Path(upper_dir).mkdir(parents=True, exist_ok=True)
-    await anyio.Path(work_dir).mkdir(parents=True, exist_ok=True)
+    await upper_dir.mkdir(parents=True, exist_ok=True)
+    await work_dir.mkdir(parents=True, exist_ok=True)
 
     cmd = [
         "mount",

--- a/src/psi_agent/workspace/pack/api.py
+++ b/src/psi_agent/workspace/pack/api.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import asyncio
 import tempfile
-from pathlib import Path
 from uuid import uuid4
 
 import anyio
@@ -20,8 +19,8 @@ class PackError(Exception):
 
 
 async def pack(
-    input_dir: str | Path,
-    output_file: str | Path,
+    input_dir: str | anyio.Path,
+    output_file: str | anyio.Path,
     tag: str | None = None,
 ) -> None:
     """Pack a workspace directory into a squashfs image.
@@ -34,13 +33,13 @@ async def pack(
     Raises:
         PackError: If pack operation fails.
     """
-    input_path = Path(await anyio.Path(input_dir).resolve())
-    output_path = Path(await anyio.Path(output_file).resolve())
+    input_path = anyio.Path(await anyio.Path(input_dir).resolve())
+    output_path = anyio.Path(await anyio.Path(output_file).resolve())
 
     # Validate input directory
-    if not await anyio.Path(input_path).exists():
+    if not await input_path.exists():
         raise PackError(f"Input directory does not exist: {input_path}")
-    if not await anyio.Path(input_path).is_dir():
+    if not await input_path.is_dir():
         raise PackError(f"Input path is not a directory: {input_path}")
 
     # Generate UUID for the layer
@@ -58,11 +57,11 @@ async def pack(
 
     # Create temporary directory for staging
     with tempfile.TemporaryDirectory() as temp_dir:
-        temp_path = Path(temp_dir)
+        temp_path = anyio.Path(temp_dir)
 
         # Create layer directory
         layer_dir = temp_path / layer_name
-        await anyio.Path(layer_dir).mkdir()
+        await layer_dir.mkdir()
 
         # Copy input directory contents to layer directory
         await _copy_directory(input_path, layer_dir)
@@ -79,19 +78,19 @@ async def pack(
     logger.info(f"Successfully created squashfs at {output_path}")
 
 
-async def _copy_directory(src: Path, dst: Path) -> None:
+async def _copy_directory(src: anyio.Path, dst: anyio.Path) -> None:
     """Copy directory contents asynchronously.
 
     Args:
         src: Source directory path.
         dst: Destination directory path.
     """
-    async for item in anyio.Path(src).iterdir():
+    async for item in src.iterdir():
         dest_item = dst / item.name
         logger.debug(f"Copying: {item} -> {dest_item}")
-        if await anyio.Path(item).is_dir():
-            await anyio.Path(dest_item).mkdir()
-            await _copy_directory(Path(item), dest_item)
+        if await item.is_dir():
+            await dest_item.mkdir()
+            await _copy_directory(item, dest_item)
         else:
             async with await anyio.open_file(item, "rb") as src_file:
                 content = await src_file.read()
@@ -99,7 +98,7 @@ async def _copy_directory(src: Path, dst: Path) -> None:
                 await dst_file.write(content)
 
 
-async def _create_squashfs(src_dir: Path, output_file: Path) -> None:
+async def _create_squashfs(src_dir: anyio.Path, output_file: anyio.Path) -> None:
     """Create squashfs image from directory.
 
     Args:
@@ -110,7 +109,7 @@ async def _create_squashfs(src_dir: Path, output_file: Path) -> None:
         PackError: If mksquashfs command fails.
     """
     # Ensure parent directory exists
-    await anyio.Path(output_file).parent.mkdir(parents=True, exist_ok=True)
+    await output_file.parent.mkdir(parents=True, exist_ok=True)
 
     # Run mksquashfs command
     cmd = ["mksquashfs", str(src_dir), str(output_file), "-noappend", "-comp", "xz"]

--- a/src/psi_agent/workspace/snapshot/api.py
+++ b/src/psi_agent/workspace/snapshot/api.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import asyncio
 import shutil
 import tempfile
-from pathlib import Path
 from uuid import uuid4
 
 import anyio
@@ -21,8 +20,8 @@ class SnapshotError(Exception):
 
 
 async def snapshot(
-    input_file: str | Path,
-    mount_point: str | Path,
+    input_file: str | anyio.Path,
+    mount_point: str | anyio.Path,
     output_file: str | None = None,
     tag: str | None = None,
 ) -> None:
@@ -37,24 +36,24 @@ async def snapshot(
     Raises:
         SnapshotError: If snapshot operation fails.
     """
-    input_path = Path(await anyio.Path(input_file).resolve())
-    mount_path = Path(await anyio.Path(mount_point).resolve())
+    input_path = anyio.Path(await anyio.Path(input_file).resolve())
+    mount_path = anyio.Path(await anyio.Path(mount_point).resolve())
 
     # Validate inputs
-    if not await anyio.Path(input_path).exists():
+    if not await input_path.exists():
         raise SnapshotError(f"Input file does not exist: {input_path}")
-    if not await anyio.Path(mount_path).exists():
+    if not await mount_path.exists():
         raise SnapshotError(f"Mount point does not exist: {mount_path}")
 
     # Determine output path
-    output_path = Path(await anyio.Path(output_file).resolve()) if output_file else input_path
+    output_path = anyio.Path(await anyio.Path(output_file).resolve()) if output_file else input_path
 
     logger.info(f"Creating snapshot from {mount_path} to {output_path}")
     logger.debug(f"Input: {input_path}, Tag: {tag}")
 
     # Read mount info to get upper directory
     mount_info_path = mount_path / ".psi-mount-info"
-    if not await anyio.Path(mount_info_path).exists():
+    if not await mount_info_path.exists():
         raise SnapshotError(f"Mount info file not found: {mount_info_path}")
 
     async with await anyio.open_file(mount_info_path) as f:
@@ -67,11 +66,11 @@ async def snapshot(
     except (SyntaxError, ValueError) as e:
         raise SnapshotError(f"Invalid mount info: {e}") from e
 
-    upper_dir = Path(mount_info["upper_dir"])
+    upper_dir = anyio.Path(mount_info["upper_dir"])
 
     # Check if there are any changes
     has_changes = False
-    async for _ in anyio.Path(upper_dir).iterdir():
+    async for _ in upper_dir.iterdir():
         has_changes = True
         break
     if not has_changes:
@@ -97,14 +96,14 @@ async def snapshot(
 
     # Create temporary directory for staging
     with tempfile.TemporaryDirectory() as temp_dir:
-        temp_path = Path(temp_dir)
+        temp_path = anyio.Path(temp_dir)
 
         # Copy squashfs contents to temp directory
         await _extract_squashfs(input_path, temp_path)
 
         # Copy upper directory as new layer
         new_layer_dir = temp_path / str(new_layer_uuid)
-        await _copy_directory(Path(upper_dir), new_layer_dir)
+        await _copy_directory(upper_dir, new_layer_dir)
 
         # Write updated manifest
         manifest_path = temp_path / "manifest.json"
@@ -117,7 +116,7 @@ async def snapshot(
         await _create_squashfs(temp_path, temp_squashfs)
 
         # Atomic move to output path
-        if await anyio.Path(output_path).exists():
+        if await output_path.exists():
             # Create temp file in same directory for atomic move
             temp_output = output_path.with_suffix(".tmp")
             shutil.move(str(temp_squashfs), str(temp_output))
@@ -128,7 +127,7 @@ async def snapshot(
     logger.info(f"Successfully created snapshot at {output_path}")
 
 
-async def _read_manifest_from_squashfs(squashfs_file: Path) -> Manifest:
+async def _read_manifest_from_squashfs(squashfs_file: anyio.Path) -> Manifest:
     """Read manifest from squashfs file.
 
     Args:
@@ -138,7 +137,7 @@ async def _read_manifest_from_squashfs(squashfs_file: Path) -> Manifest:
         Manifest object.
     """
     with tempfile.TemporaryDirectory() as temp_dir:
-        temp_path = Path(temp_dir)
+        temp_path = anyio.Path(temp_dir)
 
         # Extract just the manifest.json
         cmd = ["unsquashfs", "-d", str(temp_path), str(squashfs_file), "manifest.json"]
@@ -150,7 +149,7 @@ async def _read_manifest_from_squashfs(squashfs_file: Path) -> Manifest:
         await process.communicate()
 
         manifest_path = temp_path / "manifest.json"
-        if not await anyio.Path(manifest_path).exists():
+        if not await manifest_path.exists():
             raise SnapshotError("manifest.json not found in squashfs")
 
         async with await anyio.open_file(manifest_path) as f:
@@ -159,7 +158,7 @@ async def _read_manifest_from_squashfs(squashfs_file: Path) -> Manifest:
         return parse_manifest(content)
 
 
-async def _extract_squashfs(squashfs_file: Path, output_dir: Path) -> None:
+async def _extract_squashfs(squashfs_file: anyio.Path, output_dir: anyio.Path) -> None:
     """Extract squashfs contents to directory.
 
     Args:
@@ -184,19 +183,19 @@ async def _extract_squashfs(squashfs_file: Path, output_dir: Path) -> None:
     logger.debug(f"unsquashfs output: {stderr.decode() if stderr else 'No output'}")
 
 
-async def _copy_directory(src: Path, dst: Path) -> None:
+async def _copy_directory(src: anyio.Path, dst: anyio.Path) -> None:
     """Copy directory contents.
 
     Args:
         src: Source directory.
         dst: Destination directory.
     """
-    await anyio.Path(dst).mkdir(parents=True, exist_ok=True)
+    await dst.mkdir(parents=True, exist_ok=True)
 
-    async for item in anyio.Path(src).iterdir():
+    async for item in src.iterdir():
         dest_item = dst / item.name
-        if await anyio.Path(item).is_dir():
-            await _copy_directory(Path(item), dest_item)
+        if await item.is_dir():
+            await _copy_directory(item, dest_item)
         else:
             async with await anyio.open_file(item, "rb") as src_file:
                 content = await src_file.read()
@@ -204,7 +203,7 @@ async def _copy_directory(src: Path, dst: Path) -> None:
                 await dst_file.write(content)
 
 
-async def _create_squashfs(src_dir: Path, output_file: Path) -> None:
+async def _create_squashfs(src_dir: anyio.Path, output_file: anyio.Path) -> None:
     """Create squashfs from directory.
 
     Args:

--- a/src/psi_agent/workspace/umount/api.py
+++ b/src/psi_agent/workspace/umount/api.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import asyncio
-from pathlib import Path
 
 import anyio
 from loguru import logger
@@ -16,7 +15,7 @@ class UmountError(Exception):
 
 
 async def umount(
-    mount_point: str | Path,
+    mount_point: str | anyio.Path,
 ) -> None:
     """Unmount an overlayfs workspace.
 
@@ -26,17 +25,17 @@ async def umount(
     Raises:
         UmountError: If umount operation fails.
     """
-    mount_path = Path(await anyio.Path(mount_point).resolve())
+    mount_path = anyio.Path(await anyio.Path(mount_point).resolve())
 
     # Validate mount point
-    if not await anyio.Path(mount_path).exists():
+    if not await mount_path.exists():
         raise UmountError(f"Mount point does not exist: {mount_path}")
 
     logger.info(f"Unmounting workspace at {mount_path}")
 
     # Read mount info
     mount_info_path = mount_path / ".psi-mount-info"
-    if not await anyio.Path(mount_info_path).exists():
+    if not await mount_info_path.exists():
         raise UmountError(f"Mount info file not found: {mount_info_path}")
 
     async with await anyio.open_file(mount_info_path) as f:
@@ -51,9 +50,9 @@ async def umount(
     except (SyntaxError, ValueError) as e:
         raise UmountError(f"Invalid mount info: {e}") from e
 
-    squashfs_mount = Path(mount_info["squashfs_mount"])
-    upper_dir = Path(mount_info["upper_dir"])
-    work_dir = Path(mount_info["work_dir"])
+    squashfs_mount = anyio.Path(mount_info["squashfs_mount"])
+    upper_dir = anyio.Path(mount_info["upper_dir"])
+    work_dir = anyio.Path(mount_info["work_dir"])
 
     # Unmount overlayfs
     await _unmount(mount_path)
@@ -67,12 +66,12 @@ async def umount(
     await _cleanup_directory(squashfs_mount)
 
     # Remove mount info file
-    await anyio.Path(mount_info_path).unlink()
+    await mount_info_path.unlink()
 
     logger.info(f"Successfully unmounted and cleaned up {mount_path}")
 
 
-async def _unmount(mount_point: Path) -> None:
+async def _unmount(mount_point: anyio.Path) -> None:
     """Unmount a filesystem.
 
     Args:
@@ -99,25 +98,25 @@ async def _unmount(mount_point: Path) -> None:
     logger.debug(f"umount output: {stderr.decode() if stderr else 'No output'}")
 
 
-async def _cleanup_directory(dir_path: Path) -> None:
+async def _cleanup_directory(dir_path: anyio.Path) -> None:
     """Remove a directory and its contents.
 
     Args:
         dir_path: Path to directory to remove.
     """
-    if not await anyio.Path(dir_path).exists():
+    if not await dir_path.exists():
         return
 
     try:
         # Remove directory contents
-        async for item in anyio.Path(dir_path).iterdir():
-            if await anyio.Path(item).is_dir():
-                await _cleanup_directory(Path(item))
+        async for item in dir_path.iterdir():
+            if await item.is_dir():
+                await _cleanup_directory(item)
             else:
-                await anyio.Path(item).unlink()
+                await item.unlink()
 
         # Remove empty directory
-        await anyio.Path(dir_path).rmdir()
+        await dir_path.rmdir()
         logger.debug(f"Cleaned up directory: {dir_path}")
     except Exception as e:
         logger.warning(f"Failed to cleanup directory {dir_path}: {e}")

--- a/src/psi_agent/workspace/unpack/api.py
+++ b/src/psi_agent/workspace/unpack/api.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import asyncio
-from pathlib import Path
 
 import anyio
 from loguru import logger
@@ -16,8 +15,8 @@ class UnpackError(Exception):
 
 
 async def unpack(
-    input_file: str | Path,
-    output_dir: str | Path,
+    input_file: str | anyio.Path,
+    output_dir: str | anyio.Path,
 ) -> None:
     """Unpack a squashfs image to a directory.
 
@@ -28,19 +27,19 @@ async def unpack(
     Raises:
         UnpackError: If unpack operation fails.
     """
-    input_path = Path(await anyio.Path(input_file).resolve())
-    output_path = Path(await anyio.Path(output_dir).resolve())
+    input_path = anyio.Path(await anyio.Path(input_file).resolve())
+    output_path = anyio.Path(await anyio.Path(output_dir).resolve())
 
     # Validate input file
-    if not await anyio.Path(input_path).exists():
+    if not await input_path.exists():
         raise UnpackError(f"Input file does not exist: {input_path}")
-    if not await anyio.Path(input_path).is_file():
+    if not await input_path.is_file():
         raise UnpackError(f"Input path is not a file: {input_path}")
 
     logger.info(f"Unpacking squashfs from {input_path} to {output_path}")
 
     # Create output directory
-    await anyio.Path(output_path).mkdir(parents=True, exist_ok=True)
+    await output_path.mkdir(parents=True, exist_ok=True)
 
     # Run unsquashfs command
     cmd = [

--- a/tests/ai/anthropic_messages/test_config.py
+++ b/tests/ai/anthropic_messages/test_config.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from pathlib import Path
+import anyio
 
 from psi_agent.ai.anthropic_messages.config import AnthropicMessagesConfig
 
@@ -35,12 +35,12 @@ class TestAnthropicMessagesConfig:
         assert config.base_url == "https://custom.anthropic.com"
 
     def test_socket_path(self) -> None:
-        """Test socket_path returns Path object."""
+        """Test socket_path returns anyio.Path object."""
         config = AnthropicMessagesConfig(
             session_socket="/tmp/test.sock",
             model="claude-sonnet-4-20250514",
             api_key="test-key",
         )
 
-        assert isinstance(config.socket_path(), Path)
-        assert config.socket_path() == Path("/tmp/test.sock")
+        assert isinstance(config.socket_path(), anyio.Path)
+        assert config.socket_path() == anyio.Path("/tmp/test.sock")

--- a/tests/ai/openai_completions/test_config.py
+++ b/tests/ai/openai_completions/test_config.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from pathlib import Path
+import anyio
 
 from psi_agent.ai.openai_completions.config import OpenAICompletionsConfig
 
@@ -34,7 +34,7 @@ def test_config_default_base_url() -> None:
 
 
 def test_socket_path() -> None:
-    """Test socket_path method returns Path object."""
+    """Test socket_path method returns anyio.Path object."""
     config = OpenAICompletionsConfig(
         session_socket="/tmp/test.sock",
         model="gpt-4",
@@ -42,5 +42,5 @@ def test_socket_path() -> None:
     )
 
     path = config.socket_path()
-    assert isinstance(path, Path)
-    assert path == Path("/tmp/test.sock")
+    assert isinstance(path, anyio.Path)
+    assert path == anyio.Path("/tmp/test.sock")

--- a/tests/channel/repl/test_config.py
+++ b/tests/channel/repl/test_config.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
-from pathlib import Path
+from pathlib import Path as SyncPath
+
+import anyio
 
 from psi_agent.channel.repl.config import ReplConfig
 
@@ -17,24 +19,24 @@ class TestReplConfig:
         assert config.session_socket == "/tmp/test.sock"
 
     def test_socket_path(self) -> None:
-        """Test socket_path returns Path object."""
+        """Test socket_path returns anyio.Path object."""
         config = ReplConfig(session_socket="/tmp/test.sock")
 
-        assert isinstance(config.socket_path(), Path)
-        assert config.socket_path() == Path("/tmp/test.sock")
+        assert isinstance(config.socket_path(), anyio.Path)
+        assert config.socket_path() == anyio.Path("/tmp/test.sock")
 
     def test_get_history_path_default(self) -> None:
         """Test get_history_path returns default path when not configured."""
         config = ReplConfig(session_socket="/tmp/test.sock")
 
-        expected = Path.home() / ".cache" / "psi-agent" / "repl_history.txt"
+        expected = anyio.Path(SyncPath.home() / ".cache" / "psi-agent" / "repl_history.txt")
         assert config.get_history_path() == expected
 
     def test_get_history_path_custom(self) -> None:
         """Test get_history_path returns custom path when configured."""
         config = ReplConfig(session_socket="/tmp/test.sock", history_file="/custom/history.txt")
 
-        assert config.get_history_path() == Path("/custom/history.txt")
+        assert config.get_history_path() == anyio.Path("/custom/history.txt")
 
     def test_history_file_default_none(self) -> None:
         """Test history_file defaults to None."""

--- a/tests/channel/repl/test_repl.py
+++ b/tests/channel/repl/test_repl.py
@@ -2,9 +2,10 @@
 
 from __future__ import annotations
 
-from pathlib import Path
+from pathlib import Path as SyncPath
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import anyio
 import pytest
 from prompt_toolkit.history import FileHistory
 
@@ -123,9 +124,9 @@ class TestReplHistory:
     """Tests for REPL history navigation."""
 
     @pytest.fixture
-    def config(self, tmp_path: Path) -> ReplConfig:
+    def config(self, tmp_path: SyncPath) -> ReplConfig:
         """Create test config with custom history file."""
-        history_file = tmp_path / "history.txt"
+        history_file = anyio.Path(tmp_path) / "history.txt"
         return ReplConfig(session_socket="/tmp/test.sock", history_file=str(history_file))
 
     @pytest.fixture
@@ -154,9 +155,9 @@ class TestReplHistory:
             assert isinstance(repl._session.history, FileHistory)
 
     @pytest.mark.asyncio
-    async def test_history_persists_to_file(self, tmp_path: Path) -> None:
+    async def test_history_persists_to_file(self, tmp_path: SyncPath) -> None:
         """Test that FileHistory is created with correct path."""
-        history_file = tmp_path / "history.txt"
+        history_file = anyio.Path(tmp_path) / "history.txt"
         config = ReplConfig(session_socket="/tmp/test.sock", history_file=str(history_file))
         repl = Repl(config)
 
@@ -180,11 +181,11 @@ class TestReplHistory:
             assert repl._session.history.filename == str(history_file)
 
     @pytest.mark.asyncio
-    async def test_history_loaded_from_file(self, tmp_path: Path) -> None:
+    async def test_history_loaded_from_file(self, tmp_path: SyncPath) -> None:
         """Test that FileHistory can load from existing file."""
-        history_file = tmp_path / "history.txt"
+        history_file = anyio.Path(tmp_path) / "history.txt"
         # Pre-populate history file in FileHistory format
-        history_file.write_text("\n# 2026-04-29 00:00:00\n+Previous entry\n")
+        await history_file.write_text("\n# 2026-04-29 00:00:00\n+Previous entry\n")
 
         config = ReplConfig(session_socket="/tmp/test.sock", history_file=str(history_file))
         repl = Repl(config)
@@ -235,9 +236,9 @@ class TestReplEditing:
     """Tests for REPL line editing capabilities."""
 
     @pytest.fixture
-    def config(self, tmp_path: Path) -> ReplConfig:
+    def config(self, tmp_path: SyncPath) -> ReplConfig:
         """Create test config with custom history file."""
-        history_file = tmp_path / "history.txt"
+        history_file = anyio.Path(tmp_path) / "history.txt"
         return ReplConfig(session_socket="/tmp/test.sock", history_file=str(history_file))
 
     @pytest.fixture
@@ -280,31 +281,31 @@ class TestEnsureHistoryDir:
     """Tests for _ensure_history_dir helper function."""
 
     @pytest.mark.asyncio
-    async def test_creates_directory_if_missing(self, tmp_path: Path) -> None:
+    async def test_creates_directory_if_missing(self, tmp_path: SyncPath) -> None:
         """Test that directory is created when it doesn't exist."""
-        history_path = tmp_path / "subdir" / "history.txt"
-        assert not history_path.parent.exists()
+        history_path = anyio.Path(tmp_path) / "subdir" / "history.txt"
+        assert not await history_path.parent.exists()
 
         await _ensure_history_dir(history_path)
 
-        assert history_path.parent.exists()
+        assert await history_path.parent.exists()
 
     @pytest.mark.asyncio
-    async def test_does_not_fail_if_directory_exists(self, tmp_path: Path) -> None:
+    async def test_does_not_fail_if_directory_exists(self, tmp_path: SyncPath) -> None:
         """Test that function succeeds when directory already exists."""
-        history_path = tmp_path / "history.txt"
-        history_path.parent.mkdir(parents=True, exist_ok=True)
+        history_path = anyio.Path(tmp_path) / "history.txt"
+        await history_path.parent.mkdir(parents=True, exist_ok=True)
 
         # Should not raise
         await _ensure_history_dir(history_path)
 
-        assert history_path.parent.exists()
+        assert await history_path.parent.exists()
 
     @pytest.mark.asyncio
-    async def test_creates_nested_directories(self, tmp_path: Path) -> None:
+    async def test_creates_nested_directories(self, tmp_path: SyncPath) -> None:
         """Test that nested directories are created."""
-        history_path = tmp_path / "a" / "b" / "c" / "history.txt"
+        history_path = anyio.Path(tmp_path) / "a" / "b" / "c" / "history.txt"
 
         await _ensure_history_dir(history_path)
 
-        assert history_path.parent.exists()
+        assert await history_path.parent.exists()

--- a/tests/channel/telegram/test_config.py
+++ b/tests/channel/telegram/test_config.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from pathlib import Path
+import anyio
 
 from psi_agent.channel.telegram.config import TelegramConfig
 
@@ -16,10 +16,10 @@ def test_telegram_config_creation():
 
 
 def test_telegram_config_socket_path():
-    """Test socket_path returns Path object."""
+    """Test socket_path returns anyio.Path object."""
     config = TelegramConfig(token="test-token", session_socket="/tmp/test.sock")
 
     result = config.socket_path()
 
-    assert isinstance(result, Path)
-    assert result == Path("/tmp/test.sock")
+    assert isinstance(result, anyio.Path)
+    assert result == anyio.Path("/tmp/test.sock")

--- a/tests/session/schedule/test_cron.py
+++ b/tests/session/schedule/test_cron.py
@@ -3,7 +3,8 @@
 from __future__ import annotations
 
 from datetime import datetime
-from pathlib import Path
+
+import anyio
 
 from psi_agent.session.schedule import Schedule
 
@@ -17,7 +18,7 @@ class TestCronParsing:
             name="test",
             cron="* * * * *",
             content="test",
-            task_dir=Path("/tmp"),
+            task_dir=anyio.Path("/tmp"),
         )
 
         next_run = schedule.get_next_run()
@@ -29,7 +30,7 @@ class TestCronParsing:
             name="test",
             cron="0 9 * * *",  # 9am daily
             content="test",
-            task_dir=Path("/tmp"),
+            task_dir=anyio.Path("/tmp"),
         )
 
         next_run = schedule.get_next_run()
@@ -42,7 +43,7 @@ class TestCronParsing:
             name="test",
             cron="0 9 * * 1",  # 9am every Monday
             content="test",
-            task_dir=Path("/tmp"),
+            task_dir=anyio.Path("/tmp"),
         )
 
         next_run = schedule.get_next_run()
@@ -57,7 +58,7 @@ class TestCronParsing:
             name="test",
             cron="0 9 15 * *",  # 9am on 15th of every month
             content="test",
-            task_dir=Path("/tmp"),
+            task_dir=anyio.Path("/tmp"),
         )
 
         next_run = schedule.get_next_run()
@@ -71,7 +72,7 @@ class TestCronParsing:
             name="test",
             cron="0 9 1 1 *",  # 9am on January 1st
             content="test",
-            task_dir=Path("/tmp"),
+            task_dir=anyio.Path("/tmp"),
         )
 
         next_run = schedule.get_next_run()
@@ -86,7 +87,7 @@ class TestCronParsing:
             name="test",
             cron="0 9,18 * * *",  # 9am and 6pm daily
             content="test",
-            task_dir=Path("/tmp"),
+            task_dir=anyio.Path("/tmp"),
         )
 
         next_run = schedule.get_next_run()
@@ -99,7 +100,7 @@ class TestCronParsing:
             name="test",
             cron="0 9-17 * * *",  # Every hour from 9am to 5pm
             content="test",
-            task_dir=Path("/tmp"),
+            task_dir=anyio.Path("/tmp"),
         )
 
         next_run = schedule.get_next_run()
@@ -112,7 +113,7 @@ class TestCronParsing:
             name="test",
             cron="*/15 * * * *",  # Every 15 minutes
             content="test",
-            task_dir=Path("/tmp"),
+            task_dir=anyio.Path("/tmp"),
         )
 
         next_run = schedule.get_next_run()

--- a/tests/session/schedule/test_loader.py
+++ b/tests/session/schedule/test_loader.py
@@ -3,8 +3,8 @@
 from __future__ import annotations
 
 import tempfile
-from pathlib import Path
 
+import anyio
 import pytest
 
 from psi_agent.session.schedule import load_schedule, load_schedules, parse_frontmatter
@@ -62,11 +62,11 @@ class TestLoadSchedule:
     async def test_load_valid_schedule(self) -> None:
         """Test loading a valid schedule."""
         with tempfile.TemporaryDirectory() as tmpdir:
-            task_dir = Path(tmpdir) / "test-task"
-            task_dir.mkdir()
+            task_dir = anyio.Path(tmpdir) / "test-task"
+            await task_dir.mkdir()
 
             task_file = task_dir / "TASK.md"
-            task_file.write_text("""---
+            await task_file.write_text("""---
 name: test-task
 description: A test task
 cron: "0 9 * * *"
@@ -86,8 +86,8 @@ Do something daily.""")
     async def test_load_missing_task_md(self) -> None:
         """Test loading from directory without TASK.md."""
         with tempfile.TemporaryDirectory() as tmpdir:
-            task_dir = Path(tmpdir) / "test-task"
-            task_dir.mkdir()
+            task_dir = anyio.Path(tmpdir) / "test-task"
+            await task_dir.mkdir()
 
             schedule = await load_schedule(task_dir)
 
@@ -97,11 +97,11 @@ Do something daily.""")
     async def test_load_missing_cron(self) -> None:
         """Test loading schedule without cron field."""
         with tempfile.TemporaryDirectory() as tmpdir:
-            task_dir = Path(tmpdir) / "test-task"
-            task_dir.mkdir()
+            task_dir = anyio.Path(tmpdir) / "test-task"
+            await task_dir.mkdir()
 
             task_file = task_dir / "TASK.md"
-            task_file.write_text("""---
+            await task_file.write_text("""---
 name: test-task
 ---
 
@@ -119,14 +119,14 @@ class TestLoadSchedules:
     async def test_load_multiple_schedules(self) -> None:
         """Test loading multiple schedules from workspace."""
         with tempfile.TemporaryDirectory() as tmpdir:
-            workspace = Path(tmpdir)
+            workspace = anyio.Path(tmpdir)
             schedules_dir = workspace / "schedules"
-            schedules_dir.mkdir()
+            await schedules_dir.mkdir()
 
             # Create first task
             task1_dir = schedules_dir / "task1"
-            task1_dir.mkdir()
-            (task1_dir / "TASK.md").write_text("""---
+            await task1_dir.mkdir()
+            await (task1_dir / "TASK.md").write_text("""---
 name: task1
 cron: "0 9 * * *"
 ---
@@ -135,8 +135,8 @@ Task 1 content.""")
 
             # Create second task
             task2_dir = schedules_dir / "task2"
-            task2_dir.mkdir()
-            (task2_dir / "TASK.md").write_text("""---
+            await task2_dir.mkdir()
+            await (task2_dir / "TASK.md").write_text("""---
 name: task2
 cron: "0 18 * * *"
 ---
@@ -154,7 +154,7 @@ Task 2 content.""")
     async def test_load_no_schedules_dir(self) -> None:
         """Test loading from workspace without schedules directory."""
         with tempfile.TemporaryDirectory() as tmpdir:
-            workspace = Path(tmpdir)
+            workspace = anyio.Path(tmpdir)
 
             schedules = await load_schedules(workspace)
 
@@ -164,9 +164,9 @@ Task 2 content.""")
     async def test_load_empty_schedules_dir(self) -> None:
         """Test loading from empty schedules directory."""
         with tempfile.TemporaryDirectory() as tmpdir:
-            workspace = Path(tmpdir)
+            workspace = anyio.Path(tmpdir)
             schedules_dir = workspace / "schedules"
-            schedules_dir.mkdir()
+            await schedules_dir.mkdir()
 
             schedules = await load_schedules(workspace)
 

--- a/tests/session/schedule/test_schedule.py
+++ b/tests/session/schedule/test_schedule.py
@@ -3,7 +3,8 @@
 from __future__ import annotations
 
 from datetime import datetime
-from pathlib import Path
+
+import anyio
 
 from psi_agent.session.schedule import Schedule
 
@@ -17,7 +18,7 @@ class TestSchedule:
             name="test-task",
             cron="0 9 * * *",
             content="Test task content",
-            task_dir=Path("/tmp/test"),
+            task_dir=anyio.Path("/tmp/test"),
         )
 
         assert schedule.name == "test-task"
@@ -32,7 +33,7 @@ class TestSchedule:
             description="A test task",
             cron="0 9 * * *",
             content="Test task content",
-            task_dir=Path("/tmp/test"),
+            task_dir=anyio.Path("/tmp/test"),
         )
 
         assert schedule.description == "A test task"
@@ -43,7 +44,7 @@ class TestSchedule:
             name="test-task",
             cron="0 9 * * *",  # 9am daily
             content="Test task content",
-            task_dir=Path("/tmp/test"),
+            task_dir=anyio.Path("/tmp/test"),
         )
 
         next_run = schedule.get_next_run()
@@ -57,7 +58,7 @@ class TestSchedule:
             name="test-task",
             cron="0 9 * * *",
             content="Test task content",
-            task_dir=Path("/tmp/test"),
+            task_dir=anyio.Path("/tmp/test"),
         )
 
         seconds = schedule.get_seconds_until_next_run()
@@ -71,7 +72,7 @@ class TestSchedule:
             name="test-task",
             cron="* * * * *",
             content="Test task content",
-            task_dir=Path("/tmp/test"),
+            task_dir=anyio.Path("/tmp/test"),
         )
 
         next_run = schedule.get_next_run()
@@ -85,7 +86,7 @@ class TestSchedule:
             name="test-task",
             cron="30 14 * * *",  # 2:30pm daily
             content="Test task content",
-            task_dir=Path("/tmp/test"),
+            task_dir=anyio.Path("/tmp/test"),
         )
 
         next_run = schedule.get_next_run()

--- a/tests/session/test_history.py
+++ b/tests/session/test_history.py
@@ -3,8 +3,8 @@
 from __future__ import annotations
 
 import tempfile
-from pathlib import Path
 
+import anyio
 import pytest
 
 from psi_agent.session.history import (
@@ -28,8 +28,8 @@ async def test_initialize_history_no_file():
 async def test_initialize_history_with_file():
     """Test history initialization with file."""
     with tempfile.TemporaryDirectory() as tmpdir:
-        history_file = Path(tmpdir) / "history.json"
-        history_file.write_text('[{"role": "user", "content": "test"}]')
+        history_file = anyio.Path(tmpdir) / "history.json"
+        await history_file.write_text('[{"role": "user", "content": "test"}]')
 
         history = await initialize_history(str(history_file))
         assert len(history.messages) == 1
@@ -41,8 +41,8 @@ async def test_initialize_history_with_file():
 async def test_initialize_history_empty_file():
     """Test history initialization with empty file."""
     with tempfile.TemporaryDirectory() as tmpdir:
-        history_file = Path(tmpdir) / "history.json"
-        history_file.write_text("")
+        history_file = anyio.Path(tmpdir) / "history.json"
+        await history_file.write_text("")
 
         history = await initialize_history(str(history_file))
         assert history.messages == []
@@ -52,8 +52,8 @@ async def test_initialize_history_empty_file():
 async def test_load_history_from_file_corrupted():
     """Test loading corrupted JSON file."""
     with tempfile.TemporaryDirectory() as tmpdir:
-        history_file = Path(tmpdir) / "history.json"
-        history_file.write_text("not valid json")
+        history_file = anyio.Path(tmpdir) / "history.json"
+        await history_file.write_text("not valid json")
 
         messages = await load_history_from_file(history_file)
         assert messages == []
@@ -63,7 +63,7 @@ async def test_load_history_from_file_corrupted():
 async def test_save_history_to_file():
     """Test saving history to file."""
     with tempfile.TemporaryDirectory() as tmpdir:
-        history_file = Path(tmpdir) / "history.json"
+        history_file = anyio.Path(tmpdir) / "history.json"
         history = History(
             messages=[{"role": "user", "content": "hello"}],
             history_file=str(history_file),
@@ -71,7 +71,7 @@ async def test_save_history_to_file():
 
         await save_history_to_file(history, history_file)
 
-        content = history_file.read_text()
+        content = await history_file.read_text()
         assert "hello" in content
         assert "user" in content
 
@@ -80,7 +80,7 @@ async def test_save_history_to_file():
 async def test_persist_history():
     """Test persist_history function."""
     with tempfile.TemporaryDirectory() as tmpdir:
-        history_file = Path(tmpdir) / "history.json"
+        history_file = anyio.Path(tmpdir) / "history.json"
         history = History(
             messages=[{"role": "assistant", "content": "response"}],
             history_file=str(history_file),
@@ -88,8 +88,8 @@ async def test_persist_history():
 
         await persist_history(history)
 
-        assert history_file.exists()
-        content = history_file.read_text()
+        assert await history_file.exists()
+        content = await history_file.read_text()
         assert "response" in content
 
 
@@ -140,8 +140,8 @@ async def test_save_history_creates_parent_dirs():
     """Test saving history - parent dirs must exist."""
     with tempfile.TemporaryDirectory() as tmpdir:
         # Parent directories must exist - save_history_to_file doesn't create them
-        history_file = Path(tmpdir) / "subdir" / "history.json"
-        history_file.parent.mkdir(parents=True, exist_ok=True)
+        history_file = anyio.Path(tmpdir) / "subdir" / "history.json"
+        await history_file.parent.mkdir(parents=True, exist_ok=True)
 
         history = History(
             messages=[{"role": "user", "content": "test"}],
@@ -150,14 +150,14 @@ async def test_save_history_creates_parent_dirs():
 
         await save_history_to_file(history, history_file)
 
-        assert history_file.exists()
+        assert await history_file.exists()
 
 
 @pytest.mark.asyncio
 async def test_load_history_nonexistent_file():
     """Test loading from nonexistent file returns empty list."""
     with tempfile.TemporaryDirectory() as tmpdir:
-        history_file = Path(tmpdir) / "nonexistent.json"
+        history_file = anyio.Path(tmpdir) / "nonexistent.json"
 
         messages = await load_history_from_file(history_file)
         assert messages == []

--- a/tests/session/test_runner.py
+++ b/tests/session/test_runner.py
@@ -6,6 +6,7 @@ import tempfile
 from pathlib import Path
 from unittest.mock import AsyncMock, patch
 
+import anyio
 import pytest
 
 from psi_agent.session.config import SessionConfig
@@ -31,7 +32,7 @@ def config():
 async def test_load_system_prompt_no_file():
     """Test loading system prompt when no system.py exists."""
     with tempfile.TemporaryDirectory() as tmpdir:
-        result = await load_system_prompt(Path(tmpdir))
+        result = await load_system_prompt(anyio.Path(tmpdir))
         assert result is None
 
 
@@ -39,12 +40,12 @@ async def test_load_system_prompt_no_file():
 async def test_load_system_prompt_with_file():
     """Test loading system prompt from system.py."""
     with tempfile.TemporaryDirectory() as tmpdir:
-        workspace = Path(tmpdir)
+        workspace = anyio.Path(tmpdir)
         systems_dir = workspace / "systems"
-        systems_dir.mkdir()
+        await systems_dir.mkdir()
 
         system_file = systems_dir / "system.py"
-        system_file.write_text(
+        await system_file.write_text(
             """
 async def build_system_prompt() -> str:
     return "You are a helpful assistant."
@@ -59,12 +60,12 @@ async def build_system_prompt() -> str:
 async def test_load_system_prompt_no_function():
     """Test loading system prompt when function doesn't exist."""
     with tempfile.TemporaryDirectory() as tmpdir:
-        workspace = Path(tmpdir)
+        workspace = anyio.Path(tmpdir)
         systems_dir = workspace / "systems"
-        systems_dir.mkdir()
+        await systems_dir.mkdir()
 
         system_file = systems_dir / "system.py"
-        system_file.write_text("# no function here\n")
+        await system_file.write_text("# no function here\n")
 
         result = await load_system_prompt(workspace)
         assert result is None
@@ -106,7 +107,7 @@ async def test_session_runner_loads_tools(config):
     # Create a tool file
     tools_dir = config.tools_dir()
     tool_file = tools_dir / "test_tool.py"
-    tool_file.write_text(
+    await tool_file.write_text(
         """
 async def tool(name: str) -> str:
     '''Test tool.

--- a/tests/session/test_tool_loader.py
+++ b/tests/session/test_tool_loader.py
@@ -3,8 +3,8 @@
 from __future__ import annotations
 
 import tempfile
-from pathlib import Path
 
+import anyio
 import pytest
 
 from psi_agent.session.tool_loader import (
@@ -21,12 +21,12 @@ async def test_compute_file_hash() -> None:
     with tempfile.NamedTemporaryFile(mode="w", suffix=".py", delete=False) as f:
         f.write("# test file\n")
         f.flush()
-        hash1 = await compute_file_hash(Path(f.name))
-        assert hash1 == await compute_file_hash(Path(f.name))  # Same content = same hash
+        hash1 = await compute_file_hash(anyio.Path(f.name))
+        assert hash1 == await compute_file_hash(anyio.Path(f.name))  # Same content = same hash
 
         f.write("# modified\n")
         f.flush()
-        hash2 = await compute_file_hash(Path(f.name))
+        hash2 = await compute_file_hash(anyio.Path(f.name))
         assert hash1 != hash2  # Different content = different hash
 
 
@@ -69,14 +69,14 @@ def test_python_type_to_openai_type() -> None:
 async def test_scan_tools_directory() -> None:
     """Test tools directory scanning."""
     with tempfile.TemporaryDirectory() as tmpdir:
-        tools_dir = Path(tmpdir)
+        tools_dir = anyio.Path(tmpdir)
 
         # Create some tool files
-        (tools_dir / "read.py").write_text("async def tool(file_path: str) -> str: pass")
-        (tools_dir / "write.py").write_text(
+        await (tools_dir / "read.py").write_text("async def tool(file_path: str) -> str: pass")
+        await (tools_dir / "write.py").write_text(
             "async def tool(file_path: str, content: str) -> str: pass"
         )
-        (tools_dir / "not_a_tool.txt").write_text("text file")
+        await (tools_dir / "not_a_tool.txt").write_text("text file")
 
         result = await scan_tools_directory(tools_dir)
 
@@ -90,12 +90,12 @@ async def test_scan_tools_directory() -> None:
 async def test_scan_tools_directory_empty() -> None:
     """Test scanning empty directory."""
     with tempfile.TemporaryDirectory() as tmpdir:
-        result = await scan_tools_directory(Path(tmpdir))
+        result = await scan_tools_directory(anyio.Path(tmpdir))
         assert result == {}
 
 
 @pytest.mark.asyncio
 async def test_scan_tools_directory_nonexistent() -> None:
     """Test scanning nonexistent directory."""
-    result = await scan_tools_directory(Path("/nonexistent/path"))
+    result = await scan_tools_directory(anyio.Path("/nonexistent/path"))
     assert result == {}

--- a/tests/session/test_workspace_watcher.py
+++ b/tests/session/test_workspace_watcher.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import anyio
 import pytest
 
 from psi_agent.session.workspace_watcher import (
@@ -22,8 +23,8 @@ class TestComputeFileHash:
     @pytest.mark.asyncio
     async def test_compute_hash_returns_string(self, tmp_path: Path) -> None:
         """Test that compute_file_hash returns a string."""
-        test_file = tmp_path / "test.py"
-        test_file.write_text("print('hello')")
+        test_file = anyio.Path(tmp_path) / "test.py"
+        await test_file.write_text("print('hello')")
 
         result = await compute_file_hash(test_file)
 
@@ -33,11 +34,11 @@ class TestComputeFileHash:
     @pytest.mark.asyncio
     async def test_same_content_same_hash(self, tmp_path: Path) -> None:
         """Test that same content produces same hash."""
-        test_file1 = tmp_path / "test1.py"
-        test_file2 = tmp_path / "test2.py"
+        test_file1 = anyio.Path(tmp_path) / "test1.py"
+        test_file2 = anyio.Path(tmp_path) / "test2.py"
         content = "print('hello')"
-        test_file1.write_text(content)
-        test_file2.write_text(content)
+        await test_file1.write_text(content)
+        await test_file2.write_text(content)
 
         hash1 = await compute_file_hash(test_file1)
         hash2 = await compute_file_hash(test_file2)
@@ -47,10 +48,10 @@ class TestComputeFileHash:
     @pytest.mark.asyncio
     async def test_different_content_different_hash(self, tmp_path: Path) -> None:
         """Test that different content produces different hash."""
-        test_file1 = tmp_path / "test1.py"
-        test_file2 = tmp_path / "test2.py"
-        test_file1.write_text("print('hello')")
-        test_file2.write_text("print('world')")
+        test_file1 = anyio.Path(tmp_path) / "test1.py"
+        test_file2 = anyio.Path(tmp_path) / "test2.py"
+        await test_file1.write_text("print('hello')")
+        await test_file2.write_text("print('world')")
 
         hash1 = await compute_file_hash(test_file1)
         hash2 = await compute_file_hash(test_file2)
@@ -64,8 +65,8 @@ class TestScanToolsDirectory:
     @pytest.mark.asyncio
     async def test_scan_empty_directory(self, tmp_path: Path) -> None:
         """Test scanning empty directory."""
-        tools_dir = tmp_path / "tools"
-        tools_dir.mkdir()
+        tools_dir = anyio.Path(tmp_path) / "tools"
+        await tools_dir.mkdir()
 
         result = await scan_tools_directory(tools_dir)
 
@@ -74,17 +75,17 @@ class TestScanToolsDirectory:
     @pytest.mark.asyncio
     async def test_scan_nonexistent_directory(self, tmp_path: Path) -> None:
         """Test scanning nonexistent directory."""
-        result = await scan_tools_directory(tmp_path / "nonexistent")
+        result = await scan_tools_directory(anyio.Path(tmp_path) / "nonexistent")
 
         assert result == {}
 
     @pytest.mark.asyncio
     async def test_scan_finds_python_files(self, tmp_path: Path) -> None:
         """Test that scan finds .py files."""
-        tools_dir = tmp_path / "tools"
-        tools_dir.mkdir()
-        (tools_dir / "read.py").write_text("async def tool(): pass")
-        (tools_dir / "write.py").write_text("async def tool(): pass")
+        tools_dir = anyio.Path(tmp_path) / "tools"
+        await tools_dir.mkdir()
+        await (tools_dir / "read.py").write_text("async def tool(): pass")
+        await (tools_dir / "write.py").write_text("async def tool(): pass")
 
         result = await scan_tools_directory(tools_dir)
 
@@ -95,10 +96,10 @@ class TestScanToolsDirectory:
     @pytest.mark.asyncio
     async def test_scan_ignores_non_python_files(self, tmp_path: Path) -> None:
         """Test that scan ignores non-.py files."""
-        tools_dir = tmp_path / "tools"
-        tools_dir.mkdir()
-        (tools_dir / "read.py").write_text("async def tool(): pass")
-        (tools_dir / "read.txt").write_text("not a tool")
+        tools_dir = anyio.Path(tmp_path) / "tools"
+        await tools_dir.mkdir()
+        await (tools_dir / "read.py").write_text("async def tool(): pass")
+        await (tools_dir / "read.txt").write_text("not a tool")
 
         result = await scan_tools_directory(tools_dir)
 
@@ -112,8 +113,8 @@ class TestScanSkillsDirectory:
     @pytest.mark.asyncio
     async def test_scan_empty_directory(self, tmp_path: Path) -> None:
         """Test scanning empty directory."""
-        skills_dir = tmp_path / "skills"
-        skills_dir.mkdir()
+        skills_dir = anyio.Path(tmp_path) / "skills"
+        await skills_dir.mkdir()
 
         result = await scan_skills_directory(skills_dir)
 
@@ -122,14 +123,14 @@ class TestScanSkillsDirectory:
     @pytest.mark.asyncio
     async def test_scan_finds_skill_md_files(self, tmp_path: Path) -> None:
         """Test that scan finds SKILL.md files."""
-        skills_dir = tmp_path / "skills"
-        skills_dir.mkdir()
+        skills_dir = anyio.Path(tmp_path) / "skills"
+        await skills_dir.mkdir()
         skill1_dir = skills_dir / "skill1"
-        skill1_dir.mkdir()
-        (skill1_dir / "SKILL.md").write_text("---\nname: skill1\n---\nContent")
+        await skill1_dir.mkdir()
+        await (skill1_dir / "SKILL.md").write_text("---\nname: skill1\n---\nContent")
         skill2_dir = skills_dir / "skill2"
-        skill2_dir.mkdir()
-        (skill2_dir / "SKILL.md").write_text("---\nname: skill2\n---\nContent")
+        await skill2_dir.mkdir()
+        await (skill2_dir / "SKILL.md").write_text("---\nname: skill2\n---\nContent")
 
         result = await scan_skills_directory(skills_dir)
 
@@ -140,11 +141,11 @@ class TestScanSkillsDirectory:
     @pytest.mark.asyncio
     async def test_scan_ignores_dirs_without_skill_md(self, tmp_path: Path) -> None:
         """Test that scan ignores directories without SKILL.md."""
-        skills_dir = tmp_path / "skills"
-        skills_dir.mkdir()
+        skills_dir = anyio.Path(tmp_path) / "skills"
+        await skills_dir.mkdir()
         skill_dir = skills_dir / "skill1"
-        skill_dir.mkdir()
-        (skill_dir / "README.md").write_text("Not a skill")
+        await skill_dir.mkdir()
+        await (skill_dir / "README.md").write_text("Not a skill")
 
         result = await scan_skills_directory(skills_dir)
 
@@ -157,8 +158,8 @@ class TestScanSchedulesDirectory:
     @pytest.mark.asyncio
     async def test_scan_empty_directory(self, tmp_path: Path) -> None:
         """Test scanning empty directory."""
-        schedules_dir = tmp_path / "schedules"
-        schedules_dir.mkdir()
+        schedules_dir = anyio.Path(tmp_path) / "schedules"
+        await schedules_dir.mkdir()
 
         result = await scan_schedules_directory(schedules_dir)
 
@@ -167,14 +168,14 @@ class TestScanSchedulesDirectory:
     @pytest.mark.asyncio
     async def test_scan_finds_task_md_files(self, tmp_path: Path) -> None:
         """Test that scan finds TASK.md files."""
-        schedules_dir = tmp_path / "schedules"
-        schedules_dir.mkdir()
+        schedules_dir = anyio.Path(tmp_path) / "schedules"
+        await schedules_dir.mkdir()
         task1_dir = schedules_dir / "task1"
-        task1_dir.mkdir()
-        (task1_dir / "TASK.md").write_text("---\ncron: '0 9 * * *'\n---\nContent")
+        await task1_dir.mkdir()
+        await (task1_dir / "TASK.md").write_text("---\ncron: '0 9 * * *'\n---\nContent")
         task2_dir = schedules_dir / "task2"
-        task2_dir.mkdir()
-        (task2_dir / "TASK.md").write_text("---\ncron: '0 10 * * *'\n---\nContent")
+        await task2_dir.mkdir()
+        await (task2_dir / "TASK.md").write_text("---\ncron: '0 10 * * *'\n---\nContent")
 
         result = await scan_schedules_directory(schedules_dir)
 
@@ -239,24 +240,25 @@ class TestWorkspaceWatcher:
     @pytest.mark.asyncio
     async def test_initialize_scans_all_directories(self, tmp_path: Path) -> None:
         """Test that initialize scans all workspace directories."""
+        workspace = anyio.Path(tmp_path)
         # Create workspace structure
-        tools_dir = tmp_path / "tools"
-        tools_dir.mkdir()
-        (tools_dir / "read.py").write_text("async def tool(): pass")
+        tools_dir = workspace / "tools"
+        await tools_dir.mkdir()
+        await (tools_dir / "read.py").write_text("async def tool(): pass")
 
-        skills_dir = tmp_path / "skills"
-        skills_dir.mkdir()
+        skills_dir = workspace / "skills"
+        await skills_dir.mkdir()
         skill_dir = skills_dir / "skill1"
-        skill_dir.mkdir()
-        (skill_dir / "SKILL.md").write_text("---\nname: skill1\n---\nContent")
+        await skill_dir.mkdir()
+        await (skill_dir / "SKILL.md").write_text("---\nname: skill1\n---\nContent")
 
-        schedules_dir = tmp_path / "schedules"
-        schedules_dir.mkdir()
+        schedules_dir = workspace / "schedules"
+        await schedules_dir.mkdir()
         task_dir = schedules_dir / "task1"
-        task_dir.mkdir()
-        (task_dir / "TASK.md").write_text("---\ncron: '0 9 * * *'\n---\nContent")
+        await task_dir.mkdir()
+        await (task_dir / "TASK.md").write_text("---\ncron: '0 9 * * *'\n---\nContent")
 
-        watcher = WorkspaceWatcher(tmp_path)
+        watcher = WorkspaceWatcher(workspace)
         await watcher.initialize()
 
         assert len(watcher.get_tool_hashes()) == 1
@@ -266,15 +268,16 @@ class TestWorkspaceWatcher:
     @pytest.mark.asyncio
     async def test_check_for_changes_detects_new_tool(self, tmp_path: Path) -> None:
         """Test that check_for_changes detects new tool."""
-        tools_dir = tmp_path / "tools"
-        tools_dir.mkdir()
-        (tools_dir / "read.py").write_text("async def tool(): pass")
+        workspace = anyio.Path(tmp_path)
+        tools_dir = workspace / "tools"
+        await tools_dir.mkdir()
+        await (tools_dir / "read.py").write_text("async def tool(): pass")
 
-        watcher = WorkspaceWatcher(tmp_path)
+        watcher = WorkspaceWatcher(workspace)
         await watcher.initialize()
 
         # Add new tool
-        (tools_dir / "write.py").write_text("async def tool(): pass")
+        await (tools_dir / "write.py").write_text("async def tool(): pass")
 
         changes = await watcher.check_for_changes()
 
@@ -284,18 +287,19 @@ class TestWorkspaceWatcher:
     @pytest.mark.asyncio
     async def test_check_for_changes_detects_modified_skill(self, tmp_path: Path) -> None:
         """Test that check_for_changes detects modified skill."""
-        skills_dir = tmp_path / "skills"
-        skills_dir.mkdir()
+        workspace = anyio.Path(tmp_path)
+        skills_dir = workspace / "skills"
+        await skills_dir.mkdir()
         skill_dir = skills_dir / "skill1"
-        skill_dir.mkdir()
+        await skill_dir.mkdir()
         skill_md = skill_dir / "SKILL.md"
-        skill_md.write_text("---\nname: skill1\n---\nOriginal content")
+        await skill_md.write_text("---\nname: skill1\n---\nOriginal content")
 
-        watcher = WorkspaceWatcher(tmp_path)
+        watcher = WorkspaceWatcher(workspace)
         await watcher.initialize()
 
         # Modify skill
-        skill_md.write_text("---\nname: skill1\n---\nModified content")
+        await skill_md.write_text("---\nname: skill1\n---\nModified content")
 
         changes = await watcher.check_for_changes()
 
@@ -305,18 +309,19 @@ class TestWorkspaceWatcher:
     @pytest.mark.asyncio
     async def test_check_for_changes_detects_removed_schedule(self, tmp_path: Path) -> None:
         """Test that check_for_changes detects removed schedule."""
-        schedules_dir = tmp_path / "schedules"
-        schedules_dir.mkdir()
+        workspace = anyio.Path(tmp_path)
+        schedules_dir = workspace / "schedules"
+        await schedules_dir.mkdir()
         task_dir = schedules_dir / "task1"
-        task_dir.mkdir()
-        (task_dir / "TASK.md").write_text("---\ncron: '0 9 * * *'\n---\nContent")
+        await task_dir.mkdir()
+        await (task_dir / "TASK.md").write_text("---\ncron: '0 9 * * *'\n---\nContent")
 
-        watcher = WorkspaceWatcher(tmp_path)
+        watcher = WorkspaceWatcher(workspace)
         await watcher.initialize()
 
         # Remove schedule
-        (task_dir / "TASK.md").unlink()
-        task_dir.rmdir()
+        await (task_dir / "TASK.md").unlink()
+        await task_dir.rmdir()
 
         changes = await watcher.check_for_changes()
 
@@ -326,11 +331,12 @@ class TestWorkspaceWatcher:
     @pytest.mark.asyncio
     async def test_check_for_changes_no_changes(self, tmp_path: Path) -> None:
         """Test that check_for_changes returns empty when no changes."""
-        tools_dir = tmp_path / "tools"
-        tools_dir.mkdir()
-        (tools_dir / "read.py").write_text("async def tool(): pass")
+        workspace = anyio.Path(tmp_path)
+        tools_dir = workspace / "tools"
+        await tools_dir.mkdir()
+        await (tools_dir / "read.py").write_text("async def tool(): pass")
 
-        watcher = WorkspaceWatcher(tmp_path)
+        watcher = WorkspaceWatcher(workspace)
         await watcher.initialize()
 
         # No changes made

--- a/tests/workspace/test_integration.py
+++ b/tests/workspace/test_integration.py
@@ -7,8 +7,9 @@ Run with: sudo uv run pytest tests/workspace/test_integration.py -v
 from __future__ import annotations
 
 import os
-from pathlib import Path
+from pathlib import Path as SyncPath
 
+import anyio
 import pytest
 
 from psi_agent.workspace.pack.api import pack
@@ -19,49 +20,51 @@ from psi_agent.workspace.unpack.api import unpack
 class TestIntegration:
     """Integration tests for workspace components."""
 
-    async def test_pack_unpack_roundtrip(self, tmp_path: Path) -> None:
+    async def test_pack_unpack_roundtrip(self, tmp_path: SyncPath) -> None:
         """Pack and unpack should preserve workspace contents."""
         # Create input workspace
-        input_dir = tmp_path / "workspace"
-        input_dir.mkdir()
-        (input_dir / "tools").mkdir()
-        (input_dir / "tools" / "test.py").write_text("# test tool")
-        (input_dir / "skills").mkdir()
-        (input_dir / "skills" / "example").mkdir()
-        (input_dir / "skills" / "example" / "SKILL.md").write_text(
+        input_dir = anyio.Path(tmp_path) / "workspace"
+        await input_dir.mkdir()
+        await (input_dir / "tools").mkdir()
+        await (input_dir / "tools" / "test.py").write_text("# test tool")
+        await (input_dir / "skills").mkdir()
+        await (input_dir / "skills" / "example").mkdir()
+        await (input_dir / "skills" / "example" / "SKILL.md").write_text(
             "---\nname: test\n---\nTest skill"
         )
 
         # Pack
-        squashfs_file = tmp_path / "workspace.squashfs"
+        squashfs_file = anyio.Path(tmp_path) / "workspace.squashfs"
         await pack(input_dir, squashfs_file, tag="v1.0")
 
         # Unpack
-        output_dir = tmp_path / "unpacked"
+        output_dir = anyio.Path(tmp_path) / "unpacked"
         await unpack(squashfs_file, output_dir)
 
         # Verify contents
-        assert (output_dir / "manifest.json").exists()
+        assert await (output_dir / "manifest.json").exists()
         # The layer directory name is a UUID, so we check for any directory
-        layer_dirs = [d for d in output_dir.iterdir() if d.is_dir() and d.name != "manifest.json"]
+        layer_dirs = [
+            d async for d in output_dir.iterdir() if await d.is_dir() and d.name != "manifest.json"
+        ]
         assert len(layer_dirs) == 1
 
         layer_dir = layer_dirs[0]
-        assert (layer_dir / "tools" / "test.py").exists()
-        assert (layer_dir / "skills" / "example" / "SKILL.md").exists()
+        assert await (layer_dir / "tools" / "test.py").exists()
+        assert await (layer_dir / "skills" / "example" / "SKILL.md").exists()
 
 
 class TestNonPrivileged:
     """Tests that don't require root privileges."""
 
-    async def test_pack_creates_valid_squashfs(self, tmp_path: Path) -> None:
+    async def test_pack_creates_valid_squashfs(self, tmp_path: SyncPath) -> None:
         """Pack creates a valid squashfs file."""
-        input_dir = tmp_path / "workspace"
-        input_dir.mkdir()
-        (input_dir / "test.txt").write_text("hello")
+        input_dir = anyio.Path(tmp_path) / "workspace"
+        await input_dir.mkdir()
+        await (input_dir / "test.txt").write_text("hello")
 
-        squashfs_file = tmp_path / "workspace.squashfs"
+        squashfs_file = anyio.Path(tmp_path) / "workspace.squashfs"
         await pack(input_dir, squashfs_file)
 
-        assert squashfs_file.exists()
-        assert squashfs_file.stat().st_size > 0
+        assert await squashfs_file.exists()
+        assert (await squashfs_file.stat()).st_size > 0

--- a/tests/workspace/test_mount.py
+++ b/tests/workspace/test_mount.py
@@ -2,9 +2,10 @@
 
 from __future__ import annotations
 
-from pathlib import Path
+from pathlib import Path as SyncPath
 from uuid import uuid4
 
+import anyio
 import pytest
 
 from psi_agent.workspace.manifest import Layer, Manifest
@@ -58,19 +59,19 @@ class TestResolveTargetLayer:
 class TestMount:
     """Tests for mount function."""
 
-    async def test_mount_nonexistent_input(self, tmp_path: Path) -> None:
+    async def test_mount_nonexistent_input(self, tmp_path: SyncPath) -> None:
         """Mount raises error for nonexistent input file."""
-        output_dir = tmp_path / "mounted"
+        output_dir = anyio.Path(tmp_path) / "mounted"
 
         with pytest.raises(MountError, match="does not exist"):
-            await mount(tmp_path / "nonexistent.squashfs", output_dir)
+            await mount(anyio.Path(tmp_path) / "nonexistent.squashfs", output_dir)
 
-    async def test_mount_directory_as_input(self, tmp_path: Path) -> None:
+    async def test_mount_directory_as_input(self, tmp_path: SyncPath) -> None:
         """Mount raises error when input is a directory."""
-        input_dir = tmp_path / "input"
-        input_dir.mkdir()
+        input_dir = anyio.Path(tmp_path) / "input"
+        await input_dir.mkdir()
 
-        output_dir = tmp_path / "mounted"
+        output_dir = anyio.Path(tmp_path) / "mounted"
 
         with pytest.raises(MountError, match="not a file"):
             await mount(input_dir, output_dir)

--- a/tests/workspace/test_pack.py
+++ b/tests/workspace/test_pack.py
@@ -2,8 +2,9 @@
 
 from __future__ import annotations
 
-from pathlib import Path
+from pathlib import Path as SyncPath
 
+import anyio
 import pytest
 
 from psi_agent.workspace.pack.api import PackError, pack
@@ -12,49 +13,54 @@ from psi_agent.workspace.pack.api import PackError, pack
 class TestPack:
     """Tests for pack function."""
 
-    async def test_pack_creates_squashfs(self, tmp_path: Path) -> None:
+    async def test_pack_creates_squashfs(self, tmp_path: SyncPath) -> None:
         """Pack creates a valid squashfs file."""
+        # Convert to anyio.Path
+        workspace = anyio.Path(tmp_path)
         # Create input workspace
-        input_dir = tmp_path / "workspace"
-        input_dir.mkdir()
-        (input_dir / "tools").mkdir()
-        (input_dir / "tools" / "test.py").write_text("# test tool")
+        input_dir = workspace / "workspace"
+        await input_dir.mkdir()
+        await (input_dir / "tools").mkdir()
+        await (input_dir / "tools" / "test.py").write_text("# test tool")
 
         # Create output path
-        output_file = tmp_path / "workspace.squashfs"
+        output_file = workspace / "workspace.squashfs"
 
         # Pack
         await pack(input_dir, output_file)
 
         # Verify output exists
-        assert output_file.exists()
-        assert output_file.stat().st_size > 0
+        assert await output_file.exists()
+        assert (await output_file.stat()).st_size > 0
 
-    async def test_pack_with_tag(self, tmp_path: Path) -> None:
+    async def test_pack_with_tag(self, tmp_path: SyncPath) -> None:
         """Pack with tag creates squashfs with tagged layer."""
-        input_dir = tmp_path / "workspace"
-        input_dir.mkdir()
-        (input_dir / "test.txt").write_text("test")
+        workspace = anyio.Path(tmp_path)
+        input_dir = workspace / "workspace"
+        await input_dir.mkdir()
+        await (input_dir / "test.txt").write_text("test")
 
-        output_file = tmp_path / "workspace.squashfs"
+        output_file = workspace / "workspace.squashfs"
 
         await pack(input_dir, output_file, tag="v1.0")
 
-        assert output_file.exists()
+        assert await output_file.exists()
 
-    async def test_pack_nonexistent_input(self, tmp_path: Path) -> None:
+    async def test_pack_nonexistent_input(self, tmp_path: SyncPath) -> None:
         """Pack raises error for nonexistent input directory."""
-        output_file = tmp_path / "output.squashfs"
+        workspace = anyio.Path(tmp_path)
+        output_file = workspace / "output.squashfs"
 
         with pytest.raises(PackError, match="does not exist"):
-            await pack(tmp_path / "nonexistent", output_file)
+            await pack(workspace / "nonexistent", output_file)
 
-    async def test_pack_file_as_input(self, tmp_path: Path) -> None:
+    async def test_pack_file_as_input(self, tmp_path: SyncPath) -> None:
         """Pack raises error when input is a file."""
-        input_file = tmp_path / "file.txt"
-        input_file.write_text("test")
+        workspace = anyio.Path(tmp_path)
+        input_file = workspace / "file.txt"
+        await input_file.write_text("test")
 
-        output_file = tmp_path / "output.squashfs"
+        output_file = workspace / "output.squashfs"
 
         with pytest.raises(PackError, match="not a directory"):
             await pack(input_file, output_file)

--- a/tests/workspace/test_snapshot.py
+++ b/tests/workspace/test_snapshot.py
@@ -2,9 +2,10 @@
 
 from __future__ import annotations
 
-from pathlib import Path
+from pathlib import Path as SyncPath
 from unittest.mock import patch
 
+import anyio
 import pytest
 
 from psi_agent.workspace.snapshot.api import SnapshotError, snapshot
@@ -13,58 +14,58 @@ from psi_agent.workspace.snapshot.api import SnapshotError, snapshot
 class TestSnapshot:
     """Tests for snapshot function."""
 
-    async def test_snapshot_nonexistent_input(self, tmp_path: Path) -> None:
+    async def test_snapshot_nonexistent_input(self, tmp_path: SyncPath) -> None:
         """Snapshot raises error for nonexistent input file."""
-        mount_point = tmp_path / "mounted"
-        mount_point.mkdir()
+        mount_point = anyio.Path(tmp_path) / "mounted"
+        await mount_point.mkdir()
 
         with pytest.raises(SnapshotError, match="Input file does not exist"):
-            await snapshot(tmp_path / "nonexistent.squashfs", mount_point)
+            await snapshot(anyio.Path(tmp_path) / "nonexistent.squashfs", mount_point)
 
-    async def test_snapshot_nonexistent_mount_point(self, tmp_path: Path) -> None:
+    async def test_snapshot_nonexistent_mount_point(self, tmp_path: SyncPath) -> None:
         """Snapshot raises error for nonexistent mount point."""
-        input_file = tmp_path / "workspace.squashfs"
-        input_file.touch()
+        input_file = anyio.Path(tmp_path) / "workspace.squashfs"
+        await input_file.touch()
 
         with pytest.raises(SnapshotError, match="Mount point does not exist"):
-            await snapshot(input_file, tmp_path / "nonexistent")
+            await snapshot(input_file, anyio.Path(tmp_path) / "nonexistent")
 
-    async def test_snapshot_missing_mount_info(self, tmp_path: Path) -> None:
+    async def test_snapshot_missing_mount_info(self, tmp_path: SyncPath) -> None:
         """Snapshot raises error when mount info is missing."""
-        input_file = tmp_path / "workspace.squashfs"
-        input_file.touch()
+        input_file = anyio.Path(tmp_path) / "workspace.squashfs"
+        await input_file.touch()
 
-        mount_point = tmp_path / "mounted"
-        mount_point.mkdir()
+        mount_point = anyio.Path(tmp_path) / "mounted"
+        await mount_point.mkdir()
 
         with pytest.raises(SnapshotError, match="Mount info file not found"):
             await snapshot(input_file, mount_point)
 
-    async def test_snapshot_invalid_mount_info(self, tmp_path: Path) -> None:
+    async def test_snapshot_invalid_mount_info(self, tmp_path: SyncPath) -> None:
         """Snapshot raises error when mount info is invalid."""
-        input_file = tmp_path / "workspace.squashfs"
-        input_file.touch()
+        input_file = anyio.Path(tmp_path) / "workspace.squashfs"
+        await input_file.touch()
 
-        mount_point = tmp_path / "mounted"
-        mount_point.mkdir()
+        mount_point = anyio.Path(tmp_path) / "mounted"
+        await mount_point.mkdir()
 
         # Create invalid mount info file
         mount_info = mount_point / ".psi-mount-info"
-        mount_info.write_text("not valid python")
+        await mount_info.write_text("not valid python")
 
         with pytest.raises(SnapshotError, match="Invalid mount info"):
             await snapshot(input_file, mount_point)
 
-    async def test_snapshot_with_valid_mount_info(self, tmp_path: Path) -> None:
+    async def test_snapshot_with_valid_mount_info(self, tmp_path: SyncPath) -> None:
         """Snapshot processes valid mount info correctly."""
-        input_file = tmp_path / "workspace.squashfs"
-        input_file.touch()
+        input_file = anyio.Path(tmp_path) / "workspace.squashfs"
+        await input_file.touch()
 
-        mount_point = tmp_path / "mounted"
-        mount_point.mkdir()
+        mount_point = anyio.Path(tmp_path) / "mounted"
+        await mount_point.mkdir()
 
-        upper_dir = tmp_path / "upper"
-        upper_dir.mkdir()
+        upper_dir = anyio.Path(tmp_path) / "upper"
+        await upper_dir.mkdir()
 
         # Create valid mount info file
         mount_info = mount_point / ".psi-mount-info"
@@ -72,7 +73,7 @@ class TestSnapshot:
             f"{{'squashfs_mount': '{tmp_path}/squashfs', "
             f"'upper_dir': '{upper_dir}', 'work_dir': '{tmp_path}/work'}}"
         )
-        mount_info.write_text(mount_info_content)
+        await mount_info.write_text(mount_info_content)
 
         # Mock the internal functions to avoid needing actual squashfs tools
         with (

--- a/tests/workspace/test_umount.py
+++ b/tests/workspace/test_umount.py
@@ -2,9 +2,10 @@
 
 from __future__ import annotations
 
-from pathlib import Path
+from pathlib import Path as SyncPath
 from unittest.mock import patch
 
+import anyio
 import pytest
 
 from psi_agent.workspace.umount.api import UmountError, umount
@@ -13,42 +14,42 @@ from psi_agent.workspace.umount.api import UmountError, umount
 class TestUmount:
     """Tests for umount function."""
 
-    async def test_umount_nonexistent_mount_point(self, tmp_path: Path) -> None:
+    async def test_umount_nonexistent_mount_point(self, tmp_path: SyncPath) -> None:
         """Umount raises error for nonexistent mount point."""
         with pytest.raises(UmountError, match="does not exist"):
-            await umount(tmp_path / "nonexistent")
+            await umount(anyio.Path(tmp_path) / "nonexistent")
 
-    async def test_umount_missing_mount_info(self, tmp_path: Path) -> None:
+    async def test_umount_missing_mount_info(self, tmp_path: SyncPath) -> None:
         """Umount raises error when mount info file is missing."""
-        mount_dir = tmp_path / "mounted"
-        mount_dir.mkdir()
+        mount_dir = anyio.Path(tmp_path) / "mounted"
+        await mount_dir.mkdir()
 
         with pytest.raises(UmountError, match="Mount info file not found"):
             await umount(mount_dir)
 
-    async def test_umount_invalid_mount_info(self, tmp_path: Path) -> None:
+    async def test_umount_invalid_mount_info(self, tmp_path: SyncPath) -> None:
         """Umount raises error when mount info is invalid."""
-        mount_dir = tmp_path / "mounted"
-        mount_dir.mkdir()
+        mount_dir = anyio.Path(tmp_path) / "mounted"
+        await mount_dir.mkdir()
 
         # Create invalid mount info file
         mount_info = mount_dir / ".psi-mount-info"
-        mount_info.write_text("not valid python")
+        await mount_info.write_text("not valid python")
 
         with pytest.raises(UmountError, match="Invalid mount info"):
             await umount(mount_dir)
 
-    async def test_umount_valid_mount_info_parse(self, tmp_path: Path) -> None:
+    async def test_umount_valid_mount_info_parse(self, tmp_path: SyncPath) -> None:
         """Umount correctly parses valid mount info."""
-        mount_dir = tmp_path / "mounted"
-        mount_dir.mkdir()
+        mount_dir = anyio.Path(tmp_path) / "mounted"
+        await mount_dir.mkdir()
 
-        upper_dir = tmp_path / "upper"
-        upper_dir.mkdir()
-        work_dir = tmp_path / "work"
-        work_dir.mkdir()
-        squashfs_mount = tmp_path / "squashfs"
-        squashfs_mount.mkdir()
+        upper_dir = anyio.Path(tmp_path) / "upper"
+        await upper_dir.mkdir()
+        work_dir = anyio.Path(tmp_path) / "work"
+        await work_dir.mkdir()
+        squashfs_mount = anyio.Path(tmp_path) / "squashfs"
+        await squashfs_mount.mkdir()
 
         # Create valid mount info file
         mount_info = mount_dir / ".psi-mount-info"
@@ -56,7 +57,7 @@ class TestUmount:
             f"{{'squashfs_mount': '{squashfs_mount}', "
             f"'upper_dir': '{upper_dir}', 'work_dir': '{work_dir}'}}"
         )
-        mount_info.write_text(mount_info_content)
+        await mount_info.write_text(mount_info_content)
 
         # Mock the _unmount and _cleanup_directory functions
         with (

--- a/tests/workspace/test_unpack.py
+++ b/tests/workspace/test_unpack.py
@@ -2,8 +2,9 @@
 
 from __future__ import annotations
 
-from pathlib import Path
+from pathlib import Path as SyncPath
 
+import anyio
 import pytest
 
 from psi_agent.workspace.pack.api import pack
@@ -13,38 +14,41 @@ from psi_agent.workspace.unpack.api import UnpackError, unpack
 class TestUnpack:
     """Tests for unpack function."""
 
-    async def test_unpack_creates_directory(self, tmp_path: Path) -> None:
+    async def test_unpack_creates_directory(self, tmp_path: SyncPath) -> None:
         """Unpack creates directory with squashfs contents."""
+        workspace = anyio.Path(tmp_path)
         # Create and pack a workspace
-        input_dir = tmp_path / "workspace"
-        input_dir.mkdir()
-        (input_dir / "tools").mkdir()
-        (input_dir / "tools" / "test.py").write_text("# test tool")
+        input_dir = workspace / "workspace"
+        await input_dir.mkdir()
+        await (input_dir / "tools").mkdir()
+        await (input_dir / "tools" / "test.py").write_text("# test tool")
 
-        squashfs_file = tmp_path / "workspace.squashfs"
+        squashfs_file = workspace / "workspace.squashfs"
         await pack(input_dir, squashfs_file)
 
         # Unpack
-        output_dir = tmp_path / "unpacked"
+        output_dir = workspace / "unpacked"
         await unpack(squashfs_file, output_dir)
 
         # Verify output exists
-        assert output_dir.exists()
-        assert (output_dir / "manifest.json").exists()
+        assert await output_dir.exists()
+        assert await (output_dir / "manifest.json").exists()
 
-    async def test_unpack_nonexistent_input(self, tmp_path: Path) -> None:
+    async def test_unpack_nonexistent_input(self, tmp_path: SyncPath) -> None:
         """Unpack raises error for nonexistent input file."""
-        output_dir = tmp_path / "output"
+        workspace = anyio.Path(tmp_path)
+        output_dir = workspace / "output"
 
         with pytest.raises(UnpackError, match="does not exist"):
-            await unpack(tmp_path / "nonexistent.squashfs", output_dir)
+            await unpack(workspace / "nonexistent.squashfs", output_dir)
 
-    async def test_unpack_directory_as_input(self, tmp_path: Path) -> None:
+    async def test_unpack_directory_as_input(self, tmp_path: SyncPath) -> None:
         """Unpack raises error when input is a directory."""
-        input_dir = tmp_path / "input"
-        input_dir.mkdir()
+        workspace = anyio.Path(tmp_path)
+        input_dir = workspace / "input"
+        await input_dir.mkdir()
 
-        output_dir = tmp_path / "output"
+        output_dir = workspace / "output"
 
         with pytest.raises(UnpackError, match="not a file"):
             await unpack(input_dir, output_dir)


### PR DESCRIPTION
## Summary

- Migrate all `pathlib.Path` usage to `anyio.Path` for fully async file operations
- Update all type annotations to use `anyio.Path` instead of `pathlib.Path`
- Convert test files to properly handle pytest's `tmp_path` fixture (returns `pathlib.Path`)
- Use `SyncPath` (pathlib.Path) only for default path construction with `Path.home()`

## Changes

### Source Files
- Config files: Replace `pathlib.Path` with `anyio.Path` in return types
- Session files: Update `Schedule.task_dir`, workspace watcher, tool loader, runner, history
- Workspace files: Migrate all pack/unpack/mount/snapshot/umount APIs
- AI files: Update server socket path handling

### Test Files
- Convert `tmp_path` fixtures to `anyio.Path` where needed
- Update `isinstance` checks to expect `anyio.Path`
- Use async file operations in test setup

## Test plan

- [x] All 248 tests pass
- [x] `ruff check` passes
- [x] `ruff format` passes
- [x] `ty check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)