### PR TITLE
Add auto-alpha-tag GitHub Action for daily CI-passed commit tagging

### DIFF
--- a/.github/workflows/auto-alpha-tag.yml
+++ b/.github/workflows/auto-alpha-tag.yml
@@ -1,0 +1,91 @@
+name: Auto Alpha Tag
+
+on:
+  schedule:
+    # 1:00 UTC = 9:00 AM Beijing time (UTC+8)
+    - cron: '0 1 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+env:
+  CI_WORKFLOW: ci.yml
+
+jobs:
+  auto-tag:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Fetch all tags
+        run: git fetch --tags origin
+
+      - name: Create and push alpha tag
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # Step 1: Find the last successful CI run on main branch
+          RUN_DATA=$(gh run list \
+            --workflow="${{ env.CI_WORKFLOW }}" \
+            --branch=main \
+            --status=success \
+            --limit=1 \
+            --json headSha)
+
+          if [ -z "$RUN_DATA" ] || [ "$RUN_DATA" = "[]" ]; then
+            echo "::notice::No successful CI runs found on main branch, skipping"
+            exit 0
+          fi
+
+          COMMIT_SHA=$(echo "$RUN_DATA" | jq -r '.[0].headSha')
+          echo "Found last successful CI commit: $COMMIT_SHA"
+
+          # Step 2: Check if commit already has a tag
+          if git describe --exact-match "$COMMIT_SHA" 2>/dev/null; then
+            EXISTING_TAG=$(git describe --exact-match "$COMMIT_SHA")
+            echo "::notice::Commit $COMMIT_SHA already has tag: $EXISTING_TAG, skipping"
+            exit 0
+          fi
+
+          # Step 3: Find the most recent alpha tag to derive version prefix
+          DESCRIBE_OUTPUT=$(git describe --tags --match 'v*-alpha*' "$COMMIT_SHA" 2>/dev/null || true)
+
+          if [ -z "$DESCRIBE_OUTPUT" ]; then
+            echo "::notice::No previous alpha tag found. Please create an initial alpha tag manually (e.g., v0.1.0-alpha20260401)."
+            exit 0
+          fi
+
+          echo "Found alpha tag reference: $DESCRIBE_OUTPUT"
+
+          # Extract version prefix (vN.N.N) from describe output
+          # Format: vN.N.N-alphaYYYYMMDD-N-gHASH
+          VERSION_PREFIX=$(echo "$DESCRIBE_OUTPUT" | sed 's/-alpha[0-9]*-[0-9]*-g[0-9a-f]*$//')
+
+          if [ -z "$VERSION_PREFIX" ]; then
+            echo "::warning::Failed to extract version prefix from: $DESCRIBE_OUTPUT"
+            exit 0
+          fi
+
+          echo "Version prefix: $VERSION_PREFIX"
+
+          # Step 4: Generate new tag
+          DATE_SUFFIX=$(date +%Y%m%d)
+          NEW_TAG="${VERSION_PREFIX}-alpha${DATE_SUFFIX}"
+
+          # Check if tag already exists for today
+          if git tag -l "$NEW_TAG" | grep -q "$NEW_TAG"; then
+            echo "::notice::Tag $NEW_TAG already exists, skipping"
+            exit 0
+          fi
+
+          # Step 5: Create and push the tag
+          echo "Creating tag: $NEW_TAG on commit: $COMMIT_SHA"
+          git tag "$NEW_TAG" "$COMMIT_SHA"
+          git push origin "$NEW_TAG"
+
+          echo "::notice::Successfully created and pushed tag: $NEW_TAG"

--- a/openspec/changes/archive/2026-04-29-auto-alpha-tag/.openspec.yaml
+++ b/openspec/changes/archive/2026-04-29-auto-alpha-tag/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-29

