### PR TITLE
Add proxy support to Telegram channel

### DIFF
--- a/openspec/changes/archive/2026-04-29-add-proxy-for-telegram/.openspec.yaml
+++ b/openspec/changes/archive/2026-04-29-add-proxy-for-telegram/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-29

--- a/openspec/changes/archive/2026-04-29-add-proxy-for-telegram/design.md
+++ b/openspec/changes/archive/2026-04-29-add-proxy-for-telegram/design.md
@@ -1,0 +1,48 @@
+## Context
+
+The Telegram channel (`psi-agent channel telegram`) uses `python-telegram-bot` library to connect to Telegram Bot API. Currently, it only supports direct connections, which fails in restricted network environments.
+
+`python-telegram-bot` v20+ supports proxy configuration via the `proxy_url` parameter in `Application.builder()`. This uses Python's built-in `aiohttp` connector with proxy support.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Add optional `--proxy` CLI argument accepting proxy URLs
+- Support SOCKS5 (`socks5://`), HTTP (`http://`), and HTTPS (`https://`) proxy URLs
+- Default behavior unchanged (no proxy when argument not provided)
+- Pass proxy to `python-telegram-bot` Application builder
+
+**Non-Goals:**
+- Proxy authentication UI/CLI (credentials embedded in URL are supported)
+- Proxy connection testing/validation
+- Multiple proxy configurations or fallback chains
+
+## Decisions
+
+### Proxy URL Format
+
+Use standard URL format for all proxy types:
+- `socks5://host:port` - SOCKS5 proxy
+- `socks5://user:pass@host:port` - SOCKS5 with authentication
+- `http://host:port` - HTTP proxy
+- `https://host:port` - HTTPS proxy
+
+**Rationale**: Standard URL format is widely understood and supported by `aiohttp`. No need for custom parsing logic.
+
+### Configuration Storage
+
+Add `proxy` field to `TelegramConfig` dataclass as `str | None = None`.
+
+**Rationale**: Keeps configuration in one place, follows existing pattern.
+
+### Application Builder Integration
+
+Pass proxy URL to `Application.builder().proxy_url(proxy).build()`.
+
+**Rationale**: Native `python-telegram-bot` support, no custom connector needed.
+
+## Risks / Trade-offs
+
+- **SOCKS5 requires `python-socks` package** → Document in README if users need SOCKS5 support
+- **Proxy URL with credentials visible in process list** → Already mitigated by `mask_sensitive_args()` pattern (extend to include `proxy`)
+- **Invalid proxy URL causes startup failure** → Clear error message from `aiohttp`, acceptable behavior

--- a/openspec/changes/archive/2026-04-29-add-proxy-for-telegram/proposal.md
+++ b/openspec/changes/archive/2026-04-29-add-proxy-for-telegram/proposal.md
@@ -1,0 +1,26 @@
+## Why
+
+Users in restricted network environments (e.g., behind corporate firewalls, in countries with Telegram restrictions) cannot connect to Telegram Bot API directly. Adding proxy support allows the telegram channel to work in these environments by routing connections through SOCKS5, HTTP, or HTTPS proxies.
+
+## What Changes
+
+- Add optional `proxy` parameter to Telegram channel CLI (`psi-agent channel telegram`)
+- Support three proxy types: SOCKS5, HTTP, HTTPS
+- Default to `None` (no proxy) for normal operation
+- Pass proxy configuration to `python-telegram-bot`'s Application builder
+
+## Capabilities
+
+### New Capabilities
+
+- `telegram-proxy`: Support for proxy configuration in Telegram channel, enabling connections through SOCKS5, HTTP, or HTTPS proxies
+
+### Modified Capabilities
+
+- `telegram-channel`: CLI now accepts optional `--proxy` argument; bot initialization passes proxy to Application builder
+
+## Impact
+
+- **Affected code**: `src/psi_agent/channel/telegram/cli.py`, `src/psi_agent/channel/telegram/config.py`, `src/psi_agent/channel/telegram/bot.py`
+- **Dependencies**: `python-telegram-bot` supports proxy via `proxy_url` parameter in Application builder (no new dependencies needed)
+- **API**: CLI adds `--proxy` optional argument

