### PR TITLE
Add inline publish job to auto-alpha-tag workflow

### DIFF
--- a/.github/workflows/auto-alpha-tag.yml
+++ b/.github/workflows/auto-alpha-tag.yml
@@ -15,6 +15,9 @@ env:
 jobs:
   auto-tag:
     runs-on: ubuntu-latest
+    outputs:
+      tag-created: ${{ steps.create-tag.outputs.created }}
+      tag-name: ${{ steps.create-tag.outputs.tag-name }}
 
     steps:
       - name: Checkout repository
@@ -26,6 +29,7 @@ jobs:
         run: git fetch --tags origin
 
       - name: Create and push alpha tag
+        id: create-tag
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -89,3 +93,32 @@ jobs:
           git push origin "$NEW_TAG"
 
           echo "::notice::Successfully created and pushed tag: $NEW_TAG"
+          echo "created=true" >> $GITHUB_OUTPUT
+          echo "tag-name=$NEW_TAG" >> $GITHUB_OUTPUT
+
+  publish:
+    runs-on: ubuntu-latest
+    needs: auto-tag
+    if: needs.auto-tag.outputs.tag-created == 'true'
+    environment: pypi
+
+    permissions:
+      id-token: write
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.auto-tag.outputs.tag-name }}
+
+      - name: Setup uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          python-version: "3.14"
+
+      - name: Build
+        run: uv build
+
+      - name: Publish to PyPI
+        run: uv publish

--- a/.github/workflows/auto-alpha-tag.yml
+++ b/.github/workflows/auto-alpha-tag.yml
@@ -16,7 +16,7 @@ jobs:
   auto-tag:
     runs-on: ubuntu-latest
     outputs:
-      tag-created: ${{ steps.create-tag.outputs.created }}
+      tag-created: ${{ steps.create-tag.outputs.tag-created }}
       tag-name: ${{ steps.create-tag.outputs.tag-name }}
 
     steps:
@@ -93,7 +93,7 @@ jobs:
           git push origin "$NEW_TAG"
 
           echo "::notice::Successfully created and pushed tag: $NEW_TAG"
-          echo "created=true" >> $GITHUB_OUTPUT
+          echo "tag-created=true" >> $GITHUB_OUTPUT
           echo "tag-name=$NEW_TAG" >> $GITHUB_OUTPUT
 
   publish:

--- a/openspec/changes/archive/2026-04-29-inline-publish-in-auto-alpha-tag/.openspec.yaml
+++ b/openspec/changes/archive/2026-04-29-inline-publish-in-auto-alpha-tag/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-29

--- a/openspec/changes/archive/2026-04-29-inline-publish-in-auto-alpha-tag/design.md
+++ b/openspec/changes/archive/2026-04-29-inline-publish-in-auto-alpha-tag/design.md
@@ -1,0 +1,47 @@
+## Context
+
+The current CI/CD setup has two workflows:
+1. `ci.yml` - runs on push/PR, includes `check` job and `publish` job (triggered by version tags)
+2. `auto-alpha-tag.yml` - runs daily, creates alpha tags for CI-passed commits
+
+The problem: `auto-alpha-tag.yml` uses `github.token` (GITHUB_TOKEN) to push tags. GitHub's security model prevents `GITHUB_TOKEN` from triggering other workflows, so when a new tag is pushed, `ci.yml`'s `publish` job is never triggered.
+
+Current workaround options considered:
+1. Use a Personal Access Token (PAT) - requires secret management, security risk
+2. Use a GitHub App token - requires app installation, more complex setup
+3. Inline the publish job directly - simple, no additional secrets needed
+
+## Goals / Non-Goals
+
+**Goals:**
+- Enable automatic PyPI publishing for alpha tags created by `auto-alpha-tag.yml`
+- Keep the solution simple without additional secrets or tokens
+- Maintain the existing `publish` job in `ci.yml` for manual releases
+
+**Non-Goals:**
+- Changing the `ci.yml` workflow structure
+- Adding new secrets or tokens
+- Modifying the tag naming convention
+
+## Decisions
+
+**Decision 1: Inline the publish job in auto-alpha-tag.yml**
+
+Rationale: This is the simplest solution that doesn't require additional secrets or complex setup. The `publish` job logic is already well-defined in `ci.yml`, and copying it ensures the same publishing behavior.
+
+Alternatives considered:
+- **PAT-based approach**: Would require storing a long-lived token as a repository secret, increasing security risk
+- **GitHub App**: More complex setup, requires app installation and token generation
+- **Repository dispatch**: Would still need a separate workflow with a trigger mechanism
+
+**Decision 2: Use job output to conditionally run publish**
+
+The `auto-tag` job outputs whether a new tag was created. The `publish` job uses `needs: auto-tag` and checks the output to determine if publishing should proceed.
+
+## Risks / Trade-offs
+
+**Code duplication**: The `publish` job logic exists in both `ci.yml` and `auto-alpha-tag.yml`. If publishing steps change, both files need updates.
+- Mitigation: Keep the job simple and well-documented. The duplication is minimal (4 steps).
+
+**No tag trigger for alpha releases**: Alpha tags won't trigger `ci.yml` at all.
+- This is acceptable because alpha releases are automated daily snapshots, not formal releases.

