### PR TITLE
Refine streaming behavior across components

### DIFF
--- a/openspec/changes/archive/2026-04-29-streaming-ipc/.openspec.yaml
+++ b/openspec/changes/archive/2026-04-29-streaming-ipc/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-29

--- a/openspec/changes/archive/2026-04-29-streaming-ipc/design.md
+++ b/openspec/changes/archive/2026-04-29-streaming-ipc/design.md
@@ -1,0 +1,84 @@
+## Context
+
+当前 psi-agent 架构中，三个核心组件通过 HTTP over Unix socket 进行 IPC 通信：
+
+```
+Channel (client) → Session (server) → AI (server) → LLM API
+```
+
+**当前状态**：
+- Channel 默认发送 `stream: false`，等待完整响应
+- Session 在非流式模式下对 AI 也使用非流式请求
+- 代码已支持流式，但未作为默认行为
+
+**约束**：
+- 必须保持 OpenAI chat completion 协议兼容性
+- Tool call 处理需要完整响应后才能继续对话循环
+- 不能引入新依赖
+
+## Goals / Non-Goals
+
+**Goals:**
+- Channel 默认使用流式请求，实时显示 LLM 输出
+- Session 默认对 AI 使用流式请求，即使 Channel 未请求流式
+- 保持 tool call 处理的正确性（需要完整收集流式响应）
+- 提供流式和非流式两种 API，向后兼容
+
+**Non-Goals:**
+- 不修改 AI 组件与上游 LLM API 的通信（已支持流式）
+- 不修改 Telegram channel（单独处理）
+- 不修改 workspace 相关功能
+
+## Decisions
+
+### Decision 1: Channel 默认使用流式请求
+
+**选择**：Channel 客户端新增 `send_message_stream()` 方法，REPL 默认调用此方法。
+
+**理由**：
+- 用户可以实时看到 LLM 输出，改善体验
+- 保持 `send_message()` 方法向后兼容，供非流式场景使用
+
+**替代方案**：
+- 修改 `send_message()` 直接返回流式 — 破坏现有 API
+- 使用回调函数 — 增加复杂度
+
+### Decision 2: Session 默认对 AI 使用流式请求
+
+**选择**：`_run_conversation()` 改为默认使用流式调用 AI，内部收集完整响应。
+
+**理由**：
+- 统一处理路径，减少代码分支
+- 流式响应可以提前检测到错误
+- 为未来支持流式 tool call 做准备
+
+**实现细节**：
+- 流式响应在 Session 内部完整收集
+- Tool call 需要完整响应才能执行
+- 最终响应根据 Channel 请求决定是否流式返回
+
+### Decision 3: 流式响应格式
+
+**选择**：使用 SSE (Server-Sent Events) 格式，与 OpenAI API 一致。
+
+**格式**：
+```
+data: {"choices":[{"delta":{"content":"Hello"},"finish_reason":null}]}
+
+data: {"choices":[{"delta":{},"finish_reason":"stop"}]}
+
+data: [DONE]
+```
+
+**理由**：
+- 与 OpenAI API 完全兼容
+- 现有代码已支持此格式
+- aiohttp 原生支持 SSE
+
+## Risks / Trade-offs
+
+**[Risk] Tool call 处理延迟** → 流式响应需要完整收集后才能处理 tool call，但这是必要开销，不影响最终结果正确性。
+
+**[Risk] 错误处理复杂度** → 流式传输中发生错误时，需要通过 SSE 发送错误事件。保持现有错误处理逻辑，在流式开始前检测大部分错误。
+
+**[Risk] 向后兼容性** → 保留非流式 API，Channel 可选择使用哪种模式。

--- a/openspec/changes/archive/2026-04-29-streaming-ipc/proposal.md
+++ b/openspec/changes/archive/2026-04-29-streaming-ipc/proposal.md
@@ -1,0 +1,32 @@
+## Why
+
+当前 psi-agent 的组件间通信（Channel → Session → AI）在默认情况下使用非流式 HTTP 请求，导致用户需要等待完整响应生成后才能看到输出。将所有通信改为流式（SSE）可以显著改善用户体验，实现实时响应输出，让用户能够即时看到 LLM 的生成过程。
+
+## What Changes
+
+- **Channel → Session**：默认启用流式请求（`stream: true`），支持实时接收 SSE 响应
+- **Session → AI**：默认使用流式请求调用 AI 组件，即使 Channel 未请求流式
+- **Session 内部处理**：流式响应在 tool call 时需要完整收集后继续对话循环
+- **BREAKING**：Channel 客户端 API 需要支持流式响应处理（`send_message_stream` 方法）
+
+## Capabilities
+
+### New Capabilities
+
+- `streaming-ipc`: 组件间流式通信能力，定义 Channel、Session、AI 三者之间的流式交互协议
+
+### Modified Capabilities
+
+- `session-core`: 修改默认通信模式为流式，更新 streaming 响应处理逻辑
+- `repl-channel`: 添加流式响应处理，实时显示 LLM 输出
+- `psi-ai-openai-completions`: 确保流式请求作为默认模式
+
+## Impact
+
+- **Affected Code**:
+  - `src/psi_agent/channel/repl/client.py` — 添加流式请求支持
+  - `src/psi_agent/channel/repl/repl.py` — 实时显示流式输出
+  - `src/psi_agent/session/runner.py` — 默认使用流式调用 AI
+  - `src/psi_agent/session/server.py` — 流式响应处理优化
+- **API Changes**: Channel 客户端新增 `send_message_stream()` 方法
+- **Dependencies**: 无新依赖，使用现有 aiohttp SSE 支持

--- a/openspec/changes/archive/2026-04-29-streaming-ipc/specs/psi-ai-openai-completions/spec.md
+++ b/openspec/changes/archive/2026-04-29-streaming-ipc/specs/psi-ai-openai-completions/spec.md
@@ -1,0 +1,29 @@
+## ADDED Requirements
+
+### Requirement: AI component supports streaming by default
+
+The psi-ai-openai-completions component SHALL support streaming requests as the primary mode.
+
+#### Scenario: Streaming request handling
+- **WHEN** session sends request with `stream: true`
+- **THEN** server SHALL forward streaming response from upstream API
+- **AND** yield SSE chunks as they arrive
+
+#### Scenario: Non-streaming request handling
+- **WHEN** session sends request with `stream: false`
+- **THEN** server SHALL wait for complete response from upstream API
+- **AND** return single JSON response
+
+### Requirement: Streaming error handling
+
+The AI component SHALL properly handle errors during streaming.
+
+#### Scenario: Streaming error event
+- **WHEN** error occurs during streaming
+- **THEN** server SHALL send SSE error event
+- **AND** log the error details
+
+#### Scenario: Connection error before streaming
+- **WHEN** connection to upstream API fails
+- **THEN** server SHALL return error response before starting stream
+- **AND** NOT start SSE stream

--- a/openspec/changes/archive/2026-04-29-streaming-ipc/specs/repl-channel/spec.md
+++ b/openspec/changes/archive/2026-04-29-streaming-ipc/specs/repl-channel/spec.md
@@ -1,0 +1,47 @@
+## MODIFIED Requirements
+
+### Requirement: REPL sends messages to session
+
+The REPL SHALL send user messages to psi-session via Unix socket using HTTP POST.
+
+#### Scenario: Send message to session
+- **WHEN** user enters a non-empty message
+- **THEN** REPL SHALL send POST request to session with message in request body
+
+#### Scenario: Receive response from session
+- **WHEN** session returns a response
+- **THEN** REPL SHALL display the response content to stdout
+
+#### Scenario: Streaming response display
+- **WHEN** session returns streaming (SSE) response
+- **THEN** REPL SHALL display content chunks in real-time as they arrive
+
+## ADDED Requirements
+
+### Requirement: REPL uses streaming by default
+
+The REPL SHALL use streaming requests by default for better user experience.
+
+#### Scenario: Default streaming request
+- **WHEN** user enters a message
+- **THEN** REPL SHALL send request with `stream: true`
+- **AND** display response chunks in real-time
+
+#### Scenario: Real-time output display
+- **WHEN** streaming response arrives
+- **THEN** REPL SHALL print each content chunk immediately
+- **AND** NOT wait for complete response
+
+### Requirement: REPL client provides streaming API
+
+The REPL client SHALL provide both streaming and non-streaming methods.
+
+#### Scenario: Streaming method
+- **WHEN** calling `send_message_stream()` with a callback
+- **THEN** client SHALL invoke callback for each received chunk
+- **AND** return when stream completes
+
+#### Scenario: Non-streaming method
+- **WHEN** calling `send_message()`
+- **THEN** client SHALL wait for complete response
+- **AND** return full response string

--- a/openspec/changes/archive/2026-04-29-streaming-ipc/specs/session-core/spec.md
+++ b/openspec/changes/archive/2026-04-29-streaming-ipc/specs/session-core/spec.md
@@ -1,0 +1,33 @@
+## MODIFIED Requirements
+
+### Requirement: Session handles streaming responses
+
+The session SHALL support streaming (SSE) responses from psi-ai-* and forward them to channel in OpenAI format.
+
+#### Scenario: Streaming response forwarded to channel
+- **WHEN** psi-ai returns streaming response
+- **THEN** session forwards SSE chunks to channel in OpenAI format
+
+#### Scenario: Session uses streaming by default for AI calls
+- **WHEN** session calls AI component for inference
+- **THEN** session SHALL send `stream: true` request
+- **AND** internally collect complete response for tool call handling
+
+#### Scenario: Tool calls require complete response
+- **WHEN** streaming response contains tool_calls
+- **THEN** session SHALL collect all streaming chunks completely
+- **AND** reconstruct tool_calls before executing tools
+
+## ADDED Requirements
+
+### Requirement: Session provides streaming control
+
+The session SHALL support both streaming and non-streaming response modes based on channel request.
+
+#### Scenario: Channel requests streaming
+- **WHEN** channel sends request with `stream: true`
+- **THEN** session SHALL forward streaming response directly to channel
+
+#### Scenario: Channel requests non-streaming
+- **WHEN** channel sends request with `stream: false`
+- **THEN** session SHALL collect complete response and return as single JSON

--- a/openspec/changes/archive/2026-04-29-streaming-ipc/specs/streaming-ipc/spec.md
+++ b/openspec/changes/archive/2026-04-29-streaming-ipc/specs/streaming-ipc/spec.md
@@ -1,0 +1,70 @@
+## Purpose
+
+定义 psi-agent 组件间（Channel、Session、AI）的流式通信协议，确保实时响应输出和正确的 tool call 处理。
+
+## ADDED Requirements
+
+### Requirement: Channel 默认使用流式请求
+
+Channel 组件 SHALL 默认使用流式（SSE）请求与 Session 通信，实现实时响应输出。
+
+#### Scenario: REPL 发送流式请求
+- **WHEN** 用户在 REPL 中输入消息
+- **THEN** REPL SHALL 发送 `stream: true` 的请求给 Session
+- **AND** 实时显示接收到的 SSE 内容块
+
+#### Scenario: 流式响应实时显示
+- **WHEN** Session 返回流式响应
+- **THEN** Channel SHALL 逐块解析并显示内容
+- **AND** 在收到 `[DONE]` 标记后结束显示
+
+### Requirement: Channel 提供非流式 API 向后兼容
+
+Channel 客户端 SHALL 保留非流式请求方法，供需要完整响应的场景使用。
+
+#### Scenario: 使用非流式 API
+- **WHEN** 调用 `send_message()` 方法
+- **THEN** Channel SHALL 发送 `stream: false` 请求
+- **AND** 等待完整响应后返回
+
+### Requirement: Session 默认对 AI 使用流式请求
+
+Session 组件 SHALL 默认使用流式请求调用 AI 组件，无论 Channel 是否请求流式。
+
+#### Scenario: Session 流式调用 AI
+- **WHEN** Session 需要调用 AI 进行推理
+- **THEN** Session SHALL 发送 `stream: true` 请求给 AI 组件
+- **AND** 内部收集完整响应用于后续处理
+
+#### Scenario: Tool call 需要完整响应
+- **WHEN** AI 返回包含 tool_calls 的流式响应
+- **THEN** Session SHALL 完整收集所有流式块
+- **AND** 重构 tool_calls 后执行工具
+
+### Requirement: Session 流式响应转发
+
+Session SHALL 根据 Channel 请求决定是否流式返回响应。
+
+#### Scenario: Channel 请求流式响应
+- **WHEN** Channel 发送 `stream: true` 请求
+- **THEN** Session SHALL 直接转发 AI 的流式响应给 Channel
+- **AND** 隐藏 tool_calls 和 thinking 内容
+
+#### Scenario: Channel 请求非流式响应
+- **WHEN** Channel 发送 `stream: false` 请求
+- **THEN** Session SHALL 收集完整响应后返回
+- **AND** 返回过滤后的 OpenAI 格式响应
+
+### Requirement: 流式错误处理
+
+所有组件 SHALL 正确处理流式传输中的错误。
+
+#### Scenario: 流式传输中发生错误
+- **WHEN** 流式传输过程中发生错误
+- **THEN** 组件 SHALL 通过 SSE 错误事件通知下游
+- **AND** 记录错误日志
+
+#### Scenario: 连接中断
+- **WHEN** 流式连接中断
+- **THEN** 接收方 SHALL 检测到连接关闭
+- **AND** 记录警告日志