--- a/openspec/changes/archive/2026-04-29-add-proxy-for-telegram/specs/telegram-channel/spec.md
+++ b/openspec/changes/archive/2026-04-29-add-proxy-for-telegram/specs/telegram-channel/spec.md
@@ -1,0 +1,46 @@
+## MODIFIED Requirements
+
+### Requirement: Telegram channel provides CLI entry point
+
+The Telegram channel SHALL provide a CLI command `psi-channel-telegram` for starting the bot.
+
+#### Scenario: CLI starts with token argument
+- **WHEN** `psi-channel-telegram --token <token> --session-socket <path>` is invoked
+- **THEN** the bot SHALL initialize and connect to the session
+
+#### Scenario: CLI starts with token and proxy argument
+- **WHEN** `psi-channel-telegram --token <token> --session-socket <path> --proxy <proxy_url>` is invoked
+- **THEN** the bot SHALL initialize with proxy configuration and connect to the session
+
+#### Scenario: Missing token shows error
+- **WHEN** `psi-channel-telegram` is invoked without `--token`
+- **THEN** the CLI SHALL display an error and exit
+
+### Requirement: Telegram channel uses tyro dataclass CLI pattern
+
+The Telegram channel CLI SHALL use a dataclass with `__call__` method for tyro integration.
+
+#### Scenario: Dataclass CLI implementation
+- **WHEN** the telegram CLI module is defined
+- **THEN** it SHALL use a `@dataclass` class named `Telegram`
+- **AND** the class SHALL have a `__call__` method that executes the command
+
+#### Scenario: CLI parameters as dataclass fields
+- **WHEN** the `Telegram` dataclass is defined
+- **THEN** `token`, `session_socket`, and `proxy` SHALL be dataclass fields
+- **AND** `proxy` SHALL be optional with default value `None`
+- **AND** tyro SHALL automatically generate CLI arguments from these fields
+
+### Requirement: CLI masks sensitive token from process title
+
+The Telegram channel CLI SHALL mask the `--token` and `--proxy` arguments from the process title immediately after parsing.
+
+#### Scenario: Token masked in process title
+- **WHEN** `psi-channel-telegram` is started with `--token 123456:ABC`
+- **THEN** the process title SHALL NOT contain the token value
+- **AND** the process title SHALL show `--token ***`
+
+#### Scenario: Proxy with credentials masked in process title
+- **WHEN** `psi-channel-telegram` is started with `--proxy socks5://user:pass@host:port`
+- **THEN** the process title SHALL NOT contain the proxy credentials
+- **AND** the process title SHALL show `--proxy ***`