--- a/openspec/changes/archive/2026-04-29-inline-publish-in-auto-alpha-tag/proposal.md
+++ b/openspec/changes/archive/2026-04-29-inline-publish-in-auto-alpha-tag/proposal.md
@@ -1,0 +1,24 @@
+## Why
+
+The `auto-alpha-tag.yml` workflow creates alpha tags daily for CI-passed commits, but the `publish` job in `ci.yml` is not triggered because GitHub's internal `GITHUB_TOKEN` cannot trigger other workflow runs. This means alpha tags are created but never published to PyPI, breaking the automated release pipeline.
+
+## What Changes
+
+- Copy the `publish` job from `ci.yml` into `auto-alpha-tag.yml` as a new job that runs after `auto-tag` job
+- The new job will run when a new tag is successfully created by the `auto-tag` job
+- Remove the `if: startsWith(github.ref, 'refs/tags/v')` condition since the workflow itself is only triggered by the auto-tag process
+
+## Capabilities
+
+### New Capabilities
+
+- `auto-alpha-publish`: Automated PyPI publishing for alpha tags created by the auto-alpha-tag workflow
+
+### Modified Capabilities
+
+None - this is a new capability, not a modification to existing behavior.
+
+## Impact
+
+- `.github/workflows/auto-alpha-tag.yml` - add `publish` job
+- PyPI package publishing will happen automatically after alpha tag creation

--- a/openspec/changes/archive/2026-04-29-inline-publish-in-auto-alpha-tag/specs/auto-alpha-publish/spec.md
+++ b/openspec/changes/archive/2026-04-29-inline-publish-in-auto-alpha-tag/specs/auto-alpha-publish/spec.md
@@ -1,0 +1,26 @@
+## ADDED Requirements
+
+### Requirement: Alpha tag triggers PyPI publish
+The `auto-alpha-tag.yml` workflow SHALL include a `publish` job that publishes the package to PyPI when a new alpha tag is successfully created.
+
+#### Scenario: New alpha tag triggers publish
+- **WHEN** the `auto-tag` job successfully creates and pushes a new alpha tag
+- **THEN** the `publish` job SHALL run and publish the package to PyPI
+
+#### Scenario: No new tag skips publish
+- **WHEN** the `auto-tag` job does not create a new tag (already exists, no CI runs, etc.)
+- **THEN** the `publish` job SHALL be skipped
+
+### Requirement: Publish job uses trusted publishing
+The `publish` job in `auto-alpha-tag.yml` SHALL use the same trusted publishing mechanism as `ci.yml` (OIDC token with PyPI).
+
+#### Scenario: Trusted publishing configuration
+- **WHEN** the `publish` job runs
+- **THEN** it SHALL use `uv publish` with OIDC authentication via the `pypi` environment
+
+### Requirement: Publish job depends on auto-tag
+The `publish` job SHALL have `needs: [auto-tag]` dependency to ensure it only runs after tag creation.
+
+#### Scenario: Job ordering
+- **WHEN** the workflow runs
+- **THEN** the `publish` job SHALL wait for the `auto-tag` job to complete before starting

