### PR TITLE
Add Codecov test results integration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,13 +33,19 @@ jobs:
         run: uv run pytest
 
       - name: Test coverage
-        run: uv run pytest --cov-report=xml --cov=src/psi_agent --cov-branch
+        run: uv run pytest --cov-report=xml --cov=src/psi_agent --cov-branch --junitxml=junit.xml -o junit_family=legacy
 
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           slug: psi-agent/psi-agent
+
+      - name: Upload test results to Codecov
+        if: ${{ !cancelled() }}
+        uses: codecov/test-results-action@v1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
 
   publish:
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ ENV/
 .pytest_cache/
 .coverage
 coverage.xml
+junit.xml
 
 # Project
 

--- a/openspec/changes/archive/2026-04-29-add-codecov-test-results/.openspec.yaml
+++ b/openspec/changes/archive/2026-04-29-add-codecov-test-results/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-29

--- a/openspec/changes/archive/2026-04-29-add-codecov-test-results/design.md
+++ b/openspec/changes/archive/2026-04-29-add-codecov-test-results/design.md
@@ -1,0 +1,47 @@
+## Context
+
+当前 CI 已集成 Codecov 覆盖率报告上传。pytest 支持生成 JUnit XML 格式的测试结果报告，Codecov 提供 `test-results-action` 可以解析并展示测试结果。
+
+## Goals / Non-Goals
+
+**Goals:**
+- 在 PR 中显示测试结果状态
+- 上传 JUnit XML 测试报告到 Codecov
+- 支持查看测试失败详情
+
+**Non-Goals:**
+- 不修改测试本身
+- 不配置 Codecov YAML 高级设置
+
+## Decisions
+
+### 1. 使用 JUnit XML 格式
+
+**选择**: `--junitxml=junit.xml -o junit_family=legacy`
+
+**理由**:
+- pytest 原生支持 JUnit XML 格式
+- Codecov test-results-action 完美支持
+- `junit_family=legacy` 确保兼容性
+
+### 2. 使用 codecov/test-results-action@v1
+
+**选择**: 官方 test-results-action
+
+**理由**:
+- 与 codecov/codecov-action 配套
+- 支持自动检测 JUnit XML 格式
+- 使用相同的 `CODECOV_TOKEN`
+
+### 3. 条件执行 `if: ${{ !cancelled() }}`
+
+**选择**: 即使前面步骤失败也上传测试结果
+
+**理由**:
+- 测试失败时更需要查看测试结果
+- `!cancelled()` 确保只有手动取消时才不上传
+
+## Risks / Trade-offs
+
+**风险**: 测试结果文件可能较大
+→ **缓解**: JUnit XML 文件通常较小，且会被 gitignore 忽略

--- a/openspec/changes/archive/2026-04-29-add-codecov-test-results/proposal.md
+++ b/openspec/changes/archive/2026-04-29-add-codecov-test-results/proposal.md
@@ -1,0 +1,24 @@
+## Why
+
+当前 Codecov 已集成覆盖率报告，但缺少测试结果上传功能。上传测试结果可以在 Codecov 中查看测试失败详情、测试趋势历史，并在 PR 中显示测试状态变化。
+
+## What Changes
+
+- 在 pytest 命令中添加 `--junitxml=junit.xml -o junit_family=legacy` 参数生成 JUnit XML 报告
+- 添加 `codecov/test-results-action@v1` 上传测试结果
+- 将 `junit.xml` 添加到 `.gitignore`
+
+## Capabilities
+
+### New Capabilities
+
+- `codecov-test-results`: CI 中上传 JUnit 测试结果到 Codecov，显示测试状态和失败详情
+
+### Modified Capabilities
+
+- `ci-workflow`: 修改 pytest 命令生成 JUnit XML，添加 test-results-action
+
+## Impact
+
+- `.github/workflows/ci.yml` - 添加 test-results-action，修改 pytest 命令
+- `.gitignore` - 添加 `junit.xml`

--- a/openspec/changes/archive/2026-04-29-add-codecov-test-results/specs/ci-workflow/spec.md
+++ b/openspec/changes/archive/2026-04-29-add-codecov-test-results/specs/ci-workflow/spec.md
@@ -1,0 +1,10 @@
+## ADDED Requirements
+
+### Requirement: Test step generates JUnit XML
+
+The CI workflow SHALL run pytest with JUnit XML output.
+
+#### Scenario: JUnit XML generation
+- **WHEN** the test step runs
+- **THEN** pytest executes with `--junitxml=junit.xml -o junit_family=legacy`
+- **AND** junit.xml is generated in the project root