--- a/openspec/changes/archive/2026-04-29-add-proxy-for-telegram/specs/telegram-proxy/spec.md
+++ b/openspec/changes/archive/2026-04-29-add-proxy-for-telegram/specs/telegram-proxy/spec.md
@@ -1,0 +1,50 @@
+## ADDED Requirements
+
+### Requirement: Telegram channel supports optional proxy configuration
+
+The Telegram channel SHALL accept an optional `--proxy` argument for routing connections through a proxy server.
+
+#### Scenario: Start without proxy
+- **WHEN** `psi-agent channel telegram --token <token> --session-socket <path>` is invoked without `--proxy`
+- **THEN** the bot SHALL connect directly to Telegram Bot API
+
+#### Scenario: Start with SOCKS5 proxy
+- **WHEN** `psi-agent channel telegram --token <token> --session-socket <path> --proxy socks5://host:port` is invoked
+- **THEN** the bot SHALL route all connections through the SOCKS5 proxy
+
+#### Scenario: Start with HTTP proxy
+- **WHEN** `psi-agent channel telegram --token <token> --session-socket <path> --proxy http://host:port` is invoked
+- **THEN** the bot SHALL route all connections through the HTTP proxy
+
+#### Scenario: Start with HTTPS proxy
+- **WHEN** `psi-agent channel telegram --token <token> --session-socket <path> --proxy https://host:port` is invoked
+- **THEN** the bot SHALL route all connections through the HTTPS proxy
+
+### Requirement: Telegram channel supports proxy with authentication
+
+The Telegram channel SHALL support proxy URLs with embedded credentials.
+
+#### Scenario: SOCKS5 proxy with authentication
+- **WHEN** `--proxy socks5://user:password@host:port` is provided
+- **THEN** the bot SHALL authenticate with the proxy using the provided credentials
+
+#### Scenario: HTTP proxy with authentication
+- **WHEN** `--proxy http://user:password@host:port` is provided
+- **THEN** the bot SHALL authenticate with the proxy using the provided credentials
+
+### Requirement: Proxy configuration is passed to python-telegram-bot
+
+The Telegram channel SHALL pass the proxy URL to `python-telegram-bot`'s Application builder.
+
+#### Scenario: Proxy URL passed to Application builder
+- **WHEN** a proxy URL is provided via CLI
+- **THEN** the `Application.builder()` SHALL be called with `.proxy_url(proxy_url)`
+
+### Requirement: Proxy argument is masked from process title
+
+The Telegram channel CLI SHALL mask the `--proxy` argument from the process title if it contains credentials.
+
+#### Scenario: Proxy with credentials masked
+- **WHEN** `--proxy socks5://user:pass@host:port` is provided
+- **THEN** the process title SHALL NOT contain the credentials
+- **AND** the process title SHALL show `--proxy ***`

--- a/openspec/changes/archive/2026-04-29-add-proxy-for-telegram/tasks.md
+++ b/openspec/changes/archive/2026-04-29-add-proxy-for-telegram/tasks.md
@@ -1,0 +1,23 @@
+## 1. Configuration
+
+- [x] 1.1 Add `proxy: str | None = None` field to `TelegramConfig` dataclass in `config.py`
+- [x] 1.2 Update `TelegramConfig` docstring to document the new `proxy` parameter
+
+## 2. CLI
+
+- [x] 2.1 Add `proxy: str | None = None` field to `Telegram` dataclass in `cli.py`
+- [x] 2.2 Update `Telegram` docstring to document the new `--proxy` argument
+- [x] 2.3 Pass `proxy` to `TelegramConfig` constructor
+- [x] 2.4 Update `mask_sensitive_args` call to include `["token", "proxy"]` (proxy may contain credentials)
+
+## 3. Bot Implementation
+
+- [x] 3.1 Modify `TelegramBot.start()` to pass `proxy_url` to `Application.builder()` when proxy is configured
+- [x] 3.2 Add debug logging for proxy configuration
+
+## 4. Testing
+
+- [x] 4.1 Add unit tests for `TelegramConfig` with proxy parameter
+- [x] 4.2 Add unit tests for CLI parsing with and without `--proxy` argument
+- [x] 4.3 Run `ruff check`, `ruff format`, `ty check` to ensure code quality
+- [x] 4.4 Run full test suite to verify no regressions

--- a/openspec/specs/telegram-channel/spec.md
+++ b/openspec/specs/telegram-channel/spec.md
@@ -8,6 +8,10 @@ The Telegram channel SHALL provide a CLI command `psi-channel-telegram` for star
 - **WHEN** `psi-channel-telegram --token <token> --session-socket <path>` is invoked
 - **THEN** the bot SHALL initialize and connect to the session
 