--- a/openspec/changes/archive/2026-04-29-inline-publish-in-auto-alpha-tag/tasks.md
+++ b/openspec/changes/archive/2026-04-29-inline-publish-in-auto-alpha-tag/tasks.md
@@ -1,0 +1,12 @@
+## 1. Modify auto-alpha-tag.yml
+
+- [x] 1.1 Add job output from `auto-tag` job to indicate if a new tag was created
+- [x] 1.2 Add `publish` job with `needs: [auto-tag]` dependency
+- [x] 1.3 Configure `publish` job to run only when a new tag was created
+- [x] 1.4 Copy the publish steps from `ci.yml` (checkout, setup uv, build, publish)
+- [x] 1.5 Add `environment: pypi` and `permissions: id-token: write` to `publish` job
+
+## 2. Verification
+
+- [x] 2.1 Verify workflow syntax is valid
+- [x] 2.2 Review the complete workflow to ensure all requirements are met

--- a/openspec/changes/archive/2026-04-29-rename-output-to-tag-created/.openspec.yaml
+++ b/openspec/changes/archive/2026-04-29-rename-output-to-tag-created/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-29

--- a/openspec/changes/archive/2026-04-29-rename-output-to-tag-created/design.md
+++ b/openspec/changes/archive/2026-04-29-rename-output-to-tag-created/design.md
@@ -1,0 +1,26 @@
+## Context
+
+Simple naming consistency fix. The `auto-alpha-tag.yml` workflow has two outputs from the `create-tag` step:
+- `created` - boolean indicating if a tag was created
+- `tag-name` - the name of the created tag
+
+The naming is inconsistent: `tag-name` uses kebab-case prefix while `created` does not.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Rename `created` to `tag-created` for consistent naming with `tag-name`
+
+**Non-Goals:**
+- Any behavior changes
+- Other workflow modifications
+
+## Decisions
+
+**Decision: Use `tag-created` as the new name**
+
+This matches the pattern of `tag-name` and makes the output names self-documenting.
+
+## Risks / Trade-offs
+
+None - this is a simple rename with no functional impact.

--- a/openspec/changes/archive/2026-04-29-rename-output-to-tag-created/proposal.md
+++ b/openspec/changes/archive/2026-04-29-rename-output-to-tag-created/proposal.md
@@ -1,0 +1,22 @@
+## Why
+
+The `auto-alpha-tag.yml` workflow uses inconsistent output naming: `steps.create-tag.outputs.created` for the boolean flag but `steps.create-tag.outputs.tag-name` for the tag name. This inconsistency reduces code readability.
+
+## What Changes
+
+- Rename `created` output to `tag-created` for consistency with `tag-name`
+
+## Capabilities
+
+### New Capabilities
+
+None
+
+### Modified Capabilities
+
+- `auto-alpha-publish`: Output naming convention change (no behavior change)
+
+## Impact
+
+- `.github/workflows/auto-alpha-tag.yml` - rename output from `created` to `tag-created`
+- `openspec/specs/auto-alpha-publish/spec.md` - update to reflect new output name

--- a/openspec/changes/archive/2026-04-29-rename-output-to-tag-created/specs/auto-alpha-publish/spec.md
+++ b/openspec/changes/archive/2026-04-29-rename-output-to-tag-created/specs/auto-alpha-publish/spec.md
@@ -1,4 +1,4 @@
-## Requirements
+## MODIFIED Requirements
 
 ### Requirement: Alpha tag triggers PyPI publish
 The `auto-alpha-tag.yml` workflow SHALL include a `publish` job that publishes the package to PyPI when a new alpha tag is successfully created.