--- a/openspec/changes/archive/2026-04-29-streaming-ipc/tasks.md
+++ b/openspec/changes/archive/2026-04-29-streaming-ipc/tasks.md
@@ -1,0 +1,40 @@
+## 1. Channel Client Streaming Support
+
+- [x] 1.1 Add `send_message_stream()` method to `ReplClient` class in `src/psi_agent/channel/repl/client.py`
+- [x] 1.2 Implement SSE parsing logic for streaming responses
+- [x] 1.3 Add callback parameter for real-time chunk processing
+- [x] 1.4 Update existing `send_message()` to keep non-streaming behavior
+
+## 2. REPL Real-time Display
+
+- [x] 2.1 Update `repl.py` to use `send_message_stream()` by default
+- [x] 2.2 Implement real-time output display for streaming chunks
+- [x] 2.3 Handle `[DONE]` marker to finalize display
+- [x] 2.4 Add option to switch between streaming/non-streaming mode
+
+## 3. Session Default Streaming
+
+- [x] 3.1 Modify `_run_conversation()` in `runner.py` to use streaming by default
+- [x] 3.2 Implement internal collection of streaming chunks for tool call handling
+- [x] 3.3 Ensure tool call reconstruction works with collected streaming data
+- [x] 3.4 Update `_run_streaming_conversation()` to handle both modes cleanly
+
+## 4. Session Response Forwarding
+
+- [x] 4.1 Update `_handle_chat_completions()` in `server.py` to default `stream: true`
+- [x] 4.2 Ensure streaming response forwarding hides tool_calls properly
+- [x] 4.3 Verify non-streaming mode still works when explicitly requested
+
+## 5. Testing
+
+- [x] 5.1 Add unit tests for `ReplClient.send_message_stream()`
+- [x] 5.2 Add unit tests for streaming chunk parsing
+- [x] 5.3 Add integration tests for Channel → Session → AI streaming flow
+- [x] 5.4 Add tests for tool call handling with streaming responses
+- [x] 5.5 Run full test suite to verify no regressions
+
+## 6. Documentation and Quality
+
+- [x] 6.1 Update CLAUDE.md if needed for new streaming behavior
+- [x] 6.2 Run `ruff check` and `ruff format` on all modified files
+- [x] 6.3 Run `ty check` for type safety verification

--- a/openspec/changes/archive/2026-04-30-improve-streaming-test-coverage/.openspec.yaml
+++ b/openspec/changes/archive/2026-04-30-improve-streaming-test-coverage/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-30

--- a/openspec/changes/archive/2026-04-30-improve-streaming-test-coverage/design.md
+++ b/openspec/changes/archive/2026-04-30-improve-streaming-test-coverage/design.md
@@ -1,0 +1,40 @@
+## Context
+
+The streaming behavior changes introduced new code paths that lack sufficient test coverage. Additionally, manual review is needed to ensure CLAUDE.md compliance for patterns not caught by automated tools.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Achieve >90% patch coverage for modified files
+- Ensure all code follows CLAUDE.md conventions
+- Document any patterns that need manual enforcement
+
+**Non-Goals:**
+- Refactoring existing working code
+- Adding new features
+- Changing existing behavior
+
+## Decisions
+
+### Test Coverage Strategy
+
+Focus on testing the uncovered code paths:
+- `runner.py`: Streaming with tool calls, error handling, thinking block generation
+- `client.py`: Streaming callback handling, error cases
+- `repl.py`: Non-streaming mode, edge cases
+- `cli.py`: Non-streaming mode paths
+
+### CLAUDE.md Compliance Review
+
+Review each modified file for:
+1. Async interface compliance (all async functions, anyio for IO)
+2. Type annotations (all functions must have them)
+3. Docstring format (Google style)
+4. Import order (stdlib, third-party, local)
+5. Error handling (try-except with loguru)
+6. Logging granularity (DEBUG for I/O, INFO for lifecycle)
+
+## Risks / Trade-offs
+
+- **Risk**: Tests may be brittle if they mock too much internal detail
+  - **Mitigation**: Focus on behavior testing, not implementation details

--- a/openspec/changes/archive/2026-04-30-improve-streaming-test-coverage/proposal.md
+++ b/openspec/changes/archive/2026-04-30-improve-streaming-test-coverage/proposal.md
@@ -1,0 +1,27 @@
+## Why
+
+The recent streaming behavior changes have insufficient test coverage (70.06% patch coverage with 44 lines missing). Additionally, a manual code review is needed to ensure all changes comply with CLAUDE.md coding standards that are not enforced by ruff or ty.
+
+## What Changes
+
+- Add missing test coverage for streaming-related code paths
+- Review all modified files for CLAUDE.md compliance
+- Fix any non-compliant code patterns
+
+## Capabilities
+
+### New Capabilities
+
+None - this is a quality improvement change.
+
+### Modified Capabilities
+
+None - no spec-level behavior changes, only test coverage and code quality improvements.
+
+## Impact
+
+- `src/psi_agent/session/runner.py` - 23 missing lines, 2 partials
+- `src/psi_agent/channel/repl/client.py` - 8 missing lines, 2 partials
+- `src/psi_agent/channel/repl/repl.py` - 4 missing lines, 1 partial
+- `src/psi_agent/channel/cli/cli.py` - 2 missing lines
+- `src/psi_agent/channel/repl/cli.py` - 2 missing lines

--- a/openspec/changes/archive/2026-04-30-improve-streaming-test-coverage/tasks.md
+++ b/openspec/changes/archive/2026-04-30-improve-streaming-test-coverage/tasks.md
@@ -1,0 +1,24 @@
+## 1. CLAUDE.md Compliance Review
+
+- [x] 1.1 Review `src/psi_agent/session/runner.py` for CLAUDE.md compliance
+- [x] 1.2 Review `src/psi_agent/session/server.py` for CLAUDE.md compliance
+- [x] 1.3 Review `src/psi_agent/channel/repl/repl.py` for CLAUDE.md compliance
+- [x] 1.4 Review `src/psi_agent/channel/repl/client.py` for CLAUDE.md compliance
+- [x] 1.5 Review `src/psi_agent/channel/repl/config.py` for CLAUDE.md compliance
+- [x] 1.6 Review `src/psi_agent/channel/repl/cli.py` for CLAUDE.md compliance
+- [x] 1.7 Review `src/psi_agent/channel/cli/cli.py` for CLAUDE.md compliance
+
+## 2. Test Coverage Improvements
+
+- [x] 2.1 Add tests for `runner.py` uncovered lines (streaming with tool calls, error handling)
+- [x] 2.2 Add tests for `client.py` uncovered lines (streaming callback, error cases)
+- [x] 2.3 Add tests for `repl.py` uncovered lines (non-streaming mode)
+- [x] 2.4 Add tests for `cli.py` uncovered lines (non-streaming mode)
+- [x] 2.5 Add tests for `repl/cli.py` uncovered lines
+
+## 3. Quality Checks
+
+- [x] 3.1 Run full test suite to verify all tests pass
+- [x] 3.2 Verify patch coverage is >90%
+- [x] 3.3 Run `ruff check` and `ruff format`
+- [x] 3.4 Run `ty check`

--- a/openspec/changes/archive/2026-04-30-refine-streaming-behavior/.openspec.yaml
+++ b/openspec/changes/archive/2026-04-30-refine-streaming-behavior/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-30

--- a/openspec/changes/archive/2026-04-30-refine-streaming-behavior/design.md
+++ b/openspec/changes/archive/2026-04-30-refine-streaming-behavior/design.md
@@ -1,0 +1,88 @@
+## Context
+
+当前 psi-agent 的流式通信已基本实现，但需要细化：
+
+**当前状态**：
+- AI 组件根据请求决定流式/非流式
+- Session 内部默认流式调用 AI，但不返回 thinking/tool call 过程
+- REPL 支持 `/quit` 和 `/stream` 命令
+- CLI 默认非流式
+
+**约束**：
+- 保持 OpenAI chat completion 协议兼容性
+- Thinking 和 tool call 输出需要特定格式，便于 Channel 解析和显示
+- Telegram channel 暂不更新
+
+## Goals / Non-Goals
+
+**Goals:**
+- Session 将 thinking 和 tool call 过程以特定格式返回给 Channel
+- REPL 简化为纯消息转发，通过命令行参数控制流式
+- CLI 默认流式，可通过参数切换
+- 定义 thinking 输出格式约定
+
+**Non-Goals:**
+- 不修改 Telegram channel
+- 不修改 AI 组件（已满足需求）
+- 不修改底层通信协议
+
+## Decisions
+
+### Decision 1: Thinking 输出格式
+
+**选择**：使用特殊标记包裹 thinking 和 tool call 内容。
+
+**格式约定**：
+```
+<thinking>
+[思考内容或 tool call 信息]
+</thinking>
+```
+
+**理由**：
+- 与 XML 类似，易于解析
+- 不干扰正常内容显示
+- Channel 可以选择显示或隐藏
+
+**Tool call 格式**：
+```
+<thinking>
+[Tool: tool_name]
+Arguments: {"arg1": "value1"}
+Result: [工具执行结果]
+</thinking>
+```
+
+### Decision 2: Session 返回 thinking 的时机
+
+**选择**：在流式模式下，thinking/tool call 内容作为独立的 SSE 事件发送。
+
+**实现**：
+- 每个 tool call 执行完成后，立即发送 thinking 块
+- 最终 AI 响应正常流式返回
+- 非流式模式下，thinking 内容放在响应的特定字段或前缀
+
+### Decision 3: REPL 命令行参数
+
+**选择**：添加 `--no-stream` 参数，默认流式。
+
+**理由**：
+- 符合"默认最佳体验"原则
+- 用户通过 Ctrl+D/Ctrl+C 退出更自然
+- 简化代码，移除命令解析逻辑
+
+### Decision 4: CLI channel 默认流式
+
+**选择**：CLI 默认 `stream: true`，添加 `--no-stream` 切换非流式。
+
+**理由**：
+- 与 REPL 行为一致
+- 流式提供更好的用户体验
+
+## Risks / Trade-offs
+
+**[Risk] Thinking 内容过长** → Channel 可以选择折叠或隐藏 thinking 内容。
+
+**[Risk] 格式解析复杂度** → 使用简单的 XML-like 标记，降低解析复杂度。
+
+**[Risk] Breaking change for REPL** → 用户需要适应新的退出方式（Ctrl+D/Ctrl+C）。

--- a/openspec/changes/archive/2026-04-30-refine-streaming-behavior/proposal.md
+++ b/openspec/changes/archive/2026-04-30-refine-streaming-behavior/proposal.md
@@ -1,0 +1,40 @@
+## Why
+
+当前流式实现需要进一步细化：1) Session 应将 thinking 和 tool call 过程以特定格式返回给 Channel，让用户看到完整的推理过程；2) REPL 应简化为纯消息转发，不支持任何命令；3) CLI channel 需要默认流式。
+
+## What Changes
+
+- **AI 组件**：保持现状，根据请求的 `stream` 参数决定流式或非流式访问上游 API
+- **Session**：
+  - 无论 Channel 是否请求流式，都流式调用 AI
+  - 将 thinking 和 tool call 过程以特定格式拼接到响应中返回给 Channel
+  - 支持流式和非流式两种模式返回给 Channel
+- **REPL channel**：
+  - **BREAKING** 移除 `/quit` 和 `/stream` 命令，简化为纯消息转发
+  - 默认流式，通过命令行参数 `--no-stream` 切换非流式
+  - Ctrl+D/Ctrl+C 退出
+- **CLI channel**：默认流式，通过 `--no-stream` 参数切换非流式
+- **Telegram channel**：暂不更新
+
+## Capabilities
+
+### New Capabilities
+
+- `thinking-output-format`: 定义 thinking 和 tool call 的输出格式约定
+
+### Modified Capabilities
+
+- `streaming-ipc`: 更新 Session 行为，增加 thinking/tool call 输出
+- `repl-channel`: 简化为纯消息转发，移除命令支持
+- `session-core`: Session 默认流式调用 AI，返回 thinking 过程
+
+## Impact
+
+- **Affected Code**:
+  - `src/psi_agent/session/runner.py` — 添加 thinking/tool call 格式化输出
+  - `src/psi_agent/session/server.py` — 流式返回 thinking 过程
+  - `src/psi_agent/channel/repl/repl.py` — 移除命令支持，添加命令行参数
+  - `src/psi_agent/channel/repl/cli.py` — 添加 `--stream`/`--no-stream` 参数
+  - `src/psi_agent/channel/cli/cli.py` — 默认流式，添加切换参数
+- **API Changes**: REPL CLI 参数变化
+- **Breaking Changes**: REPL 不再支持 `/quit` 和 `/stream` 命令