+#### Scenario: CLI starts with token and proxy argument
+- **WHEN** `psi-channel-telegram --token <token> --session-socket <path> --proxy <proxy_url>` is invoked
+- **THEN** the bot SHALL initialize with proxy configuration and connect to the session
+
 #### Scenario: Missing token shows error
 - **WHEN** `psi-channel-telegram` is invoked without `--token`
 - **THEN** the CLI SHALL display an error and exit
@@ -114,7 +118,8 @@ The Telegram channel CLI SHALL use a dataclass with `__call__` method for tyro i
 
 #### Scenario: CLI parameters as dataclass fields
 - **WHEN** the `Telegram` dataclass is defined
-- **THEN** `token` and `session_socket` SHALL be dataclass fields
+- **THEN** `token`, `session_socket`, and `proxy` SHALL be dataclass fields
+- **AND** `proxy` SHALL be optional with default value `None`
 - **AND** tyro SHALL automatically generate CLI arguments from these fields
 
 ### Requirement: Telegram channel integrates with channel subcommands
@@ -135,9 +140,14 @@ The Telegram channel SHALL be available as a subcommand under `psi-agent channel
 
 ### Requirement: CLI masks sensitive token from process title
 
-The Telegram channel CLI SHALL mask the `--token` argument from the process title immediately after parsing.
+The Telegram channel CLI SHALL mask the `--token` and `--proxy` arguments from the process title immediately after parsing.
 
 #### Scenario: Token masked in process title
 - **WHEN** `psi-channel-telegram` is started with `--token 123456:ABC`
 - **THEN** the process title SHALL NOT contain the token value
 - **AND** the process title SHALL show `--token ***`
+
+#### Scenario: Proxy with credentials masked in process title
+- **WHEN** `psi-channel-telegram` is started with `--proxy socks5://user:pass@host:port`
+- **THEN** the process title SHALL NOT contain the proxy credentials
+- **AND** the process title SHALL show `--proxy ***`

--- a/openspec/specs/telegram-proxy/spec.md
+++ b/openspec/specs/telegram-proxy/spec.md
@@ -1,0 +1,50 @@
+## Requirements
+
+### Requirement: Telegram channel supports optional proxy configuration
+
+The Telegram channel SHALL accept an optional `--proxy` argument for routing connections through a proxy server.
+
+#### Scenario: Start without proxy
+- **WHEN** `psi-agent channel telegram --token <token> --session-socket <path>` is invoked without `--proxy`
+- **THEN** the bot SHALL connect directly to Telegram Bot API
+
+#### Scenario: Start with SOCKS5 proxy
+- **WHEN** `psi-agent channel telegram --token <token> --session-socket <path> --proxy socks5://host:port` is invoked
+- **THEN** the bot SHALL route all connections through the SOCKS5 proxy
+
+#### Scenario: Start with HTTP proxy
+- **WHEN** `psi-agent channel telegram --token <token> --session-socket <path> --proxy http://host:port` is invoked
+- **THEN** the bot SHALL route all connections through the HTTP proxy
+
+#### Scenario: Start with HTTPS proxy
+- **WHEN** `psi-agent channel telegram --token <token> --session-socket <path> --proxy https://host:port` is invoked
+- **THEN** the bot SHALL route all connections through the HTTPS proxy
+
+### Requirement: Telegram channel supports proxy with authentication
+
+The Telegram channel SHALL support proxy URLs with embedded credentials.
+
+#### Scenario: SOCKS5 proxy with authentication
+- **WHEN** `--proxy socks5://user:password@host:port` is provided
+- **THEN** the bot SHALL authenticate with the proxy using the provided credentials
+
+#### Scenario: HTTP proxy with authentication
+- **WHEN** `--proxy http://user:password@host:port` is provided
+- **THEN** the bot SHALL authenticate with the proxy using the provided credentials
+
+### Requirement: Proxy configuration is passed to python-telegram-bot
+
+The Telegram channel SHALL pass the proxy URL to `python-telegram-bot`'s Application builder.
+
+#### Scenario: Proxy URL passed to Application builder
+- **WHEN** a proxy URL is provided via CLI
+- **THEN** the `Application.builder()` SHALL be called with `.proxy(proxy_url)`
+
+### Requirement: Proxy argument is masked from process title
+
+The Telegram channel CLI SHALL mask the `--proxy` argument from the process title if it contains credentials.
+
+#### Scenario: Proxy with credentials masked
+- **WHEN** `--proxy socks5://user:pass@host:port` is provided
+- **THEN** the process title SHALL NOT contain the credentials
+- **AND** the process title SHALL show `--proxy ***`