--- a/openspec/changes/archive/2026-04-29-auto-alpha-tag/design.md
+++ b/openspec/changes/archive/2026-04-29-auto-alpha-tag/design.md
@@ -1,0 +1,79 @@
+## Context
+
+This design introduces a GitHub Action workflow for automated alpha tagging. The workflow needs to interact with the GitHub API to query workflow runs, commits, and tags. It will run on a schedule and perform git operations to create and push tags.
+
+Key constraints:
+- Must run at 9:00 AM Beijing time (UTC+8)
+- Must only tag commits that have passed CI.yml
+- Must not create duplicate tags on already-tagged commits
+- Tag format must follow `vN.N.N-alphaYYYYMMDD` pattern
+
+## Goals / Non-Goals
+
+**Goals:**
+- Automate daily alpha tagging for CI-passed commits
+- Provide clear markers for successful builds
+- Enable downstream automation based on tags
+
+**Non-Goals:**
+- Creating release tags (only alpha tags)
+- Modifying existing CI workflow behavior
+- Handling manual tag creation or deletion
+
+## Decisions
+
+### 1. Workflow Trigger Mechanism
+**Decision**: Use `schedule` trigger with cron expression `0 1 * * *` (1:00 UTC = 9:00 AM Beijing)
+
+**Rationale**: GitHub Actions cron uses UTC. Beijing is UTC+8, so 9:00 AM Beijing = 1:00 AM UTC.
+
+**Alternatives considered**:
+- `workflow_dispatch` for manual triggers - kept as fallback for testing
+- `repository_dispatch` for external triggers - unnecessary complexity
+
+### 2. Workflow Structure
+**Decision**: Keep the workflow simple with only 3 steps: checkout, fetch tags, and a single main step that handles all logic
+
+**Rationale**: The logic is straightforward and doesn't benefit from being split into multiple steps with conditionals. A single step with clear comments is easier to read and maintain.
+
+### 3. Finding Last CI-Passed Commit
+**Decision**: Use GitHub CLI (`gh`) to query workflow runs
+
+**Rationale**: `gh run list --workflow=CI.yml --branch=main --status=success --limit=1` directly gives the most recent successful run with its head SHA.
+
+**Alternatives considered**:
+- GitHub REST API with `curl` - more verbose, requires manual pagination
+- GraphQL API - overkill for simple query
+
+### 4. Finding Previous Alpha Tag
+**Decision**: Use `git describe --tags --match 'v*-alpha*'` to find the most recent alpha tag reachable from current HEAD
+
+**Rationale**: This command finds the most recent tag that is reachable from the current commit, which correctly handles tags on other branches. The output format is `vN.N.N-alphaYYYYMMDD-N-gHASH` where N is the number of commits since the tag. We extract the version prefix using `sed 's/-alpha[0-9]*-[0-9]*-g[0-9a-f]*$//'`.
+
+**Alternatives considered**:
+- `git tag --list` - doesn't consider branch topology, may find tags from unrelated branches
+- `git describe --tags` without `--match` - may find non-alpha tags
+
+### 5. Tag Format and Date Suffix
+**Decision**: Use `YYYYMMDD` format for date suffix (e.g., `v0.1.0-alpha20260429`)
+
+**Rationale**: ISO date format is unambiguous and sorts chronologically. The version prefix (vN.N.N) is inherited from the previous alpha tag.
+
+### 6. Permission Model
+**Decision**: Use `contents: write` permission in workflow
+
+**Rationale**: Required for pushing tags to the repository. Minimal permission needed for this operation.
+
+## Risks / Trade-offs
+
+- **Risk**: No CI-passed commits found on a given day
+  → Mitigation: Workflow exits gracefully with informative message
+
+- **Risk**: No previous alpha tag exists to derive version prefix
+  → Mitigation: Exit with clear message, require manual initial tag (e.g., `v0.1.0-alpha20260401`)
+
+- **Risk**: Tag already exists for the date (multiple runs same day)
+  → Mitigation: Check for existing tag before creating, skip if exists
+
+- **Risk**: CI workflow name changes
+  → Mitigation: Document the dependency, make workflow name configurable via env var

--- a/openspec/changes/archive/2026-04-29-auto-alpha-tag/proposal.md
+++ b/openspec/changes/archive/2026-04-29-auto-alpha-tag/proposal.md
@@ -1,0 +1,27 @@
+## Why
+
+Currently, there is no automated process to tag successful builds on the main branch. This makes it difficult to track which commits have passed CI and are ready for further processing (e.g., deployment, release candidates). An automated daily tagging system would provide clear markers for CI-verified commits, enabling downstream automation and improving release traceability.
+
+## What Changes
+
+- Add a new GitHub Action workflow that runs daily at 9:00 AM (Beijing time)
+- The workflow will automatically find the last CI-passed commit on main branch
+- If that commit doesn't already have a tag, it will create an alpha tag with format `vN.N.N-alphaYYYYMMDD`
+- The tag is derived from the most recent alpha tag pattern, incrementing the date suffix
+
+## Capabilities
+
+### New Capabilities
+
+- `auto-alpha-tag`: Automated daily alpha tagging for CI-passed commits on main branch
+
+### Modified Capabilities
+
+- `ci-workflow`: The new workflow will reference the existing CI.yml workflow to determine commit success status
+
+## Impact
+
+- New file: `.github/workflows/auto-alpha-tag.yml`
+- Reads from: `.github/workflows/CI.yml` (to check commit status)
+- Requires: `contents: write` permission for pushing tags
+- No breaking changes to existing functionality