--- a/openspec/changes/archive/2026-04-29-add-codecov-test-results/specs/codecov-test-results/spec.md
+++ b/openspec/changes/archive/2026-04-29-add-codecov-test-results/specs/codecov-test-results/spec.md
@@ -1,0 +1,24 @@
+## ADDED Requirements
+
+### Requirement: Test results upload to Codecov
+
+The CI workflow SHALL upload JUnit XML test results to Codecov after test execution.
+
+#### Scenario: Successful test results upload on PR
+- **WHEN** a pull request is opened or updated
+- **THEN** the CI uploads junit.xml to Codecov
+- **AND** the PR shows test results status
+
+#### Scenario: Test results upload even on test failure
+- **WHEN** tests fail
+- **THEN** junit.xml is still uploaded to Codecov
+- **AND** test failure details are visible in Codecov
+
+### Requirement: JUnit XML report generation
+
+The CI workflow SHALL generate JUnit XML test results report.
+
+#### Scenario: JUnit XML generation
+- **WHEN** pytest runs
+- **THEN** junit.xml file is generated in the project root
+- **AND** the report includes test names, results, and failure details

--- a/openspec/changes/archive/2026-04-29-add-codecov-test-results/tasks.md
+++ b/openspec/changes/archive/2026-04-29-add-codecov-test-results/tasks.md
@@ -1,0 +1,18 @@
+## 1. Modify Test Command
+
+- [x] 1.1 Update pytest command to generate JUnit XML (`--junitxml=junit.xml -o junit_family=legacy`)
+- [x] 1.2 Verify junit.xml is generated correctly
+
+## 2. Add Codecov Test Results Action
+
+- [x] 2.1 Add `codecov/test-results-action@v1` step after test step in ci.yml
+- [x] 2.2 Configure action with `token` and `if: ${{ !cancelled() }}`
+
+## 3. Update .gitignore
+
+- [x] 3.1 Add junit.xml to .gitignore
+
+## 4. Verify Integration
+
+- [ ] 4.1 Push changes and verify CI passes
+- [ ] 4.2 Check PR shows Codecov test results

--- a/openspec/specs/ci-workflow/spec.md
+++ b/openspec/specs/ci-workflow/spec.md
@@ -80,3 +80,12 @@ The CI workflow SHALL run pytest with coverage and generate XML report with bran
 - **THEN** coverage.xml is uploaded to Codecov
 - **AND** upload failure does not fail the CI
 
+### Requirement: Test step generates JUnit XML
+
+The CI workflow SHALL run pytest with JUnit XML output.
+
+#### Scenario: JUnit XML generation
+- **WHEN** the test step runs
+- **THEN** pytest executes with `--junitxml=junit.xml -o junit_family=legacy`
+- **AND** junit.xml is generated in the project root
+

--- a/openspec/specs/codecov-test-results/spec.md
+++ b/openspec/specs/codecov-test-results/spec.md
@@ -1,0 +1,28 @@
+# codecov-test-results Specification
+
+## Purpose
+TBD - created by archiving change add-codecov-test-results. Update Purpose after archive.
+## Requirements
+### Requirement: Test results upload to Codecov
+
+The CI workflow SHALL upload JUnit XML test results to Codecov after test execution.
+
+#### Scenario: Successful test results upload on PR
+- **WHEN** a pull request is opened or updated
+- **THEN** the CI uploads junit.xml to Codecov
+- **AND** the PR shows test results status
+
+#### Scenario: Test results upload even on test failure
+- **WHEN** tests fail
+- **THEN** junit.xml is still uploaded to Codecov
+- **AND** test failure details are visible in Codecov
+
+### Requirement: JUnit XML report generation
+
+The CI workflow SHALL generate JUnit XML test results report.
+
+#### Scenario: JUnit XML generation
+- **WHEN** pytest runs
+- **THEN** junit.xml file is generated in the project root
+- **AND** the report includes test names, results, and failure details
+


### PR DESCRIPTION
## Summary

- Add `--junitxml=junit.xml -o junit_family=legacy` to pytest for JUnit XML output
- Add `codecov/test-results-action@v1` for test results upload to Codecov
- Add `junit.xml` to `.gitignore`

## Test plan

- [ ] Verify CI passes on this PR
- [ ] Check Codecov shows test results

🤖 Generated with [Claude Code](https://claude.com/claude-code)