--- a/src/psi_agent/channel/telegram/bot.py
+++ b/src/psi_agent/channel/telegram/bot.py
@@ -68,7 +68,18 @@ class TelegramBot:
 
     async def start(self) -> None:
         """Start the Telegram bot."""
-        self._app = Application.builder().token(self.config.token).build()
+        builder = Application.builder().token(self.config.token)
+
+        # Configure proxy if provided
+        if self.config.proxy:
+            builder = builder.proxy(self.config.proxy)
+            # Log proxy without credentials (show host only)
+            proxy_display = (
+                self.config.proxy.split("@")[-1] if "@" in self.config.proxy else self.config.proxy
+            )
+            logger.debug(f"Using proxy: {proxy_display}")
+
+        self._app = builder.build()
 
         # Add handlers
         self._app.add_handler(CommandHandler("start", self._start_command))

--- a/src/psi_agent/channel/telegram/cli.py
+++ b/src/psi_agent/channel/telegram/cli.py
@@ -15,19 +15,29 @@ from psi_agent.utils.proctitle import mask_sensitive_args
 
 @dataclass
 class Telegram:
-    """Run the Telegram channel for bot conversation."""
+    """Run the Telegram channel for bot conversation.
+
+    Args:
+        token: Telegram bot token.
+        session_socket: Path to the Unix socket for communication with psi-session.
+        proxy: Optional proxy URL for connecting to Telegram API. Supports socks5://,
+            http://, and https:// formats. Defaults to None (direct connection).
+    """
 
     token: str
     session_socket: str
+    proxy: str | None = None
 
     def __call__(self) -> None:
         # Mask sensitive arguments from process title
-        mask_sensitive_args(["token"])
+        mask_sensitive_args(["token", "proxy"])
 
         logger.info("Starting psi-channel-telegram")
         logger.debug(f"Config: session_socket={self.session_socket}")
 
-        config = TelegramConfig(token=self.token, session_socket=self.session_socket)
+        config = TelegramConfig(
+            token=self.token, session_socket=self.session_socket, proxy=self.proxy
+        )
         bot = TelegramBot(config)
 
         asyncio.run(bot.start())

--- a/src/psi_agent/channel/telegram/config.py
+++ b/src/psi_agent/channel/telegram/config.py
@@ -14,10 +14,13 @@ class TelegramConfig:
     Args:
         token: Telegram bot token.
         session_socket: Path to the Unix socket for communication with psi-session.