--- a/openspec/changes/archive/2026-04-30-refine-streaming-behavior/specs/repl-channel/spec.md
+++ b/openspec/changes/archive/2026-04-30-refine-streaming-behavior/specs/repl-channel/spec.md
@@ -1,0 +1,72 @@
+## MODIFIED Requirements
+
+### Requirement: REPL uses streaming by default
+
+The REPL SHALL use streaming requests by default for better user experience.
+
+#### Scenario: Default streaming request
+- **WHEN** user enters a message
+- **THEN** REPL SHALL send request with `stream: true`
+- **AND** display response chunks in real-time
+
+#### Scenario: Non-streaming via CLI flag
+- **WHEN** REPL is started with `--no-stream` flag
+- **THEN** REPL SHALL use non-streaming mode
+- **AND** wait for complete response before displaying
+
+### Requirement: REPL client provides streaming API
+
+The REPL client SHALL provide both streaming and non-streaming methods.
+
+#### Scenario: Streaming method
+- **WHEN** calling `send_message_stream()` with a callback
+- **THEN** client SHALL invoke callback for each received chunk
+- **AND** return when stream completes
+
+#### Scenario: Non-streaming method
+- **WHEN** calling `send_message()`
+- **THEN** client SHALL wait for complete response
+- **AND** return full response string
+
+## REMOVED Requirements
+
+### Requirement: REPL provides graceful exit
+
+**Reason**: REPL 简化为纯消息转发，不再支持命令。
+
+**Migration**: 用户使用 Ctrl+D (EOF) 或 Ctrl+C 退出 REPL。
+
+### Requirement: REPL sends messages to session
+
+The REPL SHALL send user messages to psi-session via Unix socket using HTTP POST.
+
+#### Scenario: Send message to session
+- **WHEN** user enters a non-empty message
+- **THEN** REPL SHALL send POST request to session with message in request body
+
+#### Scenario: Receive response from session
+- **WHEN** session returns a response
+- **THEN** REPL SHALL display the response content to stdout
+
+#### Scenario: Streaming response display
+- **WHEN** session returns streaming (SSE) response
+- **THEN** REPL SHALL display content chunks in real-time as they arrive
+
+## ADDED Requirements
+
+### Requirement: REPL is pure message forwarder
+
+The REPL SHALL act as a pure message forwarder without command support.
+
+#### Scenario: No command parsing
+- **WHEN** user enters text starting with `/`
+- **THEN** REPL SHALL treat it as normal message
+- **AND** forward it to session without interpretation
+
+#### Scenario: Exit via EOF
+- **WHEN** user presses Ctrl+D
+- **THEN** REPL SHALL exit cleanly
+
+#### Scenario: Exit via interrupt
+- **WHEN** user presses Ctrl+C
+- **THEN** REPL SHALL exit cleanly

--- a/openspec/changes/archive/2026-04-30-refine-streaming-behavior/specs/session-core/spec.md
+++ b/openspec/changes/archive/2026-04-30-refine-streaming-behavior/specs/session-core/spec.md
@@ -1,0 +1,38 @@
+## MODIFIED Requirements
+
+### Requirement: Session handles streaming responses
+
+The session SHALL support streaming (SSE) responses from psi-ai-* and forward them to channel in OpenAI format, including thinking content.
+
+#### Scenario: Streaming response forwarded to channel
+- **WHEN** psi-ai returns streaming response
+- **THEN** session forwards SSE chunks to channel in OpenAI format
+
+#### Scenario: Session uses streaming by default for AI calls
+- **WHEN** session calls AI component for inference
+- **THEN** session SHALL send `stream: true` request
+- **AND** internally collect complete response for tool call handling
+
+#### Scenario: Tool calls require complete response
+- **WHEN** streaming response contains tool_calls
+- **THEN** session SHALL collect all streaming chunks completely
+- **AND** reconstruct tool_calls before executing tools
+
+#### Scenario: Thinking content included in response
+- **WHEN** session executes tool calls
+- **THEN** session SHALL output thinking blocks with tool call information
+- **AND** include tool name, arguments, and result
+
+### Requirement: Session provides streaming control
+
+The session SHALL support both streaming and non-streaming response modes based on channel request.
+
+#### Scenario: Channel requests streaming
+- **WHEN** channel sends request with `stream: true`
+- **THEN** session SHALL forward streaming response directly to channel
+- **AND** include thinking blocks as they are generated
+
+#### Scenario: Channel requests non-streaming
+- **WHEN** channel sends request with `stream: false`
+- **THEN** session SHALL collect complete response and return as single JSON
+- **AND** prepend thinking content to the message

--- a/openspec/changes/archive/2026-04-30-refine-streaming-behavior/specs/streaming-ipc/spec.md
+++ b/openspec/changes/archive/2026-04-30-refine-streaming-behavior/specs/streaming-ipc/spec.md
@@ -1,0 +1,31 @@
+## MODIFIED Requirements
+
+### Requirement: Session 默认对 AI 使用流式请求
+
+Session 组件 SHALL 默认使用流式请求调用 AI 组件，无论 Channel 是否请求流式。
+
+#### Scenario: Session 流式调用 AI
+- **WHEN** Session 需要调用 AI 进行推理
+- **THEN** Session SHALL 发送 `stream: true` 请求给 AI 组件
+- **AND** 内部收集完整响应用于后续处理
+
+#### Scenario: Tool call 需要完整响应
+- **WHEN** AI 返回包含 tool_calls 的流式响应
+- **THEN** Session SHALL 完整收集所有流式块
+- **AND** 重构 tool_calls 后执行工具
+
+### Requirement: Session 流式响应转发
+
+Session SHALL 根据 Channel 请求决定是否流式返回响应，并包含 thinking 过程。
+
+#### Scenario: Channel 请求流式响应
+- **WHEN** Channel 发送 `stream: true` 请求
+- **THEN** Session SHALL 流式转发 AI 响应给 Channel
+- **AND** 在 tool call 执行后立即发送 thinking 块
+- **AND** 隐藏 tool_calls 原始数据
+
+#### Scenario: Channel 请求非流式响应
+- **WHEN** Channel 发送 `stream: false` 请求
+- **THEN** Session SHALL 收集完整响应后返回
+- **AND** thinking 内容作为消息前缀返回
+- **AND** 返回过滤后的 OpenAI 格式响应

--- a/openspec/changes/archive/2026-04-30-refine-streaming-behavior/specs/thinking-output-format/spec.md
+++ b/openspec/changes/archive/2026-04-30-refine-streaming-behavior/specs/thinking-output-format/spec.md
@@ -1,0 +1,53 @@
+## Purpose
+
+定义 Session 返回给 Channel 的 thinking 和 tool call 输出格式，让用户能看到完整的推理过程。
+
+## ADDED Requirements
+
+### Requirement: Thinking 输出使用 XML-like 标记
+
+Session SHALL 使用 `<thinking>` 标签包裹 thinking 和 tool call 内容。
+
+#### Scenario: Thinking 内容格式
+- **WHEN** Session 需要返回 thinking 内容
+- **THEN** 内容 SHALL 被包裹在 `<thinking>` 和 `</thinking>` 标签之间
+- **AND** Channel 可以解析并选择显示或隐藏
+
+#### Scenario: Thinking 标签解析
+- **WHEN** Channel 收到包含 `<thinking>` 标签的内容
+- **THEN** Channel SHALL 能够正确解析标签内容
+- **AND** 标签外的内容正常显示
+
+### Requirement: Tool call 输出格式
+
+Session SHALL 以特定格式输出 tool call 信息。
+
+#### Scenario: Tool call 输出
+- **WHEN** Session 执行 tool call
+- **THEN** 输出格式 SHALL 为：
+```
+<thinking>
+[Tool: tool_name]
+Arguments: {"arg": "value"}
+Result: [执行结果]
+</thinking>
+```
+
+#### Scenario: 多个 tool calls
+- **WHEN** Session 执行多个 tool calls
+- **THEN** 每个 tool call SHALL 输出独立的 thinking 块
+- **AND** 按执行顺序排列
+
+### Requirement: Thinking 内容流式返回
+
+Session SHALL 在流式模式下实时返回 thinking 内容。
+
+#### Scenario: 流式 thinking 返回
+- **WHEN** tool call 执行完成
+- **THEN** Session SHALL 立即发送 thinking 块
+- **AND** 不等待后续 tool calls 或最终响应
+
+#### Scenario: 非流式 thinking 返回
+- **WHEN** Channel 请求非流式响应
+- **THEN** thinking 内容 SHALL 作为消息内容的前缀返回
+- **AND** 最终 AI 响应跟在 thinking 内容之后

--- a/openspec/changes/archive/2026-04-30-refine-streaming-behavior/tasks.md
+++ b/openspec/changes/archive/2026-04-30-refine-streaming-behavior/tasks.md
@@ -1,0 +1,42 @@
+## 1. Thinking Output Format Implementation
+
+- [x] 1.1 Add `format_thinking_block()` function in `runner.py` to format tool call info
+- [x] 1.2 Add `format_tool_call_thinking()` function to format individual tool call output
+- [x] 1.3 Update `_run_conversation()` to output thinking blocks during tool execution
+
+## 2. Session Streaming with Thinking
+
+- [x] 2.1 Update `_run_streaming_conversation()` to send thinking blocks as SSE events
+- [x] 2.2 Modify `_make_streaming_response()` to include thinking content
+- [x] 2.3 Update `_handle_non_streaming()` to prepend thinking content to response
+- [x] 2.4 Ensure thinking blocks are sent immediately after tool execution
+
+## 3. REPL Simplification
+
+- [x] 3.1 Remove `/quit` command handling from `repl.py`
+- [x] 3.2 Remove `/stream` command handling from `repl.py`
+- [x] 3.3 Remove `set_streaming()` method (use CLI flag instead)
+- [x] 3.4 Simplify `run()` to pure message forwarding loop
+- [x] 3.5 Add `--no-stream` CLI flag to `ReplConfig`
+- [x] 3.6 Update CLI entry point to pass streaming flag from config
+
+## 4. CLI Channel Default Streaming
+
+- [x] 4.1 Change default `stream` value to `True` in `cli.py`
+- [x] 4.2 Rename `--stream` flag to `--no-stream` for disabling streaming
+- [x] 4.3 Update CLI help text and documentation
+
+## 5. Testing
+
+- [x] 5.1 Add unit tests for `format_thinking_block()` function
+- [x] 5.2 Add unit tests for `format_tool_call_thinking()` function
+- [x] 5.3 Add tests for thinking content in streaming response
+- [x] 5.4 Add tests for thinking content in non-streaming response
+- [x] 5.5 Update REPL tests to remove command-related tests
+- [x] 5.6 Add tests for REPL CLI flag handling
+- [x] 5.7 Run full test suite to verify no regressions
+
+## 6. Quality Checks
+
+- [x] 6.1 Run `ruff check` and `ruff format` on all modified files
+- [x] 6.2 Run `ty check` for type safety verification

--- a/openspec/specs/psi-ai-openai-completions/spec.md
+++ b/openspec/specs/psi-ai-openai-completions/spec.md
@@ -187,3 +187,31 @@ The `psi_agent.ai.__init__.py` file SHALL import CLI classes in a way that avoid
 #### Scenario: Anthropic messages command works
 - **WHEN** running `psi-agent ai anthropic-messages --help`
 - **THEN** the help text is displayed correctly
+
+### Requirement: AI component supports streaming by default
+
+The psi-ai-openai-completions component SHALL support streaming requests as the primary mode.
+
+#### Scenario: Streaming request handling
+- **WHEN** session sends request with `stream: true`
+- **THEN** server SHALL forward streaming response from upstream API
+- **AND** yield SSE chunks as they arrive
+
+#### Scenario: Non-streaming request handling
+- **WHEN** session sends request with `stream: false`
+- **THEN** server SHALL wait for complete response from upstream API
+- **AND** return single JSON response
+
+### Requirement: Streaming error handling
+
+The AI component SHALL properly handle errors during streaming.
+
+#### Scenario: Streaming error event
+- **WHEN** error occurs during streaming
+- **THEN** server SHALL send SSE error event
+- **AND** log the error details
+
+#### Scenario: Connection error before streaming
+- **WHEN** connection to upstream API fails
+- **THEN** server SHALL return error response before starting stream
+- **AND** NOT start SSE stream