@@ -14,17 +14,3 @@ The `auto-alpha-tag.yml` workflow SHALL include a `publish` job that publishes t
 #### Scenario: Output naming consistency
 - **WHEN** the `create-tag` step sets outputs
 - **THEN** the outputs SHALL use consistent naming: `tag-created` and `tag-name`
-
-### Requirement: Publish job uses trusted publishing
-The `publish` job in `auto-alpha-tag.yml` SHALL use the same trusted publishing mechanism as `ci.yml` (OIDC token with PyPI).
-
-#### Scenario: Trusted publishing configuration
-- **WHEN** the `publish` job runs
-- **THEN** it SHALL use `uv publish` with OIDC authentication via the `pypi` environment
-
-### Requirement: Publish job depends on auto-tag
-The `publish` job SHALL have `needs: [auto-tag]` dependency to ensure it only runs after tag creation.
-
-#### Scenario: Job ordering
-- **WHEN** the workflow runs
-- **THEN** the `publish` job SHALL wait for the `auto-tag` job to complete before starting

--- a/openspec/changes/archive/2026-04-29-rename-output-to-tag-created/tasks.md
+++ b/openspec/changes/archive/2026-04-29-rename-output-to-tag-created/tasks.md
@@ -1,0 +1,9 @@
+## 1. Rename output in workflow
+
+- [x] 1.1 Rename `created` to `tag-created` in the step output (`echo "created=true" >> $GITHUB_OUTPUT`)
+- [x] 1.2 Rename `created` to `tag-created` in the job outputs mapping
+- [x] 1.3 Rename `created` to `tag-created` in the publish job's `if` condition
+
+## 2. Update spec
+
+- [x] 2.1 Update `openspec/specs/auto-alpha-publish/spec.md` to reflect the new output name

--- a/openspec/specs/auto-alpha-publish/spec.md
+++ b/openspec/specs/auto-alpha-publish/spec.md
@@ -1,0 +1,26 @@
+## Requirements
+
+### Requirement: Alpha tag triggers PyPI publish
+The `auto-alpha-tag.yml` workflow SHALL include a `publish` job that publishes the package to PyPI when a new alpha tag is successfully created.
+
+#### Scenario: New alpha tag triggers publish
+- **WHEN** the `auto-tag` job successfully creates and pushes a new alpha tag
+- **THEN** the `publish` job SHALL run and publish the package to PyPI
+
+#### Scenario: No new tag skips publish
+- **WHEN** the `auto-tag` job does not create a new tag (already exists, no CI runs, etc.)
+- **THEN** the `publish` job SHALL be skipped
+
+### Requirement: Publish job uses trusted publishing
+The `publish` job in `auto-alpha-tag.yml` SHALL use the same trusted publishing mechanism as `ci.yml` (OIDC token with PyPI).
+
+#### Scenario: Trusted publishing configuration
+- **WHEN** the `publish` job runs
+- **THEN** it SHALL use `uv publish` with OIDC authentication via the `pypi` environment
+
+### Requirement: Publish job depends on auto-tag
+The `publish` job SHALL have `needs: [auto-tag]` dependency to ensure it only runs after tag creation.
+
+#### Scenario: Job ordering
+- **WHEN** the workflow runs
+- **THEN** the `publish` job SHALL wait for the `auto-tag` job to complete before starting


### PR DESCRIPTION
## Summary
- Add `publish` job to `auto-alpha-tag.yml` that runs after successful tag creation
- Use job outputs (`tag-created`, `tag-name`) to pass information between jobs
- Checkout the specific tag ref for correct version publishing
- Use trusted publishing with `pypi` environment and OIDC permissions

## Why
The `auto-alpha-tag.yml` workflow creates alpha tags daily, but the `publish` job in `ci.yml` is not triggered because GitHub's internal `GITHUB_TOKEN` cannot trigger other workflows. This change inlines the publish job directly to enable automatic PyPI publishing for alpha releases.

## Test plan
- [ ] Verify workflow syntax is valid
- [ ] Wait for next scheduled run or trigger manually to verify publish works

🤖 Generated with [Claude Code](https://claude.com/claude-code)