+        proxy: Optional proxy URL for connecting to Telegram API. Supports socks5://,
+            http://, and https:// formats. Defaults to None (direct connection).
     """
 
     token: str
     session_socket: str
+    proxy: str | None = None
 
     def socket_path(self) -> anyio.Path:
         """Get the socket path as a Path object."""

--- a/tests/channel/telegram/test_cli.py
+++ b/tests/channel/telegram/test_cli.py
@@ -1,0 +1,60 @@
+"""Tests for Telegram CLI."""
+
+from __future__ import annotations
+
+from psi_agent.channel.telegram.cli import Telegram
+
+
+def test_telegram_cli_without_proxy():
+    """Test Telegram CLI without proxy argument."""
+    cli = Telegram(token="test-token", session_socket="/tmp/test.sock")
+
+    assert cli.token == "test-token"
+    assert cli.session_socket == "/tmp/test.sock"
+    assert cli.proxy is None
+
+
+def test_telegram_cli_with_proxy():
+    """Test Telegram CLI with proxy argument."""
+    cli = Telegram(
+        token="test-token",
+        session_socket="/tmp/test.sock",
+        proxy="socks5://localhost:1080",
+    )
+
+    assert cli.token == "test-token"
+    assert cli.session_socket == "/tmp/test.sock"
+    assert cli.proxy == "socks5://localhost:1080"
+
+
+def test_telegram_cli_with_http_proxy():
+    """Test Telegram CLI with HTTP proxy."""
+    cli = Telegram(
+        token="test-token",
+        session_socket="/tmp/test.sock",
+        proxy="http://proxy.example.com:8080",
+    )
+
+    assert cli.proxy == "http://proxy.example.com:8080"
+
+
+def test_telegram_cli_with_https_proxy():
+    """Test Telegram CLI with HTTPS proxy."""
+    cli = Telegram(
+        token="test-token",
+        session_socket="/tmp/test.sock",
+        proxy="https://proxy.example.com:8443",
+    )
+
+    assert cli.proxy == "https://proxy.example.com:8443"
+
+
+def test_telegram_cli_with_proxy_auth():
+    """Test Telegram CLI with proxy containing credentials."""
+    cli = Telegram(
+        token="test-token",
+        session_socket="/tmp/test.sock",
+        proxy="socks5://user:password@proxy.example.com:1080",
+    )
+
+    assert cli.proxy == "socks5://user:password@proxy.example.com:1080"

--- a/tests/channel/telegram/test_config.py
+++ b/tests/channel/telegram/test_config.py
@@ -23,3 +23,43 @@ def test_telegram_config_socket_path():
 
     assert isinstance(result, anyio.Path)
     assert result == anyio.Path("/tmp/test.sock")
+
+
+def test_telegram_config_proxy_default_none():
+    """Test TelegramConfig proxy defaults to None."""
+    config = TelegramConfig(token="test-token", session_socket="/tmp/test.sock")
+
+    assert config.proxy is None
+
+
+def test_telegram_config_with_proxy():
+    """Test TelegramConfig can be created with proxy."""
+    config = TelegramConfig(
+        token="test-token",
+        session_socket="/tmp/test.sock",
+        proxy="socks5://localhost:1080",
+    )
+
+    assert config.proxy == "socks5://localhost:1080"
+
+
+def test_telegram_config_with_http_proxy():
+    """Test TelegramConfig with HTTP proxy."""
+    config = TelegramConfig(
+        token="test-token",
+        session_socket="/tmp/test.sock",
+        proxy="http://proxy.example.com:8080",
+    )
+
+    assert config.proxy == "http://proxy.example.com:8080"
+
+
+def test_telegram_config_with_proxy_auth():
+    """Test TelegramConfig with proxy containing credentials."""
+    config = TelegramConfig(
+        token="test-token",
+        session_socket="/tmp/test.sock",
+        proxy="socks5://user:password@proxy.example.com:1080",
+    )
+
+    assert config.proxy == "socks5://user:password@proxy.example.com:1080"


### PR DESCRIPTION
## Summary

- Add optional `--proxy` CLI argument to `psi-agent channel telegram` for routing connections through SOCKS5, HTTP, or HTTPS proxies
- Enable users in restricted network environments to connect to Telegram Bot API
- Mask proxy credentials from process title for security

## Changes

- Add `proxy` field to `TelegramConfig` and CLI dataclass
- Pass proxy to `python-telegram-bot` Application builder via `.proxy()`
- Update sensitive args masking to include proxy
- Add unit tests for proxy configuration

## Test plan

- [x] Unit tests for `TelegramConfig` with proxy parameter
- [x] Unit tests for CLI parsing with and without `--proxy`
- [x] `ruff check`, `ruff format`, `ty check` all pass
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)