--- a/openspec/specs/repl-channel/spec.md
+++ b/openspec/specs/repl-channel/spec.md
@@ -1,5 +1,49 @@
 ## ADDED Requirements
 
+### Requirement: REPL sends messages to session
+
+The REPL SHALL send user messages to psi-session via Unix socket using HTTP POST.
+
+#### Scenario: Send message to session
+- **WHEN** user enters a non-empty message
+- **THEN** REPL SHALL send POST request to session with message in request body
+
+#### Scenario: Receive response from session
+- **WHEN** session returns a response
+- **THEN** REPL SHALL display the response content to stdout
+
+#### Scenario: Streaming response display
+- **WHEN** session returns streaming (SSE) response
+- **THEN** REPL SHALL display content chunks in real-time as they arrive
+
+### Requirement: REPL uses streaming by default
+
+The REPL SHALL use streaming requests by default for better user experience.
+
+#### Scenario: Default streaming request
+- **WHEN** user enters a message
+- **THEN** REPL SHALL send request with `stream: true`
+- **AND** display response chunks in real-time
+
+#### Scenario: Real-time output display
+- **WHEN** streaming response arrives
+- **THEN** REPL SHALL print each content chunk immediately
+- **AND** NOT wait for complete response
+
+### Requirement: REPL client provides streaming API
+
+The REPL client SHALL provide both streaming and non-streaming methods.
+
+#### Scenario: Streaming method
+- **WHEN** calling `send_message_stream()` with a callback
+- **THEN** client SHALL invoke callback for each received chunk
+- **AND** return when stream completes
+
+#### Scenario: Non-streaming method
+- **WHEN** calling `send_message()`
+- **THEN** client SHALL wait for complete response
+- **AND** return full response string
+
 ### Requirement: REPL reads user input from stdin
 
 The REPL SHALL read user input using `prompt-toolkit`'s async `PromptSession` for enhanced editing capabilities.

--- a/openspec/specs/session-core/spec.md
+++ b/openspec/specs/session-core/spec.md
@@ -36,6 +36,28 @@ The session SHALL support streaming (SSE) responses from psi-ai-* and forward th
 - **WHEN** psi-ai returns streaming response
 - **THEN** session forwards SSE chunks to channel in OpenAI format
 
+#### Scenario: Session uses streaming by default for AI calls
+- **WHEN** session calls AI component for inference
+- **THEN** session SHALL send `stream: true` request
+- **AND** internally collect complete response for tool call handling
+
+#### Scenario: Tool calls require complete response
+- **WHEN** streaming response contains tool_calls
+- **THEN** session SHALL collect all streaming chunks completely
+- **AND** reconstruct tool_calls before executing tools
+
+### Requirement: Session provides streaming control
+
+The session SHALL support both streaming and non-streaming response modes based on channel request.
+
+#### Scenario: Channel requests streaming
+- **WHEN** channel sends request with `stream: true`
+- **THEN** session SHALL forward streaming response directly to channel
+
+#### Scenario: Channel requests non-streaming
+- **WHEN** channel sends request with `stream: false`
+- **THEN** session SHALL collect complete response and return as single JSON
+
 ### Requirement: Session returns OpenAI-format responses to channel
 
 The session SHALL return responses to channel in OpenAI chat completion format, hiding tool calls and thinking content.
@@ -47,12 +69,6 @@ The session SHALL return responses to channel in OpenAI chat completion format, 
 #### Scenario: Error response returned to channel
 - **WHEN** an error occurs during processing
 - **THEN** channel receives OpenAI-format error response
-
-The session SHALL support streaming (SSE) responses from psi-ai-* and forward them to channel.
-
-#### Scenario: Streaming response forwarded to channel
-- **WHEN** psi-ai returns streaming response
-- **THEN** session forwards SSE chunks to channel
 
 ### Requirement: Session calls system prompt builder
 

--- a/openspec/specs/streaming-ipc/spec.md
+++ b/openspec/specs/streaming-ipc/spec.md
@@ -1,0 +1,70 @@
+## Purpose
+
+定义 psi-agent 组件间（Channel、Session、AI）的流式通信协议，确保实时响应输出和正确的 tool call 处理。
+
+## Requirements
+
+### Requirement: Channel 默认使用流式请求
+
+Channel 组件 SHALL 默认使用流式（SSE）请求与 Session 通信，实现实时响应输出。
+
+#### Scenario: REPL 发送流式请求
+- **WHEN** 用户在 REPL 中输入消息
+- **THEN** REPL SHALL 发送 `stream: true` 的请求给 Session
+- **AND** 实时显示接收到的 SSE 内容块
+
+#### Scenario: 流式响应实时显示
+- **WHEN** Session 返回流式响应
+- **THEN** Channel SHALL 逐块解析并显示内容
+- **AND** 在收到 `[DONE]` 标记后结束显示
+
+### Requirement: Channel 提供非流式 API 向后兼容
+
+Channel 客户端 SHALL 保留非流式请求方法，供需要完整响应的场景使用。
+
+#### Scenario: 使用非流式 API
+- **WHEN** 调用 `send_message()` 方法
+- **THEN** Channel SHALL 发送 `stream: false` 请求
+- **AND** 等待完整响应后返回
+
+### Requirement: Session 默认对 AI 使用流式请求
+
+Session 组件 SHALL 默认使用流式请求调用 AI 组件，无论 Channel 是否请求流式。
+
+#### Scenario: Session 流式调用 AI
+- **WHEN** Session 需要调用 AI 进行推理
+- **THEN** Session SHALL 发送 `stream: true` 请求给 AI 组件
+- **AND** 内部收集完整响应用于后续处理
+
+#### Scenario: Tool call 需要完整响应
+- **WHEN** AI 返回包含 tool_calls 的流式响应
+- **THEN** Session SHALL 完整收集所有流式块
+- **AND** 重构 tool_calls 后执行工具
+
+### Requirement: Session 流式响应转发
+
+Session SHALL 根据 Channel 请求决定是否流式返回响应。
+
+#### Scenario: Channel 请求流式响应
+- **WHEN** Channel 发送 `stream: true` 请求
+- **THEN** Session SHALL 直接转发 AI 的流式响应给 Channel
+- **AND** 隐藏 tool_calls 和 thinking 内容
+
+#### Scenario: Channel 请求非流式响应
+- **WHEN** Channel 发送 `stream: false` 请求
+- **THEN** Session SHALL 收集完整响应后返回
+- **AND** 返回过滤后的 OpenAI 格式响应
+
+### Requirement: 流式错误处理
+
+所有组件 SHALL 正确处理流式传输中的错误。
+
+#### Scenario: 流式传输中发生错误
+- **WHEN** 流式传输过程中发生错误
+- **THEN** 组件 SHALL 通过 SSE 错误事件通知下游
+- **AND** 记录错误日志
+
+#### Scenario: 连接中断
+- **WHEN** 流式连接中断
+- **THEN** 接收方 SHALL 检测到连接关闭
+- **AND** 记录警告日志

--- a/src/psi_agent/channel/cli/cli.py
+++ b/src/psi_agent/channel/cli/cli.py
@@ -15,7 +15,7 @@ from loguru import logger
 async def send_message(
     session_socket: str,
     message: str,
-    stream: bool = False,
+    stream: bool = True,
 ) -> str:
     """Send a message to psi-session and return the response.
 
@@ -117,17 +117,18 @@ class Cli:
 
     session_socket: str
     message: str
-    stream: bool = False
+    no_stream: bool = False
+    """Disable streaming mode (default: streaming enabled)."""
 
     def __call__(self) -> None:
         logger.debug(f"Connecting to session socket: {self.session_socket}")
         logger.debug(f"Sending message: {self.message[:50]}...")
 
-        result = asyncio.run(send_message(self.session_socket, self.message, self.stream))
+        result = asyncio.run(send_message(self.session_socket, self.message, not self.no_stream))
 
         # For non-streaming, print the result
         # For streaming, it's already printed
-        if not self.stream:
+        if self.no_stream:
             print(result)
 
         # Exit with appropriate code

--- a/src/psi_agent/channel/repl/cli.py
+++ b/src/psi_agent/channel/repl/cli.py
@@ -17,12 +17,14 @@ class Repl:
     """Run the REPL channel for interactive conversation."""
 
     session_socket: str
+    no_stream: bool = False
+    """Disable streaming mode (default: streaming enabled)."""
 
     def __call__(self) -> None:
         logger.info("Starting psi-channel-repl")
-        logger.debug(f"Config: session_socket={self.session_socket}")
+        logger.debug(f"Config: session_socket={self.session_socket}, stream={not self.no_stream}")
 
-        config = ReplConfig(session_socket=self.session_socket)
+        config = ReplConfig(session_socket=self.session_socket, stream=not self.no_stream)
         repl = ReplRunner(config)
 
         asyncio.run(repl.run())

--- a/src/psi_agent/channel/repl/client.py
+++ b/src/psi_agent/channel/repl/client.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+from collections.abc import Callable
 from typing import Any
 
 import aiohttp
@@ -41,6 +42,78 @@ class ReplClient:
         if self._connector is not None:
             await self._connector.close()
             self._connector = None
+
+    async def send_message_stream(
+        self,
+        message: str,
+        on_chunk: Callable[[str], None] | None = None,
+    ) -> str:
+        """Send a message to psi-session with streaming response.
+
+        Args:
+            message: The user message string to send.
+            on_chunk: Optional callback invoked for each content chunk.
+
+        Returns:
+            The complete assistant's response content.
+
+        Raises:
+            RuntimeError: If client is not initialized.
+            aiohttp.ClientError: If request fails.
+        """
+        if self._session is None:
+            raise RuntimeError("Client not initialized. Use async context manager.")
+
+        url = "http://localhost/v1/chat/completions"
+        headers = {"Content-Type": "application/json"}
+        body = {
+            "messages": [{"role": "user", "content": message}],
+            "stream": True,
+        }
+        logger.debug(f"Request body: {json.dumps(body, ensure_ascii=False, indent=2)}")
+
+        logger.debug("Sending streaming message to session")
+
+        try:
+            async with self._session.post(url, headers=headers, json=body) as response:
+                if response.status != 200:
+                    text = await response.text()
+                    logger.error(f"Session returned status {response.status}: {text}")
+                    return f"Error: Session returned status {response.status}"
+
+                # Parse SSE stream
+                content_chunks = []
+                async for line in response.content:
+                    line_str = line.decode().strip()
+                    if not line_str or line_str == "data: [DONE]":
+                        continue
+                    if line_str.startswith("data: "):
+                        try:
+                            chunk = json.loads(line_str[6:])
+                            choices = chunk.get("choices", [])
+                            if choices:
+                                delta = choices[0].get("delta", {})
+                                content = delta.get("content", "")
+                                if content:
+                                    content_chunks.append(content)
+                                    if on_chunk is not None:
+                                        on_chunk(content)
+                        except json.JSONDecodeError:
+                            pass
+
+                full_content = "".join(content_chunks)
+                logger.debug(f"Received complete streaming response: {full_content[:100]}...")
+                return full_content
+
+        except aiohttp.ClientConnectorError as e:
+            logger.error(f"Failed to connect to session: {e}")
+            return f"Error: Failed to connect to session at {self.config.session_socket}"
+        except aiohttp.ClientError as e:
+            logger.error(f"Request failed: {e}")
+            return f"Error: Request failed - {e}"
+        except TimeoutError:
+            logger.error("Request timeout")
+            return "Error: Request timeout"
 
     async def send_message(self, message: str) -> str:
         """Send a message to psi-session and return the response.
@@ -82,8 +155,8 @@ class ReplClient:
                     logger.warning("Session returned no choices")
                     return "Error: No response from session"
 
-                message = choices[0].get("message", {})
-                content = message.get("content", "")
+                msg = choices[0].get("message", {})
+                content = msg.get("content", "")
                 logger.debug(f"Received response: {content[:100]}...")
                 return content
 

--- a/src/psi_agent/channel/repl/config.py
+++ b/src/psi_agent/channel/repl/config.py
@@ -15,10 +15,12 @@ class ReplConfig:
     Args:
         session_socket: Path to the Unix socket for communication with psi-session.
         history_file: Optional path to the history file. If None, uses default path.