--- a/openspec/changes/archive/2026-04-29-auto-alpha-tag/specs/auto-alpha-tag/spec.md
+++ b/openspec/changes/archive/2026-04-29-auto-alpha-tag/specs/auto-alpha-tag/spec.md
@@ -1,0 +1,66 @@
+## ADDED Requirements
+
+### Requirement: Daily scheduled execution
+The workflow SHALL execute daily at 9:00 AM Beijing time (UTC+8).
+
+#### Scenario: Scheduled trigger fires correctly
+- **WHEN** the cron schedule reaches 1:00 UTC (9:00 AM Beijing)
+- **THEN** the workflow is triggered automatically
+
+### Requirement: Find last CI-passed commit
+The workflow SHALL identify the most recent commit on main branch that has passed the CI.yml workflow.
+
+#### Scenario: CI-passed commit found
+- **WHEN** there is at least one successful CI.yml run on main branch
+- **THEN** the workflow identifies the head SHA of the most recent successful run
+
+#### Scenario: No CI-passed commit exists
+- **WHEN** there are no successful CI.yml runs on main branch
+- **THEN** the workflow exits gracefully without creating a tag
+
+### Requirement: Skip already-tagged commits
+The workflow SHALL NOT create a tag if the target commit already has any tag.
+
+#### Scenario: Commit has existing tag
+- **WHEN** the identified commit already has a tag
+- **THEN** the workflow exits without creating a new tag
+
+#### Scenario: Commit has no tag
+- **WHEN** the identified commit has no existing tag
+- **THEN** the workflow proceeds to create a new alpha tag
+
+### Requirement: Derive tag version from previous alpha tag
+The workflow SHALL derive the version prefix (N.N.N) from the most recent existing alpha tag.
+
+#### Scenario: Previous alpha tag found
+- **WHEN** there is at least one tag matching pattern `*-alpha*`
+- **THEN** the workflow extracts the version prefix (N.N.N) from the most recent one
+
+#### Scenario: No previous alpha tag exists
+- **WHEN** there are no tags matching pattern `*-alpha*`
+- **THEN** the workflow fails with an error message requiring manual initial tag creation
+
+### Requirement: Create alpha tag with date suffix
+The workflow SHALL create a tag with format `vN.N.N-alphaYYYYMMDD` where YYYYMMDD is the current date.
+
+#### Scenario: Tag created successfully
+- **WHEN** all prerequisites are satisfied (commit found, no existing tag, previous alpha tag exists)
+- **THEN** a new tag `vN.N.N-alphaYYYYMMDD` is created on the commit
+
+#### Scenario: Tag already exists for current date
+- **WHEN** a tag with the same date suffix already exists
+- **THEN** the workflow skips tag creation to avoid duplicates
+
+### Requirement: Push tag to repository
+The workflow SHALL push the created tag to the remote repository.
+
+#### Scenario: Tag pushed successfully
+- **WHEN** a new tag is created
+- **THEN** the tag is pushed to the origin repository
+
+### Requirement: Manual trigger support
+The workflow SHALL support manual triggering via workflow_dispatch for testing purposes.
+
+#### Scenario: Manual trigger
+- **WHEN** user triggers the workflow manually via workflow_dispatch
+- **THEN** the workflow executes the same logic as scheduled runs

--- a/openspec/changes/archive/2026-04-29-auto-alpha-tag/tasks.md
+++ b/openspec/changes/archive/2026-04-29-auto-alpha-tag/tasks.md
@@ -1,0 +1,39 @@
+## 1. Workflow File Creation
+
+- [x] 1.1 Create `.github/workflows/auto-alpha-tag.yml` file with workflow structure
+- [x] 1.2 Configure workflow triggers (schedule at 1:00 UTC and workflow_dispatch)
+- [x] 1.3 Set workflow permissions (`contents: write`)
+
+## 2. Find Last CI-Passed Commit
+
+- [x] 2.1 Add step to checkout repository
+- [x] 2.2 Add step to install GitHub CLI (gh)
+- [x] 2.3 Add step to query last successful CI.yml run on main branch
+- [x] 2.4 Add step to extract commit SHA from the run
+- [x] 2.5 Add error handling for no successful runs found
+
+## 3. Check Existing Tags
+
+- [x] 3.1 Add step to fetch all tags from remote
+- [x] 3.2 Add step to check if commit already has a tag using `git describe --exact-match`
+- [x] 3.3 Add conditional to skip workflow if commit is already tagged
+
+## 4. Derive Version from Previous Alpha Tag
+
+- [x] 4.1 Add step to list all alpha tags sorted by creation date
+- [x] 4.2 Add step to extract version prefix (N.N.N) from most recent alpha tag
+- [x] 4.3 Add error handling for no previous alpha tag found
+
+## 5. Create and Push Tag
+
+- [x] 5.1 Add step to generate date suffix (YYYYMMDD format)
+- [x] 5.2 Add step to construct full tag name (N.N.N-alphaYYYYMMDD)
+- [x] 5.3 Add step to check if tag with same date suffix already exists
+- [x] 5.4 Add step to create the tag on the commit
+- [x] 5.5 Add step to push the tag to origin repository
+
+## 6. Verification
+
+- [ ] 6.1 Test workflow manually via workflow_dispatch
+- [ ] 6.2 Verify workflow logs show correct behavior for all scenarios
+- [ ] 6.3 Verify created tags appear in repository