+        stream: Whether to use streaming mode. Default is True.
     """
 
     session_socket: str
     history_file: str | None = None
+    stream: bool = True
 
     def socket_path(self) -> anyio.Path:
         """Get the socket path as a Path object."""

--- a/src/psi_agent/channel/repl/repl.py
+++ b/src/psi_agent/channel/repl/repl.py
@@ -39,7 +39,7 @@ class Repl:
     async def run(self) -> None:
         """Run the REPL loop."""
         print("psi-channel-repl - Interactive conversation with psi-session")
-        print("Type /quit or press Ctrl+D to exit")
+        print("Press Ctrl+D or Ctrl+C to exit")
         print("Press Alt+Enter or Escape+Enter for new line\n")
 
         # Initialize prompt-toolkit session with file-based history
@@ -57,27 +57,47 @@ class Repl:
                         print("\nGoodbye!")
                         break
 
-                    # Check for quit command
-                    if user_input.strip().lower() == "/quit":
-                        print("Goodbye!")
-                        break
-
                     # Skip empty input
                     if not user_input.strip():
                         continue
 
                     # Send to session and get response
-                    response = await self.client.send_message(user_input)
-
-                    # Display response
-                    print(f"\n{response}\n")
+                    if self.config.stream:
+                        await self._send_and_display_streaming(user_input)
+                    else:
+                        await self._send_and_display_non_streaming(user_input)
 
                 except KeyboardInterrupt:
-                    print("\n\nInterrupted. Type /quit or press Ctrl+D to exit.\n")
-                    continue
+                    # Ctrl+C exits
+                    print("\nGoodbye!")
+                    break
                 except Exception as e:
                     logger.exception(f"Unexpected error: {e}")
                     print(f"\nError: {e}\n")
+
+    async def _send_and_display_streaming(self, user_input: str) -> None:
+        """Send message with streaming and display in real-time.
+
+        Args:
+            user_input: The user's input message.
+        """
+        print()  # Blank line before response
+
+        def on_chunk(chunk: str) -> None:
+            """Print each chunk as it arrives."""
+            print(chunk, end="", flush=True)
+
+        await self.client.send_message_stream(user_input, on_chunk=on_chunk)
+        print("\n")  # Blank line after response
+
+    async def _send_and_display_non_streaming(self, user_input: str) -> None:
+        """Send message without streaming and display complete response.
+
+        Args:
+            user_input: The user's input message.
+        """
+        response = await self.client.send_message(user_input)
+        print(f"\n{response}\n")
 
     async def _read_input(self) -> str | None:
         """Read input from stdin asynchronously using prompt-toolkit.

--- a/src/psi_agent/session/runner.py
+++ b/src/psi_agent/session/runner.py
@@ -21,6 +21,37 @@ from psi_agent.session.types import History, ToolRegistry
 from psi_agent.session.workspace_watcher import ChangeSummary, WorkspaceWatcher
 
 
+def format_thinking_block(content: str) -> str:
+    """Format content as a thinking block.
+
+    Args:
+        content: The thinking content to format.
+
+    Returns:
+        Formatted thinking block string.
+    """
+    return f"<thinking>\n{content}\n</thinking>"
+
+
+def format_tool_call_thinking(
+    tool_name: str,
+    arguments: str,
+    result: str,
+) -> str:
+    """Format tool call information as thinking content.
+
+    Args:
+        tool_name: Name of the tool called.
+        arguments: JSON string of tool arguments.
+        result: Result from tool execution.
+
+    Returns:
+        Formatted thinking block for the tool call.
+    """
+    content = f"[Tool: {tool_name}]\nArguments: {arguments}\nResult: {result}"
+    return format_thinking_block(content)
+
+
 async def _load_system(workspace: anyio.Path) -> Any:
     """Load System class from workspace systems.
 
@@ -306,144 +337,31 @@ class SessionRunner:
     async def _run_conversation(self, messages: list[dict[str, Any]]) -> dict[str, Any]:
         """Run conversation with LLM, handling tool calls.
 
+        Uses streaming internally for better error detection and unified handling.
+
         Args:
             messages: Messages to send to LLM.
 
         Returns:
-            Final response from LLM.
+            Final response from LLM with thinking content prepended.
         """
         assert self.client is not None
         assert self.history is not None
 
         current_messages = list(messages)
+        thinking_blocks: list[str] = []
 
         while True:
-            # Build request
+            # Build request with streaming enabled
             request_body = {
                 "model": "session",  # Model is determined by psi-ai
                 "messages": current_messages,
                 "tools": self.registry.list_tools(),
+                "stream": True,
             }
             logger.debug(
                 f"AI request body: {json.dumps(request_body, ensure_ascii=False, indent=2)}"
             )
-
-            # Call psi-ai
-            async with self.client.post(
-                "http://localhost/v1/chat/completions",
-                json=request_body,
-            ) as response:
-                if response.status != 200:
-                    text = await response.text()
-                    logger.error(f"AI request failed: {response.status} - {text}")
-                    return self._make_error_response(f"AI request failed: {text}")
-
-                result = await response.json()
-                logger.debug(
-                    f"AI response body: {json.dumps(result, ensure_ascii=False, indent=2)}"
-                )
-
-            # Check for tool calls
-            choice = result.get("choices", [{}])[0]
-            message = choice.get("message", {})
-            tool_calls = message.get("tool_calls", [])
-
-            if not tool_calls:
-                # No tool calls - we're done
-                # Add assistant message to history
-                self.history.add_message(message)
-                return result
-
-            # Add assistant message with tool calls to history
-            self.history.add_message(message)
-
-            # Execute tools
-            tool_messages = await execute_tools_parallel(self.registry, tool_calls)
-
-            # Add tool results to history and current messages
-            for tool_msg in tool_messages:
-                self.history.add_message(tool_msg)
-                current_messages.append(message)
-                current_messages.append(tool_msg)
-
-            logger.debug(f"Executed {len(tool_calls)} tool calls, continuing conversation")
-
-    def _make_error_response(self, error: str) -> dict[str, Any]:
-        """Create an OpenAI-format error response.
-
-        Args:
-            error: Error message.
-
-        Returns:
-            Error response dict.
-        """
-        return {
-            "choices": [
-                {
-                    "message": {
-                        "role": "assistant",
-                        "content": f"Error: {error}",
-                    },
-                    "finish_reason": "stop",
-                }
-            ]
-        }
-
-    async def process_streaming_request(
-        self, user_message: dict[str, Any]
-    ) -> AsyncGenerator[str] | dict[str, Any]:
-        """Process a user request with streaming response.
-
-        Args:
-            user_message: User message dict with role and content.
-
-        Returns:
-            Async generator yielding SSE chunks.
-        """
-        assert self.history is not None
-        assert self.client is not None
-
-        # Check for workspace changes
-        if self._watcher is not None:
-            changes = await self._watcher.check_for_changes()
-            if changes.has_changes:
-                await self._handle_workspace_changes(changes)
-
-        # Add user message to history
-        self.history.add_message(user_message)
-
-        # Build messages for LLM
-        messages = await self._build_messages()
-
-        # For streaming, we need to handle tool calls differently
-        # This implementation handles non-streaming for tool calls, then streams final response
-        return await self._run_streaming_conversation(messages)
-
-    async def _run_streaming_conversation(
-        self, messages: list[dict[str, Any]]
-    ) -> AsyncGenerator[str] | dict[str, Any]:
-        """Run conversation with streaming, handling tool calls.
-
-        Args:
-            messages: Messages to send to LLM.
-
-        Returns:
-            Async generator yielding SSE chunks, or final response dict.
-        """
-
-        assert self.client is not None
-        assert self.history is not None
-
-        current_messages = list(messages)
-
-        while True:
-            # Build request
-            request_body = {
-                "model": "session",
-                "messages": current_messages,
-                "tools": self.registry.list_tools(),
-                "stream": True,
-            }
 
             # Call psi-ai with streaming
             async with self.client.post(
@@ -492,6 +410,18 @@ class SessionRunner:
                 # Execute tools
                 tool_messages = await execute_tools_parallel(self.registry, tool_calls)
 
+                # Generate thinking blocks for each tool call
+                for i, tool_call in enumerate(tool_calls):
+                    tool_name = tool_call.get("function", {}).get("name", "unknown")
+                    arguments = tool_call.get("function", {}).get("arguments", "{}")
+                    # Get corresponding tool result
+                    if i < len(tool_messages):
+                        tool_result = tool_messages[i].get("content", "")
+                    else:
+                        tool_result = ""
+                    thinking_block = format_tool_call_thinking(tool_name, arguments, tool_result)
+                    thinking_blocks.append(thinking_block)
+
                 # Add tool results to history and current messages
                 for tool_msg in tool_messages:
                     self.history.add_message(tool_msg)
@@ -501,13 +431,194 @@ class SessionRunner:
                 logger.debug(f"Executed {len(tool_calls)} tool calls, continuing conversation")
                 continue
 
-            # No tool calls - return streaming response
+            # No tool calls - we're done
+            final_content = "".join(content_chunks)
+            self.history.add_message({"role": "assistant", "content": final_content})
+
+            # Prepend thinking blocks to final content
+            if thinking_blocks:
+                thinking_content = "\n".join(thinking_blocks) + "\n"
+                final_content = thinking_content + final_content
+
+            # Return as non-streaming response format
+            return {
+                "choices": [
+                    {
+                        "message": {
+                            "role": "assistant",
+                            "content": final_content,
+                        },
+                        "finish_reason": "stop",
+                    }
+                ]
+            }
+
+    def _make_error_response(self, error: str) -> dict[str, Any]:
+        """Create an OpenAI-format error response.
+
+        Args:
+            error: Error message.
+
+        Returns:
+            Error response dict.
+        """
+        return {
+            "choices": [
+                {
+                    "message": {
+                        "role": "assistant",
+                        "content": f"Error: {error}",
+                    },
+                    "finish_reason": "stop",
+                }
+            ]
+        }
+
+    async def process_streaming_request(self, user_message: dict[str, Any]) -> AsyncGenerator[str]:
+        """Process a user request with streaming response.
+
+        Args:
+            user_message: User message dict with role and content.
+
+        Returns:
+            Async generator yielding SSE chunks.
+        """
+        assert self.history is not None
+        assert self.client is not None
+
+        # Check for workspace changes
+        if self._watcher is not None:
+            changes = await self._watcher.check_for_changes()
+            if changes.has_changes:
+                await self._handle_workspace_changes(changes)
+
+        # Add user message to history
+        self.history.add_message(user_message)
+
+        # Build messages for LLM
+        messages = await self._build_messages()
+
+        # Stream the conversation
+        return self._stream_conversation(messages)
+
+    async def _stream_conversation(self, messages: list[dict[str, Any]]) -> AsyncGenerator[str]:
+        """Stream conversation with thinking blocks.
+
+        Args:
+            messages: Messages to send to LLM.
+
+        Yields:
+            SSE formatted strings including thinking blocks and final content.
+        """
+        assert self.client is not None
+        assert self.history is not None
+
+        current_messages = list(messages)
+
+        while True:
+            # Build request
+            request_body = {
+                "model": "session",
+                "messages": current_messages,
+                "tools": self.registry.list_tools(),
+                "stream": True,
+            }
+
+            # Call psi-ai with streaming
+            async with self.client.post(
+                "http://localhost/v1/chat/completions",
+                json=request_body,
+            ) as response:
+                if response.status != 200:
+                    text = await response.text()
+                    logger.error(f"AI request failed: {response.status} - {text}")
+                    # Yield error as SSE
+                    error_content = f"Error: AI request failed: {text}"
+                    error_data = {
+                        "choices": [{"delta": {"content": error_content}, "finish_reason": "stop"}]
+                    }
+                    data = json.dumps(error_data)
+                    yield f"data: {data}\n\n"
+                    yield "data: [DONE]\n\n"
+                    return
+
+                # Collect streaming response
+                content_chunks = []
+                tool_calls_data = []
+                async for line in response.content:
+                    line_str = line.decode().strip()
+                    if not line_str or line_str == "data: [DONE]":
+                        continue
+                    if line_str.startswith("data: "):
+                        try:
+                            chunk = json.loads(line_str[6:])
+                            delta = chunk.get("choices", [{}])[0].get("delta", {})
+
+                            if "content" in delta:
+                                content_chunks.append(delta["content"])
+                                logger.debug(f"Stream content chunk: {delta['content'][:100]}...")
+
+                            if "tool_calls" in delta:
+                                tool_calls_data.extend(delta["tool_calls"])
+                        except json.JSONDecodeError:
+                            pass
+
+            # Check if we have tool calls
+            if tool_calls_data:
+                # Reconstruct tool calls from streaming data
+                tool_calls = self._reconstruct_tool_calls(tool_calls_data)
+
+                # Add assistant message to history
+                assistant_message = {
+                    "role": "assistant",
+                    "content": "".join(content_chunks) or None,
+                    "tool_calls": tool_calls,
+                }
+                self.history.add_message(assistant_message)
+
+                # Execute tools
+                tool_messages = await execute_tools_parallel(self.registry, tool_calls)
+
+                # Yield thinking blocks for each tool call immediately
+                for i, tool_call in enumerate(tool_calls):
+                    tool_name = tool_call.get("function", {}).get("name", "unknown")
+                    arguments = tool_call.get("function", {}).get("arguments", "{}")
+                    if i < len(tool_messages):
+                        tool_result = tool_messages[i].get("content", "")
+                    else:
+                        tool_result = ""
+                    thinking_block = format_tool_call_thinking(tool_name, arguments, tool_result)
+
+                    # Yield thinking block as SSE event
+                    thinking_data = {
+                        "choices": [{"delta": {"content": thinking_block}, "finish_reason": None}]
+                    }
+                    data = json.dumps(thinking_data)
+                    yield f"data: {data}\n\n"
+
+                # Add tool results to history and current messages
+                for tool_msg in tool_messages:
+                    self.history.add_message(tool_msg)
+                    current_messages.append(assistant_message)
+                    current_messages.append(tool_msg)
+
+                logger.debug(f"Executed {len(tool_calls)} tool calls, continuing conversation")
+                continue
+
+            # No tool calls - stream final response
             final_content = "".join(content_chunks)
             self.history.add_message({"role": "assistant", "content": final_content})
             await persist_history(self.history)
 
-            # Return as SSE generator
-            return self._make_streaming_response(content_chunks)
+            # Yield final content
+            for chunk in content_chunks:
+                chunk_data = {"choices": [{"delta": {"content": chunk}, "finish_reason": None}]}
+                data = json.dumps(chunk_data)
+                yield f"data: {data}\n\n"
+
+            # Send done marker
+            yield "data: [DONE]\n\n"
+            return
 
     def _reconstruct_tool_calls(
         self, tool_calls_data: list[dict[str, Any]]
@@ -542,20 +653,3 @@ class SessionRunner:
                     tool_calls_map[index]["function"]["arguments"] += func["arguments"]
 
         return list(tool_calls_map.values())
-
-    async def _make_streaming_response(self, content_chunks: list[str]) -> AsyncGenerator[str]:
-        """Create SSE streaming response.
-
-        Args:
-            content_chunks: List of content chunks.
-
-        Returns:
-            Async generator yielding SSE formatted strings.
-        """
-
-        for chunk in content_chunks:
-            data = json.dumps({"choices": [{"delta": {"content": chunk}, "finish_reason": None}]})
-            yield f"data: {data}\n\n"
-
-        # Send done marker
-        yield "data: [DONE]\n\n"

--- a/src/psi_agent/session/server.py
+++ b/src/psi_agent/session/server.py
@@ -3,8 +3,7 @@
 from __future__ import annotations
 
 import json
-from collections.abc import AsyncGenerator
-from typing import Any, cast
+from typing import Any
 
 import anyio
 from aiohttp import web
@@ -136,16 +135,9 @@ class SessionServer:
 
         stream_gen = await self.runner.process_streaming_request(user_message)
 
-        # Handle both async generator and dict response
-        if hasattr(stream_gen, "__aiter__"):
-            async for chunk in cast(AsyncGenerator[str], stream_gen):
-                await response.write(chunk.encode())
-        else:
-            # Non-streaming result (tool calls were involved)
-            result = cast(dict[str, Any], stream_gen)
-            channel_response = self._filter_for_channel(result)
-            data = json.dumps(channel_response)
-            await response.write(f"data: {data}\n\n".encode())
+        # Stream all chunks including thinking blocks
+        async for chunk in stream_gen:
+            await response.write(chunk.encode())
 
         logger.info("Streaming response completed")
         return response

--- a/tests/channel/cli/test_cli.py
+++ b/tests/channel/cli/test_cli.py
@@ -30,18 +30,33 @@ async def test_send_message_request_format():
     assert "stream" in params
 
 
-class TestCliDataclass:
-    """Tests for CLI dataclass."""
+@pytest.mark.asyncio
+async def test_send_message_default_stream_true():
+    """Test that send_message defaults to streaming mode."""
+    sig = inspect.signature(send_message)
+    stream_param = sig.parameters["stream"]
 
-    def test_cli_import(self) -> None:
-        """Test CLI class can be imported."""
-        # Test instantiation
+    assert stream_param.default is True
+
+
+class TestCliFlags:
+    """Tests for CLI flag handling."""
+
+    def test_cli_default_stream_enabled(self) -> None:
+        """Test CLI defaults to streaming enabled."""
         cli = Cli(session_socket="/tmp/test.sock", message="Hello")
-        assert cli.session_socket == "/tmp/test.sock"
-        assert cli.message == "Hello"
-        assert cli.stream is False  # default
 
-    def test_cli_with_stream(self) -> None:
-        """Test CLI with stream option."""
-        cli = Cli(session_socket="/tmp/test.sock", message="Hello", stream=True)
-        assert cli.stream is True
+        assert cli.no_stream is False
+
+    def test_cli_no_stream_flag(self) -> None:
+        """Test CLI --no-stream flag disables streaming."""
+        cli = Cli(session_socket="/tmp/test.sock", message="Hello", no_stream=True)
+
+        assert cli.no_stream is True
+
+    def test_cli_stream_passed_to_send_message(self) -> None:
+        """Test CLI passes correct stream value to send_message."""
+        cli = Cli(session_socket="/tmp/test.sock", message="Hello", no_stream=True)
+
+        # no_stream=True means stream=False
+        assert cli.no_stream is not False

--- a/tests/channel/repl/test_cli.py
+++ b/tests/channel/repl/test_cli.py
@@ -1,0 +1,29 @@
+"""Tests for REPL channel CLI."""
+
+from __future__ import annotations
+
+from psi_agent.channel.repl.cli import Repl
+
+
+class TestReplCli:
+    """Tests for REPL CLI flag handling."""
+
+    def test_cli_default_stream_enabled(self) -> None:
+        """Test CLI defaults to streaming enabled."""
+        cli = Repl(session_socket="/tmp/test.sock")
+
+        assert cli.no_stream is False
+
+    def test_cli_no_stream_flag(self) -> None:
+        """Test CLI --no-stream flag disables streaming."""
+        cli = Repl(session_socket="/tmp/test.sock", no_stream=True)
+
+        assert cli.no_stream is True
+
+    def test_cli_passes_stream_to_config(self) -> None:
+        """Test CLI passes correct stream value to config."""
+        cli = Repl(session_socket="/tmp/test.sock", no_stream=True)
+
+        # When no_stream=True, config.stream should be False
+        # This is verified by checking the logic in __call__
+        assert cli.no_stream is True

--- a/tests/channel/repl/test_client.py
+++ b/tests/channel/repl/test_client.py
@@ -161,3 +161,122 @@ class TestReplClient:
 
         with pytest.raises(RuntimeError, match="Client not initialized"):
             await client.send_message("Hi")
+
+    @pytest.mark.asyncio
+    async def test_send_message_stream_success(self, client: ReplClient) -> None:
+        """Test successful streaming message sending."""
+        # SSE response data
+        sse_lines = [
+            b'data: {"choices":[{"delta":{"content":"Hello"}}]}\n',
+            b'data: {"choices":[{"delta":{"content":" world"}}]}\n',
+            b'data: {"choices":[{"delta":{},"finish_reason":"stop"}]}\n',
+            b"data: [DONE]\n",
+        ]
+
+        # Create async iterator mock
+        async def async_iter():
+            for line in sse_lines:
+                yield line
+
+        mock_response = MagicMock()
+        mock_response.status = 200
+        mock_response.content = async_iter()
+
+        chunks_received = []
+
+        def on_chunk(chunk: str) -> None:
+            chunks_received.append(chunk)
+
+        with (
+            patch("aiohttp.UnixConnector") as mock_connector,
+            patch("aiohttp.ClientSession") as mock_session,
+        ):
+            mock_connector_instance = AsyncMock()
+            mock_connector_instance.close = AsyncMock()
+            mock_connector.return_value = mock_connector_instance
+
+            mock_session_instance = MagicMock()
+            mock_session_instance.post = MagicMock(
+                return_value=MagicMock(__aenter__=AsyncMock(return_value=mock_response))
+            )
+            mock_session_instance.close = AsyncMock()
+            mock_session.return_value = mock_session_instance
+
+            async with client:
+                result = await client.send_message_stream("Hi", on_chunk=on_chunk)
+
+                assert result == "Hello world"
+                assert chunks_received == ["Hello", " world"]
+
+    @pytest.mark.asyncio
+    async def test_send_message_stream_without_callback(self, client: ReplClient) -> None:
+        """Test streaming without callback still returns full content."""
+        sse_lines = [
+            b'data: {"choices":[{"delta":{"content":"Test"}}]}\n',
+            b'data: {"choices":[{"delta":{"content":" response"}}]}\n',
+            b"data: [DONE]\n",
+        ]
+
+        # Create async iterator mock
+        async def async_iter():
+            for line in sse_lines:
+                yield line
+
+        mock_response = MagicMock()
+        mock_response.status = 200
+        mock_response.content = async_iter()
+
+        with (
+            patch("aiohttp.UnixConnector") as mock_connector,
+            patch("aiohttp.ClientSession") as mock_session,
+        ):
+            mock_connector_instance = AsyncMock()
+            mock_connector_instance.close = AsyncMock()
+            mock_connector.return_value = mock_connector_instance
+
+            mock_session_instance = MagicMock()
+            mock_session_instance.post = MagicMock(
+                return_value=MagicMock(__aenter__=AsyncMock(return_value=mock_response))
+            )
+            mock_session_instance.close = AsyncMock()
+            mock_session.return_value = mock_session_instance
+
+            async with client:
+                result = await client.send_message_stream("Hi")
+
+                assert result == "Test response"
+
+    @pytest.mark.asyncio
+    async def test_send_message_stream_error_status(self, client: ReplClient) -> None:
+        """Test handling error status from session in streaming mode."""
+        mock_response = MagicMock()
+        mock_response.status = 500
+        mock_response.text = AsyncMock(return_value="Internal error")
+
+        with (
+            patch("aiohttp.UnixConnector") as mock_connector,
+            patch("aiohttp.ClientSession") as mock_session,
+        ):
+            mock_connector_instance = AsyncMock()
+            mock_connector_instance.close = AsyncMock()
+            mock_connector.return_value = mock_connector_instance
+
+            mock_session_instance = MagicMock()
+            mock_session_instance.post = MagicMock(
+                return_value=MagicMock(__aenter__=AsyncMock(return_value=mock_response))
+            )
+            mock_session_instance.close = AsyncMock()
+            mock_session.return_value = mock_session_instance
+
+            async with client:
+                result = await client.send_message_stream("Hi")
+
+                assert "Error" in result
+
+    @pytest.mark.asyncio
+    async def test_send_message_stream_without_context(self, config: ReplConfig) -> None:
+        """Test that send_message_stream raises error without context."""
+        client = ReplClient(config)
+
+        with pytest.raises(RuntimeError, match="Client not initialized"):
+            await client.send_message_stream("Hi")

--- a/tests/channel/repl/test_client.py
+++ b/tests/channel/repl/test_client.py
@@ -280,3 +280,49 @@ class TestReplClient:
 
         with pytest.raises(RuntimeError, match="Client not initialized"):
             await client.send_message_stream("Hi")
+
+    @pytest.mark.asyncio
+    async def test_send_message_timeout(self, client: ReplClient) -> None:
+        """Test handling timeout error in send_message."""
+
+        with (
+            patch("aiohttp.UnixConnector") as mock_connector,
+            patch("aiohttp.ClientSession") as mock_session,
+        ):
+            mock_connector_instance = AsyncMock()
+            mock_connector_instance.close = AsyncMock()
+            mock_connector.return_value = mock_connector_instance
+
+            mock_session_instance = MagicMock()
+            mock_session_instance.post = MagicMock(side_effect=TimeoutError())
+            mock_session_instance.close = AsyncMock()
+            mock_session.return_value = mock_session_instance
+
+            async with client:
+                result = await client.send_message("Hi")
+
+                assert "Error" in result
+                assert "timeout" in result.lower()
+
+    @pytest.mark.asyncio
+    async def test_send_message_stream_timeout(self, client: ReplClient) -> None:
+        """Test handling timeout error in send_message_stream."""
+
+        with (
+            patch("aiohttp.UnixConnector") as mock_connector,
+            patch("aiohttp.ClientSession") as mock_session,
+        ):
+            mock_connector_instance = AsyncMock()
+            mock_connector_instance.close = AsyncMock()
+            mock_connector.return_value = mock_connector_instance
+
+            mock_session_instance = MagicMock()
+            mock_session_instance.post = MagicMock(side_effect=TimeoutError())
+            mock_session_instance.close = AsyncMock()
+            mock_session.return_value = mock_session_instance
+
+            async with client:
+                result = await client.send_message_stream("Hi")
+
+                assert "Error" in result
+                assert "timeout" in result.lower()

--- a/tests/channel/repl/test_config.py
+++ b/tests/channel/repl/test_config.py
@@ -42,3 +42,15 @@ class TestReplConfig:
         config = ReplConfig(session_socket="/tmp/test.sock")
 
         assert config.history_file is None
+
+    def test_stream_default_true(self) -> None:
+        """Test stream defaults to True."""
+        config = ReplConfig(session_socket="/tmp/test.sock")
+
+        assert config.stream is True
+
+    def test_stream_can_be_disabled(self) -> None:
+        """Test stream can be set to False."""
+        config = ReplConfig(session_socket="/tmp/test.sock", stream=False)
+
+        assert config.stream is False

--- a/tests/channel/repl/test_repl.py
+++ b/tests/channel/repl/test_repl.py
@@ -134,6 +134,63 @@ class TestRepl:
             assert call_args[0][0] == "Hello"
 
 
+class TestReplNonStreaming:
+    """Tests for REPL non-streaming mode."""
+
+    @pytest.fixture
+    def config(self) -> ReplConfig:
+        """Create test config with streaming disabled."""
+        return ReplConfig(session_socket="/tmp/test.sock", stream=False)
+
+    @pytest.fixture
+    def repl(self, config: ReplConfig) -> Repl:
+        """Create test REPL with non-streaming config."""
+        return Repl(config)
+
+    @pytest.mark.asyncio
+    async def test_non_streaming_uses_send_message(self, repl: Repl) -> None:
+        """Test non-streaming mode uses send_message instead of send_message_stream."""
+        inputs = ["Hello", None]  # Message, then EOF
+        input_iter = iter(inputs)
+
+        async def mock_read() -> str | None:
+            return next(input_iter, None)
+
+        mock_send = AsyncMock(return_value="Response")
+        with (
+            patch.object(repl, "_read_input", mock_read),
+            patch.object(repl.client, "send_message", mock_send),
+            patch("builtins.print"),
+        ):
+            await repl.run()
+
+            # send_message should be called (not send_message_stream)
+            assert mock_send.called
+            call_args = mock_send.call_args
+            assert call_args[0][0] == "Hello"
+
+    @pytest.mark.asyncio
+    async def test_non_streaming_displays_response(self, repl: Repl) -> None:
+        """Test non-streaming mode displays complete response."""
+        inputs = ["Hello", None]
+        input_iter = iter(inputs)
+
+        async def mock_read() -> str | None:
+            return next(input_iter, None)
+
+        mock_send = AsyncMock(return_value="Complete response")
+        with (
+            patch.object(repl, "_read_input", mock_read),
+            patch.object(repl.client, "send_message", mock_send),
+            patch("builtins.print") as mock_print,
+        ):
+            await repl.run()
+
+            # Response should be printed
+            print_calls = [str(call) for call in mock_print.call_args_list]
+            assert any("Complete response" in str(call) for call in print_calls)
+
+
 class TestReplHistory:
     """Tests for REPL history navigation."""
 

--- a/tests/channel/repl/test_repl.py
+++ b/tests/channel/repl/test_repl.py
@@ -64,9 +64,9 @@ class TestRepl:
         assert result is None
 
     @pytest.mark.asyncio
-    async def test_quit_command(self, repl: Repl) -> None:
-        """Test /quit command exits REPL."""
-        inputs = ["/quit"]
+    async def test_eof_exits_repl(self, repl: Repl) -> None:
+        """Test EOF (Ctrl+D) exits REPL."""
+        inputs = [None]  # EOF
         input_iter = iter(inputs)
 
         async def mock_read() -> str | None:
@@ -79,9 +79,22 @@ class TestRepl:
             assert any("Goodbye" in str(call) for call in mock_print.call_args_list)
 
     @pytest.mark.asyncio
+    async def test_keyboard_interrupt_exits_repl(self, repl: Repl) -> None:
+        """Test Ctrl+C exits REPL."""
+
+        async def mock_read() -> str | None:
+            raise KeyboardInterrupt()
+
+        with patch.object(repl, "_read_input", mock_read), patch("builtins.print") as mock_print:
+            await repl.run()
+
+            # Check goodbye message was printed
+            assert any("Goodbye" in str(call) for call in mock_print.call_args_list)
+
+    @pytest.mark.asyncio
     async def test_empty_input_ignored(self, repl: Repl) -> None:
         """Test empty input is ignored."""
-        inputs = ["", "/quit"]
+        inputs = ["", None]  # Empty string, then EOF
         input_iter = iter(inputs)
 
         async def mock_read() -> str | None:
@@ -101,22 +114,24 @@ class TestRepl:
     @pytest.mark.asyncio
     async def test_message_sent_to_session(self, repl: Repl) -> None:
         """Test message is sent to session."""
-        inputs = ["Hello", "/quit"]
+        inputs = ["Hello", None]  # Message, then EOF
         input_iter = iter(inputs)
 
         async def mock_read() -> str | None:
             return next(input_iter, None)
 
-        mock_send = AsyncMock(return_value="Hi there!")
+        mock_send_stream = AsyncMock(return_value="Hi there!")
         with (
             patch.object(repl, "_read_input", mock_read),
-            patch.object(repl.client, "send_message", mock_send),
+            patch.object(repl.client, "send_message_stream", mock_send_stream),
             patch("builtins.print"),
         ):
             await repl.run()
 
-            # send_message should be called with the user input
-            mock_send.assert_called_once_with("Hello")
+            # send_message_stream should be called with the user input
+            assert mock_send_stream.called
+            call_args = mock_send_stream.call_args
+            assert call_args[0][0] == "Hello"
 
 
 class TestReplHistory:
@@ -136,7 +151,7 @@ class TestReplHistory:
     @pytest.mark.asyncio
     async def test_history_stored_in_session(self, repl: Repl) -> None:
         """Test that inputs are stored in prompt-toolkit history."""
-        inputs = ["First message", "Second message", "/quit"]
+        inputs = ["First message", "Second message", None]  # Messages, then EOF
         input_iter = iter(inputs)
 
         async def mock_read() -> str | None:
@@ -160,7 +175,7 @@ class TestReplHistory:
         config = ReplConfig(session_socket="/tmp/test.sock", history_file=str(history_file))
         repl = Repl(config)
 
-        inputs = ["First message", "/quit"]
+        inputs = ["First message", None]  # Message, then EOF
         input_iter = iter(inputs)
 
         async def mock_read() -> str | None:
@@ -189,7 +204,7 @@ class TestReplHistory:
         config = ReplConfig(session_socket="/tmp/test.sock", history_file=str(history_file))
         repl = Repl(config)
 
-        inputs = ["/quit"]
+        inputs = [None]  # EOF
         input_iter = iter(inputs)
 
         async def mock_read() -> str | None:
@@ -213,22 +228,24 @@ class TestReplHistory:
     async def test_multiline_input_preserved(self, repl: Repl) -> None:
         """Test multiline input is preserved with line breaks."""
         multiline_input = "Line 1\nLine 2\nLine 3"
-        inputs = [multiline_input, "/quit"]
+        inputs = [multiline_input, None]  # Message, then EOF
         input_iter = iter(inputs)
 
         async def mock_read() -> str | None:
             return next(input_iter, None)
 
-        mock_send = AsyncMock(return_value="Response")
+        mock_send_stream = AsyncMock(return_value="Response")
         with (
             patch.object(repl, "_read_input", mock_read),
-            patch.object(repl.client, "send_message", mock_send),
+            patch.object(repl.client, "send_message_stream", mock_send_stream),
             patch("builtins.print"),
         ):
             await repl.run()
 
             # Check multiline message preserved
-            mock_send.assert_called_once_with(multiline_input)
+            assert mock_send_stream.called
+            call_args = mock_send_stream.call_args
+            assert call_args[0][0] == multiline_input
 
 
 class TestReplEditing:
@@ -248,7 +265,7 @@ class TestReplEditing:
     @pytest.mark.asyncio
     async def test_prompt_session_created(self, repl: Repl) -> None:
         """Test that PromptSession is created during run."""
-        inputs = ["/quit"]
+        inputs = [None]  # EOF
         input_iter = iter(inputs)
 
         async def mock_read() -> str | None:

--- a/tests/session/test_runner.py
+++ b/tests/session/test_runner.py
@@ -631,3 +631,138 @@ async def tool(message: str) -> str:
             assert content.startswith("<thinking>")
             assert "[Tool: echo]" in content
             assert "Done" in content  # Final response is after thinking
+
+
+class TestStreamConversation:
+    """Tests for _stream_conversation method."""
+
+    @pytest.mark.asyncio
+    async def test_stream_conversation_yields_content(self, config):
+        """Test _stream_conversation yields content chunks."""
+        runner = SessionRunner(config)
+        async with runner:
+            sse_lines = [
+                b'data: {"choices":[{"delta":{"content":"Hello"}}]}\n',
+                b'data: {"choices":[{"delta":{"content":" world"}}]}\n',
+                b'data: {"choices":[{"delta":{},"finish_reason":"stop"}]}\n',
+                b"data: [DONE]\n",
+            ]
+
+            async def async_iter():
+                for line in sse_lines:
+                    yield line
+
+            mock_response = AsyncMock()
+            mock_response.status = 200
+            mock_response.content = async_iter()
+            mock_response.__aenter__ = AsyncMock(return_value=mock_response)
+            mock_response.__aexit__ = AsyncMock(return_value=None)
+
+            with patch.object(runner.client, "post", return_value=mock_response):
+                messages = [{"role": "user", "content": "Hi"}]
+                chunks = []
+                async for chunk in runner._stream_conversation(messages):
+                    chunks.append(chunk)
+
+                # Should have content chunks and DONE
+                assert len(chunks) > 0
+                full_content = "".join(chunks)
+                assert "Hello" in full_content or "world" in full_content
+
+    @pytest.mark.asyncio
+    async def test_stream_conversation_handles_error(self, config):
+        """Test _stream_conversation handles AI request failure."""
+        runner = SessionRunner(config)
+        async with runner:
+            mock_response = AsyncMock()
+            mock_response.status = 500
+            mock_response.text = AsyncMock(return_value="Internal Server Error")
+            mock_response.__aenter__ = AsyncMock(return_value=mock_response)
+            mock_response.__aexit__ = AsyncMock(return_value=None)
+
+            with patch.object(runner.client, "post", return_value=mock_response):
+                messages = [{"role": "user", "content": "Test"}]
+                chunks = []
+                async for chunk in runner._stream_conversation(messages):
+                    chunks.append(chunk)
+
+                # Should yield error content
+                full_content = "".join(chunks)
+                assert "Error" in full_content
+
+    @pytest.mark.asyncio
+    async def test_stream_conversation_with_tool_calls(self, config):
+        """Test _stream_conversation handles tool calls and yields thinking."""
+        runner = SessionRunner(config)
+        async with runner:
+            # Create a tool
+            tool_file = config.tools_dir() / "echo.py"
+            await tool_file.write_text(
+                """
+async def tool(message: str) -> str:
+    '''Echo tool.
+
+    Args:
+        message: The message to echo.
+
+    Returns:
+        The echoed message.
+    '''
+    return message
+"""
+            )
+            tool_schema = await load_tool_from_file(tool_file)
+            if tool_schema:
+                runner.registry.register(tool_schema)
+
+            # First response with tool call
+            sse_lines_tool = [
+                b'data: {"choices":[{"delta":{"tool_calls":[{"index":0,"id":"call_1",'
+                b'"function":{"name":"echo","arguments":"{\\"mes"}}]}}]}\n',
+                b'data: {"choices":[{"delta":{"tool_calls":[{"index":0,'
+                b'"function":{"arguments":"sage\\": \\"test\\"}"}}]}}\n',
+                b"data: [DONE]\n",
+            ]
+
+            # Second response after tool execution
+            sse_lines_final = [
+                b'data: {"choices":[{"delta":{"content":"Done"}}]}\n',
+                b'data: {"choices":[{"delta":{},"finish_reason":"stop"}]}\n',
+                b"data: [DONE]\n",
+            ]
+
+            call_count = 0
+
+            def make_async_iter(lines):
+                async def async_iter():
+                    for line in lines:
+                        yield line
+
+                return async_iter()
+
+            def mock_post_side_effect(*_args, **_kwargs):
+                nonlocal call_count
+                call_count += 1
+
+                mock_response = AsyncMock()
+                mock_response.status = 200
+                mock_response.__aenter__ = AsyncMock(return_value=mock_response)
+                mock_response.__aexit__ = AsyncMock(return_value=None)
+
+                if call_count == 1:
+                    mock_response.content = make_async_iter(sse_lines_tool)
+                else:
+                    mock_response.content = make_async_iter(sse_lines_final)
+
+                return mock_response
+
+            with patch.object(runner.client, "post", side_effect=mock_post_side_effect):
+                messages = [{"role": "user", "content": "Test"}]
+                chunks = []
+                async for chunk in runner._stream_conversation(messages):
+                    chunks.append(chunk)
+
+                # Should include thinking block
+                full_content = "".join(chunks)
+                assert "<thinking>" in full_content
+                assert "[Tool: echo]" in full_content

--- a/tests/session/test_runner.py
+++ b/tests/session/test_runner.py
@@ -10,7 +10,13 @@ import anyio
 import pytest
 
 from psi_agent.session.config import SessionConfig
-from psi_agent.session.runner import SessionRunner, load_system_prompt
+from psi_agent.session.runner import (
+    SessionRunner,
+    format_thinking_block,
+    format_tool_call_thinking,
+    load_system_prompt,
+)
+from psi_agent.session.tool_loader import load_tool_from_file
 from psi_agent.session.workspace_watcher import ChangeSummary
 
 
@@ -134,16 +140,20 @@ async def test_process_request_adds_to_history(config):
     """Test process_request adds user message to history."""
     runner = SessionRunner(config)
     async with runner:
-        # Mock the AI client response using context manager
+        # Create streaming response mock
+        sse_lines = [
+            b'data: {"choices":[{"delta":{"content":"Hello!"}}]}\n',
+            b'data: {"choices":[{"delta":{},"finish_reason":"stop"}]}\n',
+            b"data: [DONE]\n",
+        ]
+
+        async def async_iter():
+            for line in sse_lines:
+                yield line
+
         mock_response = AsyncMock()
         mock_response.status = 200
-        mock_response.json = AsyncMock(
-            return_value={
-                "choices": [
-                    {"message": {"role": "assistant", "content": "Hello!"}, "finish_reason": "stop"}
-                ]
-            }
-        )
+        mock_response.content = async_iter()
         mock_response.__aenter__ = AsyncMock(return_value=mock_response)
         mock_response.__aexit__ = AsyncMock(return_value=None)
 
@@ -161,18 +171,20 @@ async def test_process_request_returns_response(config):
     """Test process_request returns AI response."""
     runner = SessionRunner(config)
     async with runner:
+        # Create streaming response mock
+        sse_lines = [
+            b'data: {"choices":[{"delta":{"content":"Response text"}}]}\n',
+            b'data: {"choices":[{"delta":{},"finish_reason":"stop"}]}\n',
+            b"data: [DONE]\n",
+        ]
+
+        async def async_iter():
+            for line in sse_lines:
+                yield line
+
         mock_response = AsyncMock()
         mock_response.status = 200
-        mock_response.json = AsyncMock(
-            return_value={
-                "choices": [
-                    {
-                        "message": {"role": "assistant", "content": "Response text"},
-                        "finish_reason": "stop",
-                    }
-                ]
-            }
-        )
+        mock_response.content = async_iter()
         mock_response.__aenter__ = AsyncMock(return_value=mock_response)
         mock_response.__aexit__ = AsyncMock(return_value=None)
 
@@ -403,3 +415,219 @@ class TestRunnerScheduleExecutor:
         runner.set_schedule_executor(executor)
 
         assert runner._schedule_executor == executor
+
+
+@pytest.mark.asyncio
+async def test_run_conversation_uses_streaming(config):
+    """Test _run_conversation uses streaming internally for AI calls."""
+    runner = SessionRunner(config)
+    async with runner:
+        # Create mock streaming response
+        sse_lines = [
+            b'data: {"choices":[{"delta":{"content":"Hello"}}]}\n',
+            b'data: {"choices":[{"delta":{"content":" world"}}]}\n',
+            b'data: {"choices":[{"delta":{},"finish_reason":"stop"}]}\n',
+            b"data: [DONE]\n",
+        ]
+
+        async def async_iter():
+            for line in sse_lines:
+                yield line
+
+        mock_response = AsyncMock()
+        mock_response.status = 200
+        mock_response.content = async_iter()
+        mock_response.__aenter__ = AsyncMock(return_value=mock_response)
+        mock_response.__aexit__ = AsyncMock(return_value=None)
+
+        with patch.object(runner.client, "post", return_value=mock_response) as mock_post:
+            messages = [{"role": "user", "content": "Hi"}]
+            result = await runner._run_conversation(messages)
+
+            # Verify streaming was requested
+            call_args = mock_post.call_args
+            request_body = call_args[1]["json"]
+            assert request_body.get("stream") is True
+
+            # Verify response
+            assert "choices" in result
+            assert result["choices"][0]["message"]["content"] == "Hello world"
+
+
+@pytest.mark.asyncio
+async def test_run_conversation_handles_tool_calls_from_stream(config):
+    """Test _run_conversation handles tool calls from streaming response."""
+    runner = SessionRunner(config)
+    async with runner:
+        # Create a tool for testing
+        tool_file = config.tools_dir() / "echo.py"
+        await tool_file.write_text(
+            """
+async def tool(message: str) -> str:
+    '''Echo tool.
+
+    Args:
+        message: The message to echo.
+
+    Returns:
+        The echoed message.
+    '''
+    return message
+"""
+        )
+        tool_schema = await load_tool_from_file(tool_file)
+        if tool_schema:
+            runner.registry.register(tool_schema)
+
+        # First streaming response with tool call
+        sse_lines_tool = [
+            b'data: {"choices":[{"delta":{"tool_calls":[{"index":0,"id":"call_1",'
+            b'"function":{"name":"echo","arguments":"{\\"mes"}}]}}]}\n',
+            b'data: {"choices":[{"delta":{"tool_calls":[{"index":0,'
+            b'"function":{"arguments":"sage\\": \\"test\\"}"}}]}}\n',
+            b"data: [DONE]\n",
+        ]
+
+        # Second streaming response after tool execution
+        sse_lines_final = [
+            b'data: {"choices":[{"delta":{"content":"Done"}}]}\n',
+            b'data: {"choices":[{"delta":{},"finish_reason":"stop"}]}\n',
+            b"data: [DONE]\n",
+        ]
+
+        call_count = 0
+
+        def make_async_iter(lines):
+            async def async_iter():
+                for line in lines:
+                    yield line
+
+            return async_iter()
+
+        def mock_post_side_effect(*_args, **_kwargs):
+            nonlocal call_count
+            call_count += 1
+
+            mock_response = AsyncMock()
+            mock_response.status = 200
+            mock_response.__aenter__ = AsyncMock(return_value=mock_response)
+            mock_response.__aexit__ = AsyncMock(return_value=None)
+
+            if call_count == 1:
+                mock_response.content = make_async_iter(sse_lines_tool)
+            else:
+                mock_response.content = make_async_iter(sse_lines_final)
+
+            return mock_response
+
+        with patch.object(runner.client, "post", side_effect=mock_post_side_effect):
+            messages = [{"role": "user", "content": "Test tool"}]
+            result = await runner._run_conversation(messages)
+
+            # Should have made 2 calls (tool call + final response)
+            assert call_count == 2
+            assert "choices" in result
+            # Check that thinking block is included
+            content = result["choices"][0]["message"]["content"]
+            assert "<thinking>" in content
+            assert "[Tool: echo]" in content
+
+
+def test_format_thinking_block():
+    """Test format_thinking_block creates correct format."""
+    content = "Test thinking"
+    result = format_thinking_block(content)
+
+    assert result == "<thinking>\nTest thinking\n</thinking>"
+
+
+def test_format_tool_call_thinking():
+    """Test format_tool_call_thinking creates correct format."""
+    result = format_tool_call_thinking(
+        tool_name="test_tool",
+        arguments='{"arg": "value"}',
+        result="success",
+    )
+
+    assert "<thinking>" in result
+    assert "[Tool: test_tool]" in result
+    assert 'Arguments: {"arg": "value"}' in result
+    assert "Result: success" in result
+    assert "</thinking>" in result
+
+
+@pytest.mark.asyncio
+async def test_run_conversation_includes_thinking(config):
+    """Test _run_conversation includes thinking blocks for tool calls."""
+    runner = SessionRunner(config)
+    async with runner:
+        # Create a tool for testing
+        tool_file = config.tools_dir() / "echo.py"
+        await tool_file.write_text(
+            """
+async def tool(message: str) -> str:
+    '''Echo tool.
+
+    Args:
+        message: The message to echo.
+
+    Returns:
+        The echoed message.
+    '''
+    return message
+"""
+        )
+        tool_schema = await load_tool_from_file(tool_file)
+        if tool_schema:
+            runner.registry.register(tool_schema)
+
+        # First streaming response with tool call
+        sse_lines_tool = [
+            b'data: {"choices":[{"delta":{"tool_calls":[{"index":0,"id":"call_1",'
+            b'"function":{"name":"echo","arguments":"{\\"mes"}}]}}]}\n',
+            b'data: {"choices":[{"delta":{"tool_calls":[{"index":0,'
+            b'"function":{"arguments":"sage\\": \\"test\\"}"}}]}}\n',
+            b"data: [DONE]\n",
+        ]
+
+        # Second streaming response after tool execution
+        sse_lines_final = [
+            b'data: {"choices":[{"delta":{"content":"Done"}}]}\n',
+            b'data: {"choices":[{"delta":{},"finish_reason":"stop"}]}\n',
+            b"data: [DONE]\n",
+        ]
+
+        call_count = 0
+
+        def make_async_iter(lines):
+            async def async_iter():
+                for line in lines:
+                    yield line
+
+            return async_iter()
+
+        def mock_post_side_effect(*_args, **_kwargs):
+            nonlocal call_count
+            call_count += 1
+
+            mock_response = AsyncMock()
+            mock_response.status = 200
+            mock_response.__aenter__ = AsyncMock(return_value=mock_response)
+            mock_response.__aexit__ = AsyncMock(return_value=None)
+
+            if call_count == 1:
+                mock_response.content = make_async_iter(sse_lines_tool)
+            else:
+                mock_response.content = make_async_iter(sse_lines_final)
+
+            return mock_response
+
+        with patch.object(runner.client, "post", side_effect=mock_post_side_effect):
+            messages = [{"role": "user", "content": "Test tool"}]
+            result = await runner._run_conversation(messages)
+
+            # Check that thinking block is prepended
+            content = result["choices"][0]["message"]["content"]
+            assert content.startswith("<thinking>")
+            assert "[Tool: echo]" in content
+            assert "Done" in content  # Final response is after thinking

--- a/tests/session/test_server.py
+++ b/tests/session/test_server.py
@@ -259,20 +259,22 @@ class TestHandleChatCompletionsWithRunner:
                 assert response.content_type == "text/event-stream"
 
     @pytest.mark.asyncio
-    async def test_handle_streaming_with_dict_response(self, config):
-        """Test handling streaming request that returns dict (tool calls involved)."""
+    async def test_handle_streaming_with_tool_calls(self, config):
+        """Test handling streaming request with tool calls (thinking blocks included)."""
         server = SessionServer(config)
 
         runner = SessionRunner(config)
         server.runner = runner
 
-        # process_streaming_request can return dict when tool calls are involved
-        mock_process_streaming_request = AsyncMock(
-            return_value={
-                "choices": [{"message": {"role": "assistant", "content": "Result"}}],
-                "model": "session",
-            }
-        )
+        # process_streaming_request now always returns async generator
+        async def mock_stream_gen():
+            yield 'data: {"choices":[{"delta":{"content":"<thinking>"}}]}\n\n'
+            yield 'data: {"choices":[{"delta":{"content":"[Tool: test]"}}]}\n\n'
+            yield 'data: {"choices":[{"delta":{"content":"</thinking>"}}]}\n\n'
+            yield 'data: {"choices":[{"delta":{"content":"Result"}}]}\n\n'
+            yield "data: [DONE]\n\n"
+
+        mock_process_streaming_request = AsyncMock(return_value=mock_stream_gen())
 
         mock_request = MagicMock()
         mock_request.json = AsyncMock(
@@ -288,5 +290,5 @@ class TestHandleChatCompletionsWithRunner:
             with patch.object(runner, "process_streaming_request", mock_process_streaming_request):
                 response = await server._handle_chat_completions(mock_request)
                 assert response.content_type == "text/event-stream"
-                # Verify write was called with the filtered response
+                # Verify write was called with the streaming content
                 mock_response.write.assert_called()


### PR DESCRIPTION
## Summary

- Add thinking output format with `<thinking>` tags for tool calls
- Session always uses streaming for AI calls internally
- Thinking blocks sent as SSE events immediately after tool execution
- REPL simplified to pure message forwarder (removed `/quit`, `/stream` commands)
- Add `--no-stream` CLI flag for REPL and CLI channels
- Default streaming mode for CLI channel
- Update specs for streaming-ipc, repl-channel, session-core

## Test plan

- [x] Unit tests for `format_thinking_block()` and `format_tool_call_thinking()`
- [x] Tests for thinking content in streaming/non-streaming responses
- [x] Updated REPL tests to remove command-related tests
- [x] All 325 tests pass
- [x] `ruff check` and `ruff format` passed
- [x] `ty check` passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)