--- a/openspec/specs/auto-alpha-tag/spec.md
+++ b/openspec/specs/auto-alpha-tag/spec.md
@@ -1,0 +1,66 @@
+## ADDED Requirements
+
+### Requirement: Daily scheduled execution
+The workflow SHALL execute daily at 9:00 AM Beijing time (UTC+8).
+
+#### Scenario: Scheduled trigger fires correctly
+- **WHEN** the cron schedule reaches 1:00 UTC (9:00 AM Beijing)
+- **THEN** the workflow is triggered automatically
+
+### Requirement: Find last CI-passed commit
+The workflow SHALL identify the most recent commit on main branch that has passed the CI.yml workflow.
+
+#### Scenario: CI-passed commit found
+- **WHEN** there is at least one successful CI.yml run on main branch
+- **THEN** the workflow identifies the head SHA of the most recent successful run
+
+#### Scenario: No CI-passed commit exists
+- **WHEN** there are no successful CI.yml runs on main branch
+- **THEN** the workflow exits gracefully without creating a tag
+
+### Requirement: Skip already-tagged commits
+The workflow SHALL NOT create a tag if the target commit already has any tag.
+
+#### Scenario: Commit has existing tag
+- **WHEN** the identified commit already has a tag
+- **THEN** the workflow exits without creating a new tag
+
+#### Scenario: Commit has no tag
+- **WHEN** the identified commit has no existing tag
+- **THEN** the workflow proceeds to create a new alpha tag
+
+### Requirement: Derive tag version from previous alpha tag
+The workflow SHALL derive the version prefix (N.N.N) from the most recent existing alpha tag.
+
+#### Scenario: Previous alpha tag found
+- **WHEN** there is at least one tag matching pattern `*-alpha*`
+- **THEN** the workflow extracts the version prefix (N.N.N) from the most recent one
+
+#### Scenario: No previous alpha tag exists
+- **WHEN** there are no tags matching pattern `*-alpha*`
+- **THEN** the workflow fails with an error message requiring manual initial tag creation
+
+### Requirement: Create alpha tag with date suffix
+The workflow SHALL create a tag with format `vN.N.N-alphaYYYYMMDD` where YYYYMMDD is the current date.
+
+#### Scenario: Tag created successfully
+- **WHEN** all prerequisites are satisfied (commit found, no existing tag, previous alpha tag exists)
+- **THEN** a new tag `vN.N.N-alphaYYYYMMDD` is created on the commit
+
+#### Scenario: Tag already exists for current date
+- **WHEN** a tag with the same date suffix already exists
+- **THEN** the workflow skips tag creation to avoid duplicates
+
+### Requirement: Push tag to repository
+The workflow SHALL push the created tag to the remote repository.
+
+#### Scenario: Tag pushed successfully
+- **WHEN** a new tag is created
+- **THEN** the tag is pushed to the origin repository
+
+### Requirement: Manual trigger support
+The workflow SHALL support manual triggering via workflow_dispatch for testing purposes.
+
+#### Scenario: Manual trigger
+- **WHEN** user triggers the workflow manually via workflow_dispatch
+- **THEN** the workflow executes the same logic as scheduled runs


### PR DESCRIPTION
## Summary
- Add GitHub Action workflow that runs daily at 9:00 AM Beijing time (1:00 UTC)
- Automatically finds the last CI-passed commit on main branch
- Creates alpha tag with format `vN.N.N-alphaYYYYMMDD` if commit has no existing tag
- Derives version prefix from previous alpha tag using `git describe --tags --match 'v*-alpha*'`

## Behavior
1. Scheduled trigger at 1:00 UTC (9:00 AM Beijing)
2. Query last successful CI run on main branch via `gh run list`
3. Skip if commit already has a tag
4. Find previous alpha tag to derive version prefix
5. Create and push new alpha tag with current date suffix

## Edge Cases Handled
- No successful CI runs: exits gracefully with notice
- Commit already tagged: skips with notice
- No previous alpha tag: exits with notice, requires manual initial tag
- Tag already exists for today: skips to avoid duplicates

## Test Plan
- [ ] Trigger workflow manually via workflow_dispatch
- [ ] Verify workflow logs show correct behavior
- [ ] Verify created tags appear in repository

🤖 Generated with [Claude Code](https://claude.com/claude-code)