### PR TITLE
Add streaming output support for Telegram channel

### DIFF
--- a/openspec/changes/archive/2026-04-30-telegram-streaming/.openspec.yaml
+++ b/openspec/changes/archive/2026-04-30-telegram-streaming/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-30

--- a/openspec/changes/archive/2026-04-30-telegram-streaming/design.md
+++ b/openspec/changes/archive/2026-04-30-telegram-streaming/design.md
@@ -1,0 +1,70 @@
+## Context
+
+Telegram Bot API 支持消息编辑功能（`editMessageText`），可以利用此特性实现流式输出效果。当前 Telegram channel 仅支持非流式模式，等待 session 返回完整响应后一次性发送给用户。
+
+流式输出的挑战：
+- Telegram API 有速率限制（约 30 次/秒），高频编辑可能触发限制
+- LLM 流式输出通常较快（每秒数十个 chunk），直接转发会导致过多 API 调用
+- 需要缓冲机制将多个 chunk 打包，减少编辑次数
+
+参考实现：
+- REPL channel 已实现流式输出，使用 `send_message_stream()` 方法和 SSE 解析
+- CLI 使用 `--no-stream` 开关控制流式模式
+
+## Goals / Non-Goals
+
+**Goals:**
+- 实现流式消息编辑，让用户实时看到 AI 响应生成过程
+- 提供可配置的最小编辑间隔，避免 Telegram API 速率限制
+- 保持与 REPL channel 一致的 CLI 风格
+
+**Non-Goals:**
+- 不改变 session 或 AI 组件的流式协议
+- 不实现消息删除或重新生成功能
+- 不处理 markdown 渲染（Telegram 有自己的解析器）
+
+## Decisions
+
+### 1. 流式缓冲策略
+
+**决定：使用时间窗口缓冲**
+
+维护一个缓冲区，收集流式 chunk，按固定时间间隔（默认 1 秒）批量更新 Telegram 消息。
+
+**理由：**
+- 简单实现，无需复杂的启发式算法
+- 用户可配置间隔，适应不同场景
+- 避免速率限制问题
+
+**替代方案：**
+- 按 chunk 数量触发：难以预测合适的阈值
+- 按 token 边界触发：增加复杂度，收益不明显
+
+### 2. 消息编辑实现
+
+**决定：使用 `python-telegram-bot` 的 `edit_text()` 方法**
+
+在收到第一个 chunk 时发送初始消息，后续 chunk 通过编辑更新。
+
+**理由：**
+- 原生 API 支持，无需额外依赖
+- 与现有代码风格一致
+
+### 3. CLI 参数设计
+
+**决定：与 REPL channel 保持一致**
+
+```bash
+psi-agent channel telegram --token <token> --session-socket <path> [--no-stream] [--stream-interval 1.0]
+```
+
+**理由：**
+- 一致的用户体验
+- `--no-stream` 是否定式开关，默认启用流式
+- `--stream-interval` 使用浮点数，支持亚秒级间隔
+
+## Risks / Trade-offs
+
+- **Telegram API 速率限制** → 设置合理的默认间隔（1 秒），并在文档中说明
+- **消息长度超过 4096 字符** → 复用现有的 `split_message()` 函数，编辑时截断或分多条
+- **网络延迟导致编辑顺序错乱** → 使用 asyncio 保证顺序执行

--- a/openspec/changes/archive/2026-04-30-telegram-streaming/proposal.md
+++ b/openspec/changes/archive/2026-04-30-telegram-streaming/proposal.md
@@ -1,0 +1,28 @@
+## Why
+
+Telegram 消息支持编辑功能，可以利用此特性实现流式输出效果，让用户实时看到 AI 响应的生成过程，提升用户体验。当前 Telegram channel 仅支持等待完整响应后一次性发送，用户需要等待较长时间才能看到任何输出。
+
+## What Changes
+
+- Telegram channel 新增流式输出模式（默认启用），通过编辑消息实现实时更新效果
+- CLI 新增 `--no-stream` 开关用于禁用流式模式
+- CLI 新增 `--stream-interval` 参数控制消息编辑的最小时间间隔（默认 1 秒）
+- Client 新增 `send_message_stream()` 方法支持流式请求和消息编辑
+
+## Capabilities
+
+### New Capabilities
+
+- `telegram-streaming-output`: Telegram channel 流式输出功能，通过消息编辑实现实时响应显示
+
+### Modified Capabilities
+
+- `telegram-channel`: 新增 CLI 参数（`--no-stream`, `--stream-interval`）和流式请求支持
+
+## Impact
+
+- `src/psi_agent/channel/telegram/cli.py` — 新增 `no_stream` 和 `stream_interval` 参数
+- `src/psi_agent/channel/telegram/config.py` — 新增配置字段
+- `src/psi_agent/channel/telegram/client.py` — 新增 `send_message_stream()` 方法
+- `src/psi_agent/channel/telegram/bot.py` — 实现流式消息编辑逻辑
+- `openspec/specs/telegram-channel/spec.md` — 新增流式相关需求

--- a/openspec/changes/archive/2026-04-30-telegram-streaming/specs/telegram-channel/spec.md
+++ b/openspec/changes/archive/2026-04-30-telegram-streaming/specs/telegram-channel/spec.md
@@ -1,0 +1,42 @@
+## ADDED Requirements
+
+### Requirement: Telegram channel CLI supports streaming configuration
+
+The Telegram channel CLI SHALL support streaming mode configuration via command-line arguments.
+
+#### Scenario: Default streaming mode
+- **WHEN** `psi-agent channel telegram --token <token> --session-socket <path>` is invoked
+- **THEN** streaming mode SHALL be enabled by default
+
+#### Scenario: Disable streaming with flag
+- **WHEN** `psi-agent channel telegram --token <token> --session-socket <path> --no-stream` is invoked
+- **THEN** streaming mode SHALL be disabled
+- **AND** the channel SHALL wait for complete response before sending
+
+#### Scenario: Configure stream interval
+- **WHEN** `psi-agent channel telegram --token <token> --session-socket <path> --stream-interval 2.0` is invoked
+- **THEN** the channel SHALL use 2.0 second as the minimum edit interval
+
+#### Scenario: Stream interval is a float
+- **WHEN** `--stream-interval` is specified
+- **THEN** the value SHALL be parsed as a float
+- **AND** support values like 0.5, 1.0, 2.5
+
+### Requirement: Telegram channel client supports streaming requests
+
+The Telegram channel client SHALL provide a streaming method for communicating with psi-session.
+
+#### Scenario: Streaming method sends stream request
+- **WHEN** `send_message_stream()` is called
+- **THEN** the client SHALL send request with `stream: true`
+- **AND** invoke callback for each received chunk
+
+#### Scenario: Non-streaming method sends regular request
+- **WHEN** `send_message()` is called
+- **THEN** the client SHALL send request with `stream: false`
+- **AND** wait for complete response
+
+#### Scenario: Streaming callback receives chunks
+- **WHEN** session returns streaming (SSE) response
+- **THEN** the callback SHALL be invoked for each content chunk
+- **AND** chunks SHALL be passed as strings

--- a/openspec/changes/archive/2026-04-30-telegram-streaming/specs/telegram-streaming-output/spec.md
+++ b/openspec/changes/archive/2026-04-30-telegram-streaming/specs/telegram-streaming-output/spec.md
@@ -1,0 +1,51 @@
+## ADDED Requirements
+
+### Requirement: Telegram channel supports streaming output via message editing
+
+The Telegram channel SHALL support streaming output by editing messages in real-time when streaming mode is enabled.
+
+#### Scenario: Streaming mode enabled by default
+- **WHEN** Telegram channel starts without `--no-stream` flag
+- **THEN** the channel SHALL use streaming mode for message responses
+- **AND** edit messages in real-time as content arrives
+
+#### Scenario: Streaming message editing
+- **WHEN** streaming mode is enabled and a chunk arrives from session
+- **THEN** the channel SHALL edit the previously sent message with new content
+- **AND** accumulate content across multiple edits
+
+#### Scenario: First chunk sends initial message
+- **WHEN** the first streaming chunk arrives
+- **THEN** the channel SHALL send a new message to Telegram
+- **AND** subsequent chunks SHALL edit this message
+
+### Requirement: Telegram channel buffers streaming chunks by time interval
+
+The Telegram channel SHALL buffer streaming chunks and update messages at configurable time intervals to avoid API rate limits.
+
+#### Scenario: Buffer chunks within interval
+- **WHEN** multiple chunks arrive within the configured interval
+- **THEN** the channel SHALL buffer all chunks
+- **AND** send a single edit at the end of the interval
+
+#### Scenario: Default interval is 1 second
+- **WHEN** Telegram channel starts without `--stream-interval` flag
+- **THEN** the channel SHALL use 1.0 second as default interval
+
+#### Scenario: Custom interval configuration
+- **WHEN** Telegram channel starts with `--stream-interval 0.5`
+- **THEN** the channel SHALL use 0.5 second as the update interval
+
+### Requirement: Telegram channel handles long streaming messages
+
+The Telegram channel SHALL handle streaming messages that exceed Telegram's 4096 character limit.
+
+#### Scenario: Message exceeds limit during streaming
+- **WHEN** accumulated streaming content exceeds 4096 characters
+- **THEN** the channel SHALL truncate the displayed message to 4096 characters
+- **AND** send remaining content as a new message when streaming completes
+
+#### Scenario: Final message splitting
+- **WHEN** streaming completes and total content exceeds 4096 characters
+- **THEN** the channel SHALL split the complete content into multiple messages
+- **AND** use existing `split_message()` function for splitting

--- a/openspec/changes/archive/2026-04-30-telegram-streaming/tasks.md
+++ b/openspec/changes/archive/2026-04-30-telegram-streaming/tasks.md
@@ -1,0 +1,28 @@
+## 1. Configuration Updates
+
+- [x] 1.1 Update `TelegramConfig` dataclass to add `stream` (bool, default True) and `stream_interval` (float, default 1.0) fields
+- [x] 1.2 Update `cli.py` to add `--no-stream` and `--stream-interval` CLI arguments following REPL channel pattern
+
+## 2. Client Streaming Support
+
+- [x] 2.1 Add `send_message_stream()` method to `TelegramClient` with SSE parsing (reference `ReplClient.send_message_stream()`)
+- [x] 2.2 Add `on_chunk` callback parameter to `send_message_stream()` for real-time chunk delivery
+
+## 3. Bot Streaming Implementation
+
+- [x] 3.1 Implement streaming message handler in `TelegramBot._handle_message()` that uses `send_message_stream()`
+- [x] 3.2 Implement time-based buffering logic to accumulate chunks and edit messages at configured intervals
+- [x] 3.3 Handle first chunk by sending initial message, subsequent chunks by editing
+- [x] 3.4 Handle message length exceeding 4096 characters during streaming (truncate display, send remainder on completion)
+- [x] 3.5 Implement non-streaming fallback when `--no-stream` is set
+
+## 4. Testing
+
+- [x] 4.1 Add unit tests for `TelegramConfig` with new fields
+- [x] 4.2 Add unit tests for `TelegramClient.send_message_stream()` method
+- [x] 4.3 Add unit tests for streaming buffer logic in `TelegramBot`
+- [x] 4.4 Add integration test for streaming message editing flow
+
+## 5. Documentation
+
+- [x] 5.1 Update `openspec/specs/telegram-channel/spec.md` with new streaming requirements

--- a/openspec/specs/telegram-channel/spec.md
+++ b/openspec/specs/telegram-channel/spec.md
@@ -151,3 +151,94 @@ The Telegram channel CLI SHALL mask the `--token` and `--proxy` arguments from t
 - **WHEN** `psi-channel-telegram` is started with `--proxy socks5://user:pass@host:port`
 - **THEN** the process title SHALL NOT contain the proxy credentials
 - **AND** the process title SHALL show `--proxy ***`
+
+### Requirement: Telegram channel CLI supports streaming configuration
+
+The Telegram channel CLI SHALL support streaming mode configuration via command-line arguments.
+
+#### Scenario: Default streaming mode
+- **WHEN** `psi-agent channel telegram --token <token> --session-socket <path>` is invoked
+- **THEN** streaming mode SHALL be enabled by default
+
+#### Scenario: Disable streaming with flag
+- **WHEN** `psi-agent channel telegram --token <token> --session-socket <path> --no-stream` is invoked
+- **THEN** streaming mode SHALL be disabled
+- **AND** the channel SHALL wait for complete response before sending
+
+#### Scenario: Configure stream interval
+- **WHEN** `psi-agent channel telegram --token <token> --session-socket <path> --stream-interval 2.0` is invoked
+- **THEN** the channel SHALL use 2.0 second as the minimum edit interval
+
+#### Scenario: Stream interval is a float
+- **WHEN** `--stream-interval` is specified
+- **THEN** the value SHALL be parsed as a float
+- **AND** support values like 0.5, 1.0, 2.5
+
+### Requirement: Telegram channel supports streaming output via message editing
+
+The Telegram channel SHALL support streaming output by editing messages in real-time when streaming mode is enabled.
+
+#### Scenario: Streaming mode enabled by default
+- **WHEN** Telegram channel starts without `--no-stream` flag
+- **THEN** the channel SHALL use streaming mode for message responses
+- **AND** edit messages in real-time as content arrives
+
+#### Scenario: Streaming message editing
+- **WHEN** streaming mode is enabled and a chunk arrives from session
+- **THEN** the channel SHALL edit the previously sent message with new content
+- **AND** accumulate content across multiple edits
+
+#### Scenario: First chunk sends initial message
+- **WHEN** the first streaming chunk arrives
+- **THEN** the channel SHALL send a new message to Telegram
+- **AND** subsequent chunks SHALL edit this message
+
+### Requirement: Telegram channel buffers streaming chunks by time interval
+
+The Telegram channel SHALL buffer streaming chunks and update messages at configurable time intervals to avoid API rate limits.
+
+#### Scenario: Buffer chunks within interval
+- **WHEN** multiple chunks arrive within the configured interval
+- **THEN** the channel SHALL buffer all chunks
+- **AND** send a single edit at the end of the interval
+
+#### Scenario: Default interval is 1 second
+- **WHEN** Telegram channel starts without `--stream-interval` flag
+- **THEN** the channel SHALL use 1.0 second as default interval
+
+#### Scenario: Custom interval configuration
+- **WHEN** Telegram channel starts with `--stream-interval 0.5`
+- **THEN** the channel SHALL use 0.5 second as the update interval
+
+### Requirement: Telegram channel handles long streaming messages
+
+The Telegram channel SHALL handle streaming messages that exceed Telegram's 4096 character limit.
+
+#### Scenario: Message exceeds limit during streaming
+- **WHEN** accumulated streaming content exceeds 4096 characters
+- **THEN** the channel SHALL truncate the displayed message to 4096 characters
+- **AND** send remaining content as a new message when streaming completes
+
+#### Scenario: Final message splitting
+- **WHEN** streaming completes and total content exceeds 4096 characters
+- **THEN** the channel SHALL split the complete content into multiple messages
+- **AND** use existing `split_message()` function for splitting
+
+### Requirement: Telegram channel client supports streaming requests
+
+The Telegram channel client SHALL provide a streaming method for communicating with psi-session.
+
+#### Scenario: Streaming method sends stream request
+- **WHEN** `send_message_stream()` is called
+- **THEN** the client SHALL send request with `stream: true`
+- **AND** invoke callback for each received chunk
+
+#### Scenario: Non-streaming method sends regular request
+- **WHEN** `send_message()` is called
+- **THEN** the client SHALL send request with `stream: false`
+- **AND** wait for complete response
+
+#### Scenario: Streaming callback receives chunks
+- **WHEN** session returns streaming (SSE) response
+- **THEN** the callback SHALL be invoked for each content chunk
+- **AND** chunks SHALL be passed as strings

--- a/openspec/specs/telegram-streaming-output/spec.md
+++ b/openspec/specs/telegram-streaming-output/spec.md
@@ -1,0 +1,51 @@
+## ADDED Requirements
+
+### Requirement: Telegram channel supports streaming output via message editing
+
+The Telegram channel SHALL support streaming output by editing messages in real-time when streaming mode is enabled.
+
+#### Scenario: Streaming mode enabled by default
+- **WHEN** Telegram channel starts without `--no-stream` flag
+- **THEN** the channel SHALL use streaming mode for message responses
+- **AND** edit messages in real-time as content arrives
+
+#### Scenario: Streaming message editing
+- **WHEN** streaming mode is enabled and a chunk arrives from session
+- **THEN** the channel SHALL edit the previously sent message with new content
+- **AND** accumulate content across multiple edits
+
+#### Scenario: First chunk sends initial message
+- **WHEN** the first streaming chunk arrives
+- **THEN** the channel SHALL send a new message to Telegram
+- **AND** subsequent chunks SHALL edit this message
+
+### Requirement: Telegram channel buffers streaming chunks by time interval
+
+The Telegram channel SHALL buffer streaming chunks and update messages at configurable time intervals to avoid API rate limits.
+
+#### Scenario: Buffer chunks within interval
+- **WHEN** multiple chunks arrive within the configured interval
+- **THEN** the channel SHALL buffer all chunks
+- **AND** send a single edit at the end of the interval
+
+#### Scenario: Default interval is 1 second
+- **WHEN** Telegram channel starts without `--stream-interval` flag
+- **THEN** the channel SHALL use 1.0 second as default interval
+
+#### Scenario: Custom interval configuration
+- **WHEN** Telegram channel starts with `--stream-interval 0.5`
+- **THEN** the channel SHALL use 0.5 second as the update interval
+
+### Requirement: Telegram channel handles long streaming messages
+
+The Telegram channel SHALL handle streaming messages that exceed Telegram's 4096 character limit.
+
+#### Scenario: Message exceeds limit during streaming
+- **WHEN** accumulated streaming content exceeds 4096 characters
+- **THEN** the channel SHALL truncate the displayed message to 4096 characters
+- **AND** send remaining content as a new message when streaming completes
+
+#### Scenario: Final message splitting
+- **WHEN** streaming completes and total content exceeds 4096 characters
+- **THEN** the channel SHALL split the complete content into multiple messages
+- **AND** use existing `split_message()` function for splitting

--- a/src/psi_agent/channel/telegram/bot.py
+++ b/src/psi_agent/channel/telegram/bot.py
@@ -138,7 +138,25 @@ class TelegramBot:
 
         logger.info(f"Received message from {user_id}: {message_text[:50]}...")
 
-        # Forward to session
+        # Use streaming or non-streaming based on config
+        if self.config.stream:
+            await self._handle_message_streaming(update, user_id, message_text)
+        else:
+            await self._handle_message_non_streaming(update, user_id, message_text)
+
+    async def _handle_message_non_streaming(
+        self, update: Update, user_id: str, message_text: str
+    ) -> None:
+        """Handle message with non-streaming response.
+
+        Args:
+            update: The Telegram update.
+            user_id: The user identifier.
+            message_text: The message text.
+        """
+        if update.message is None:
+            return
+
         response = await self.client.send_message(message_text, user_id)
 
         # Split and send response
@@ -149,3 +167,96 @@ class TelegramBot:
             except Exception as e:
                 logger.error(f"Failed to send message: {e}")
                 break
+
+    async def _handle_message_streaming(
+        self, update: Update, user_id: str, message_text: str
+    ) -> None:
+        """Handle message with streaming response using message editing.
+
+        Args:
+            update: The Telegram update.
+            user_id: The user identifier.
+            message_text: The message text.
+        """
+        # Buffer for accumulating content
+        content_buffer: list[str] = []
+        last_edit_time: float = 0.0
+        sent_message: Any = None
+        edit_task: asyncio.Task[None] | None = None
+
+        async def edit_message() -> None:
+            """Edit the sent message with current buffer content."""
+            nonlocal last_edit_time
+
+            if sent_message is None:
+                return
+
+            current_content = "".join(content_buffer)
+            # Truncate if exceeds limit during streaming
+            display_content = current_content[:TELEGRAM_MAX_MESSAGE_LENGTH]
+
+            try:
+                await sent_message.edit_text(display_content)
+                last_edit_time = asyncio.get_running_loop().time()
+            except Exception as e:
+                logger.error(f"Failed to edit message: {e}")
+
+        def on_chunk(chunk: str) -> None:
+            """Callback for each streaming chunk."""
+            nonlocal edit_task
+
+            content_buffer.append(chunk)
+
+            # Check if we should schedule an edit
+            current_time = asyncio.get_running_loop().time()
+            time_since_last_edit = current_time - last_edit_time
+
+            if time_since_last_edit >= self.config.stream_interval and (
+                edit_task is None or edit_task.done()
+            ):
+                # Schedule edit task
+                edit_task = asyncio.create_task(edit_message())
+
+        # Send initial message placeholder
+        if update.message is None:
+            return
+
+        try:
+            sent_message = await update.message.reply_text("...")
+        except Exception as e:
+            logger.error(f"Failed to send initial message: {e}")
+            return
+
+        # Get streaming response
+        response = await self.client.send_message_stream(message_text, user_id, on_chunk)
+
+        # Final edit with complete content
+        final_content = "".join(content_buffer) if content_buffer else response
+
+        # Wait for any pending edit task
+        if edit_task is not None and not edit_task.done():
+            await edit_task
+
+        # Handle message splitting if content exceeds limit
+        if len(final_content) > TELEGRAM_MAX_MESSAGE_LENGTH:
+            # Edit first message with truncated content
+            try:
+                await sent_message.edit_text(final_content[:TELEGRAM_MAX_MESSAGE_LENGTH])
+            except Exception as e:
+                logger.error(f"Failed to edit final message: {e}")
+
+            # Send remaining content as new messages
+            chunks = split_message(final_content)
+            assert update.message is not None
+            for chunk in chunks[1:]:  # Skip first chunk (already sent)
+                try:
+                    await update.message.reply_text(chunk)
+                except Exception as e:
+                    logger.error(f"Failed to send additional message: {e}")
+                    break
+        else:
+            # Edit with complete content
+            try:
+                await sent_message.edit_text(final_content)
+            except Exception as e:
+                logger.error(f"Failed to edit final message: {e}")

--- a/src/psi_agent/channel/telegram/cli.py
+++ b/src/psi_agent/channel/telegram/cli.py
@@ -22,21 +22,33 @@ class Telegram:
         session_socket: Path to the Unix socket for communication with psi-session.
         proxy: Optional proxy URL for connecting to Telegram API. Supports socks5://,
             http://, and https:// formats. Defaults to None (direct connection).
+        no_stream: Disable streaming mode (default: streaming enabled).
+        stream_interval: Minimum time interval (in seconds) between message edits
+            when streaming. Defaults to 1.0.
     """
 
     token: str
     session_socket: str
     proxy: str | None = None
+    no_stream: bool = False
+    stream_interval: float = 1.0
 
     def __call__(self) -> None:
         # Mask sensitive arguments from process title
         mask_sensitive_args(["token", "proxy"])
 
         logger.info("Starting psi-channel-telegram")
-        logger.debug(f"Config: session_socket={self.session_socket}")
+        logger.debug(
+            f"Config: session_socket={self.session_socket}, stream={not self.no_stream}, "
+            f"stream_interval={self.stream_interval}"
+        )
 
         config = TelegramConfig(
-            token=self.token, session_socket=self.session_socket, proxy=self.proxy
+            token=self.token,
+            session_socket=self.session_socket,
+            proxy=self.proxy,
+            stream=not self.no_stream,
+            stream_interval=self.stream_interval,
         )
         bot = TelegramBot(config)
 

--- a/src/psi_agent/channel/telegram/client.py
+++ b/src/psi_agent/channel/telegram/client.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+from collections.abc import Callable
 from typing import Any
 
 import aiohttp
@@ -88,6 +89,81 @@ class TelegramClient:
                 content = msg.get("content", "")
                 logger.debug(f"Received response: {content[:100]}...")
                 return content
+
+        except aiohttp.ClientConnectorError as e:
+            logger.error(f"Failed to connect to session: {e}")
+            return f"Error: Failed to connect to session at {self.config.session_socket}"
+        except aiohttp.ClientError as e:
+            logger.error(f"Request failed: {e}")
+            return f"Error: Request failed - {e}"
+        except TimeoutError:
+            logger.error("Request timeout")
+            return "Error: Request timeout"
+
+    async def send_message_stream(
+        self,
+        message: str,
+        user_id: str,
+        on_chunk: Callable[[str], None] | None = None,
+    ) -> str:
+        """Send a message to psi-session with streaming response.
+
+        Args:
+            message: The user message string to send.
+            user_id: The Telegram user identifier (format: telegram:<id>).
+            on_chunk: Optional callback invoked for each content chunk.
+
+        Returns:
+            The complete assistant's response content.
+
+        Raises:
+            RuntimeError: If client is not initialized.
+        """
+        if self._session is None:
+            raise RuntimeError("Client not initialized. Use async context manager.")
+
+        url = "http://localhost/v1/chat/completions"
+        headers = {"Content-Type": "application/json"}
+        body = {
+            "model": "session",
+            "messages": [{"role": "user", "content": message}],
+            "user": user_id,
+            "stream": True,
+        }
+        logger.debug(f"Request body: {json.dumps(body, ensure_ascii=False, indent=2)}")
+
+        logger.debug(f"Sending streaming message to session for user {user_id}")
+
+        try:
+            async with self._session.post(url, headers=headers, json=body) as response:
+                if response.status != 200:
+                    text = await response.text()
+                    logger.error(f"Session returned status {response.status}: {text}")
+                    return f"Error: Session returned status {response.status}"
+
+                # Parse SSE stream
+                content_chunks: list[str] = []
+                async for line in response.content:
+                    line_str = line.decode().strip()
+                    if not line_str or line_str == "data: [DONE]":
+                        continue
+                    if line_str.startswith("data: "):
+                        try:
+                            chunk = json.loads(line_str[6:])
+                            choices = chunk.get("choices", [])
+                            if choices:
+                                delta = choices[0].get("delta", {})
+                                content = delta.get("content", "")
+                                if content:
+                                    content_chunks.append(content)
+                                    if on_chunk is not None:
+                                        on_chunk(content)
+                        except json.JSONDecodeError:
+                            pass
+
+                full_content = "".join(content_chunks)
+                logger.debug(f"Received complete streaming response: {full_content[:100]}...")
+                return full_content
 
         except aiohttp.ClientConnectorError as e:
             logger.error(f"Failed to connect to session: {e}")

--- a/src/psi_agent/channel/telegram/config.py
+++ b/src/psi_agent/channel/telegram/config.py
@@ -16,11 +16,17 @@ class TelegramConfig:
         session_socket: Path to the Unix socket for communication with psi-session.
         proxy: Optional proxy URL for connecting to Telegram API. Supports socks5://,
             http://, and https:// formats. Defaults to None (direct connection).
+        stream: Enable streaming mode for real-time message updates via editing.
+            Defaults to True.
+        stream_interval: Minimum time interval (in seconds) between message edits
+            when streaming. Helps avoid Telegram API rate limits. Defaults to 1.0.
     """
 
     token: str
     session_socket: str
     proxy: str | None = None
+    stream: bool = True
+    stream_interval: float = 1.0
 
     def socket_path(self) -> anyio.Path:
         """Get the socket path as a Path object."""

--- a/tests/channel/telegram/test_bot_streaming.py
+++ b/tests/channel/telegram/test_bot_streaming.py
@@ -1,0 +1,403 @@
+"""Tests for TelegramBot streaming logic."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from psi_agent.channel.telegram.bot import TelegramBot, split_message
+from psi_agent.channel.telegram.config import TelegramConfig
+
+
+@pytest.fixture
+def config():
+    """Create test config with streaming enabled."""
+    return TelegramConfig(
+        token="test-token", session_socket="/tmp/test.sock", stream=True, stream_interval=1.0
+    )
+
+
+@pytest.fixture
+def config_no_stream():
+    """Create test config with streaming disabled."""
+    return TelegramConfig(token="test-token", session_socket="/tmp/test.sock", stream=False)
+
+
+class TestSplitMessage:
+    """Tests for split_message function."""
+
+    def test_short_message(self):
+        """Test short message is not split."""
+        result = split_message("Hello")
+        assert result == ["Hello"]
+
+    def test_exact_limit(self):
+        """Test message at exact limit is not split."""
+        text = "a" * 4096
+        result = split_message(text)
+        assert result == [text]
+
+    def test_over_limit(self):
+        """Test message over limit is split."""
+        text = "a" * 5000
+        result = split_message(text)
+        assert len(result) == 2
+        assert len(result[0]) <= 4096
+        assert "".join(result) == text
+
+    def test_split_at_newline(self):
+        """Test split prefers newline boundary when possible."""
+        # Create text where newline is in a good position for splitting
+        text = "a" * 2000 + "\n" + "b" * 3000
+        result = split_message(text)
+        # The split should happen at or near the newline
+        assert len(result) == 2
+        assert "".join(result) == text
+
+
+class TestTelegramBotStreaming:
+    """Tests for TelegramBot streaming behavior."""
+
+    def test_bot_creation_with_streaming(self, config):
+        """Test bot can be created with streaming config."""
+        bot = TelegramBot(config)
+        assert bot.config.stream is True
+        assert bot.config.stream_interval == 1.0
+
+    def test_bot_creation_without_streaming(self, config_no_stream):
+        """Test bot can be created with streaming disabled."""
+        bot = TelegramBot(config_no_stream)
+        assert bot.config.stream is False
+
+    @pytest.mark.asyncio
+    async def test_non_streaming_handler(self, config_no_stream):
+        """Test non-streaming handler sends message correctly."""
+        bot = TelegramBot(config_no_stream)
+
+        # Mock update and message
+        mock_message = AsyncMock()
+        mock_message.text = "Hello"
+        mock_message.reply_text = AsyncMock()
+
+        mock_update = MagicMock()
+        mock_update.message = mock_message
+        mock_update.effective_user = MagicMock(id=123)
+
+        # Mock client response
+        with patch.object(bot.client, "send_message", AsyncMock(return_value="Test response")):
+            async with bot.client:
+                await bot._handle_message_non_streaming(mock_update, "telegram:123", "Hello")
+
+        mock_message.reply_text.assert_called_once_with("Test response")
+
+    @pytest.mark.asyncio
+    async def test_non_streaming_handler_splits_long_message(self, config_no_stream):
+        """Test non-streaming handler splits long messages."""
+        bot = TelegramBot(config_no_stream)
+
+        mock_message = AsyncMock()
+        mock_message.text = "Hello"
+        mock_message.reply_text = AsyncMock()
+
+        mock_update = MagicMock()
+        mock_update.message = mock_message
+        mock_update.effective_user = MagicMock(id=123)
+
+        long_response = "a" * 5000
+        with patch.object(bot.client, "send_message", AsyncMock(return_value=long_response)):
+            async with bot.client:
+                await bot._handle_message_non_streaming(mock_update, "telegram:123", "Hello")
+
+        # Should be called twice for split message
+        assert mock_message.reply_text.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_streaming_handler_sends_initial_message(self, config):
+        """Test streaming handler sends initial placeholder message."""
+        bot = TelegramBot(config)
+
+        mock_message = AsyncMock()
+        mock_message.text = "Hello"
+        mock_message.reply_text = AsyncMock()
+
+        mock_sent_message = AsyncMock()
+        mock_sent_message.edit_text = AsyncMock()
+        mock_message.reply_text.return_value = mock_sent_message
+
+        mock_update = MagicMock()
+        mock_update.message = mock_message
+        mock_update.effective_user = MagicMock(id=123)
+
+        # Mock streaming response
+        async def mock_stream(_message: str, _user_id: str, on_chunk) -> str:
+            on_chunk("Test")
+            return "Test"
+
+        with patch.object(bot.client, "send_message_stream", mock_stream):
+            async with bot.client:
+                await bot._handle_message_streaming(mock_update, "telegram:123", "Hello")
+
+        # Initial message should be sent
+        mock_message.reply_text.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_streaming_handler_edits_message(self, config):
+        """Test streaming handler edits message with content."""
+        bot = TelegramBot(config)
+
+        mock_message = AsyncMock()
+        mock_message.text = "Hello"
+        mock_message.reply_text = AsyncMock()
+
+        mock_sent_message = AsyncMock()
+        mock_sent_message.edit_text = AsyncMock()
+        mock_message.reply_text.return_value = mock_sent_message
+
+        mock_update = MagicMock()
+        mock_update.message = mock_message
+        mock_update.effective_user = MagicMock(id=123)
+
+        # Mock streaming response
+        async def mock_stream(_message: str, _user_id: str, on_chunk) -> str:
+            on_chunk("Hello ")
+            on_chunk("world")
+            return "Hello world"
+
+        with patch.object(bot.client, "send_message_stream", mock_stream):
+            async with bot.client:
+                await bot._handle_message_streaming(mock_update, "telegram:123", "Hello")
+
+        # Final edit should be called
+        mock_sent_message.edit_text.assert_called()
+
+    @pytest.mark.asyncio
+    async def test_handle_message_none_message(self, config):
+        """Test _handle_message returns early when message is None."""
+        bot = TelegramBot(config)
+
+        mock_update = MagicMock()
+        mock_update.message = None
+        mock_update.effective_user = MagicMock(id=123)
+
+        # Should return early without error
+        await bot._handle_message(mock_update, MagicMock())
+
+    @pytest.mark.asyncio
+    async def test_handle_message_none_text(self, config):
+        """Test _handle_message returns early when message text is None."""
+        bot = TelegramBot(config)
+
+        mock_message = MagicMock()
+        mock_message.text = None
+
+        mock_update = MagicMock()
+        mock_update.message = mock_message
+        mock_update.effective_user = MagicMock(id=123)
+
+        # Should return early without error
+        await bot._handle_message(mock_update, MagicMock())
+
+    @pytest.mark.asyncio
+    async def test_handle_message_none_user(self, config):
+        """Test _handle_message returns early when user is None."""
+        bot = TelegramBot(config)
+
+        mock_message = MagicMock()
+        mock_message.text = "Hello"
+
+        mock_update = MagicMock()
+        mock_update.message = mock_message
+        mock_update.effective_user = None
+
+        # Should return early without error
+        await bot._handle_message(mock_update, MagicMock())
+
+    @pytest.mark.asyncio
+    async def test_handle_message_routes_to_streaming(self, config):
+        """Test _handle_message routes to streaming handler when stream is True."""
+        bot = TelegramBot(config)
+
+        mock_message = AsyncMock()
+        mock_message.text = "Hello"
+
+        mock_update = MagicMock()
+        mock_update.message = mock_message
+        mock_update.effective_user = MagicMock(id=123)
+
+        # Patch both handlers to track which is called
+        with (
+            patch.object(bot, "_handle_message_streaming", AsyncMock()) as mock_streaming,
+            patch.object(bot, "_handle_message_non_streaming", AsyncMock()),
+        ):
+            await bot._handle_message(mock_update, MagicMock())
+            mock_streaming.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_handle_message_routes_to_non_streaming(self, config_no_stream):
+        """Test _handle_message routes to non-streaming handler when stream is False."""
+        bot = TelegramBot(config_no_stream)
+
+        mock_message = AsyncMock()
+        mock_message.text = "Hello"
+
+        mock_update = MagicMock()
+        mock_update.message = mock_message
+        mock_update.effective_user = MagicMock(id=123)
+
+        # Patch both handlers to track which is called
+        with (
+            patch.object(bot, "_handle_message_streaming", AsyncMock()),
+            patch.object(bot, "_handle_message_non_streaming", AsyncMock()) as mock_non_streaming,
+        ):
+            await bot._handle_message(mock_update, MagicMock())
+            mock_non_streaming.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_start_command_with_user(self, config):
+        """Test _start_command logs user ID."""
+        bot = TelegramBot(config)
+
+        mock_update = MagicMock()
+        mock_update.effective_user = MagicMock(id=123)
+
+        # Should not raise error
+        await bot._start_command(mock_update, MagicMock())
+
+    @pytest.mark.asyncio
+    async def test_start_command_without_user(self, config):
+        """Test _start_command handles missing user."""
+        bot = TelegramBot(config)
+
+        mock_update = MagicMock()
+        mock_update.effective_user = None
+
+        # Should not raise error
+        await bot._start_command(mock_update, MagicMock())
+
+    @pytest.mark.asyncio
+    async def test_streaming_handler_send_initial_fails(self, config):
+        """Test streaming handler handles failure to send initial message."""
+        bot = TelegramBot(config)
+
+        mock_message = AsyncMock()
+        mock_message.text = "Hello"
+        mock_message.reply_text = AsyncMock(side_effect=Exception("Network error"))
+
+        mock_update = MagicMock()
+        mock_update.message = mock_message
+        mock_update.effective_user = MagicMock(id=123)
+
+        # Should return early without error
+        async with bot.client:
+            await bot._handle_message_streaming(mock_update, "telegram:123", "Hello")
+
+    @pytest.mark.asyncio
+    async def test_streaming_handler_long_message_split(self, config):
+        """Test streaming handler splits long messages."""
+        bot = TelegramBot(config)
+
+        mock_message = AsyncMock()
+        mock_message.text = "Hello"
+        mock_message.reply_text = AsyncMock()
+
+        mock_sent_message = AsyncMock()
+        mock_sent_message.edit_text = AsyncMock()
+        mock_message.reply_text.return_value = mock_sent_message
+
+        mock_update = MagicMock()
+        mock_update.message = mock_message
+        mock_update.effective_user = MagicMock(id=123)
+
+        # Mock streaming response with long content
+        long_content = "a" * 5000
+
+        async def mock_stream(_message: str, _user_id: str, on_chunk) -> str:
+            on_chunk(long_content)
+            return long_content
+
+        with patch.object(bot.client, "send_message_stream", mock_stream):
+            async with bot.client:
+                await bot._handle_message_streaming(mock_update, "telegram:123", "Hello")
+
+        # Should send initial message + one additional message for overflow
+        assert mock_message.reply_text.call_count >= 1
+
+    @pytest.mark.asyncio
+    async def test_streaming_handler_edit_fails(self, config):
+        """Test streaming handler handles edit failure gracefully."""
+        bot = TelegramBot(config)
+
+        mock_message = AsyncMock()
+        mock_message.text = "Hello"
+        mock_message.reply_text = AsyncMock()
+
+        mock_sent_message = AsyncMock()
+        mock_sent_message.edit_text = AsyncMock(side_effect=Exception("Edit failed"))
+        mock_message.reply_text.return_value = mock_sent_message
+
+        mock_update = MagicMock()
+        mock_update.message = mock_message
+        mock_update.effective_user = MagicMock(id=123)
+
+        async def mock_stream(_message: str, _user_id: str, on_chunk) -> str:
+            on_chunk("Test")
+            return "Test"
+
+        with patch.object(bot.client, "send_message_stream", mock_stream):
+            async with bot.client:
+                # Should not raise error
+                await bot._handle_message_streaming(mock_update, "telegram:123", "Hello")
+
+    @pytest.mark.asyncio
+    async def test_non_streaming_handler_send_fails(self, config_no_stream):
+        """Test non-streaming handler handles send failure."""
+        bot = TelegramBot(config_no_stream)
+
+        mock_message = AsyncMock()
+        mock_message.text = "Hello"
+        mock_message.reply_text = AsyncMock(side_effect=Exception("Send failed"))
+
+        mock_update = MagicMock()
+        mock_update.message = mock_message
+        mock_update.effective_user = MagicMock(id=123)
+
+        with patch.object(bot.client, "send_message", AsyncMock(return_value="Test response")):
+            async with bot.client:
+                await bot._handle_message_non_streaming(mock_update, "telegram:123", "Hello")
+
+        # Should have attempted to send once
+        mock_message.reply_text.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_non_streaming_handler_none_message(self, config_no_stream):
+        """Test non-streaming handler returns early when message is None."""
+        bot = TelegramBot(config_no_stream)
+
+        mock_update = MagicMock()
+        mock_update.message = None
+
+        async with bot.client:
+            await bot._handle_message_non_streaming(mock_update, "telegram:123", "Hello")
+
+    @pytest.mark.asyncio
+    async def test_bot_with_proxy(self):
+        """Test bot creation with proxy configuration."""
+        config = TelegramConfig(
+            token="test-token",
+            session_socket="/tmp/test.sock",
+            proxy="socks5://user:pass@proxy.example.com:1080",
+        )
+        bot = TelegramBot(config)
+        assert bot.config.proxy == "socks5://user:pass@proxy.example.com:1080"
+
+    @pytest.mark.asyncio
+    async def test_bot_with_proxy_no_auth(self):
+        """Test bot creation with proxy without credentials."""
+        config = TelegramConfig(
+            token="test-token",
+            session_socket="/tmp/test.sock",
+            proxy="socks5://proxy.example.com:1080",
+        )
+        bot = TelegramBot(config)
+        assert bot.config.proxy == "socks5://proxy.example.com:1080"

--- a/tests/channel/telegram/test_cli.py
+++ b/tests/channel/telegram/test_cli.py
@@ -58,3 +58,33 @@ def test_telegram_cli_with_proxy_auth():
     )
 
     assert cli.proxy == "socks5://user:password@proxy.example.com:1080"
+
+
+def test_telegram_cli_streaming_defaults():
+    """Test Telegram CLI streaming defaults to enabled."""
+    cli = Telegram(token="test-token", session_socket="/tmp/test.sock")
+
+    assert cli.no_stream is False
+    assert cli.stream_interval == 1.0
+
+
+def test_telegram_cli_no_stream_flag():
+    """Test Telegram CLI with --no-stream flag."""
+    cli = Telegram(token="test-token", session_socket="/tmp/test.sock", no_stream=True)
+
+    assert cli.no_stream is True
+
+
+def test_telegram_cli_custom_stream_interval():
+    """Test Telegram CLI with custom stream interval."""
+    cli = Telegram(token="test-token", session_socket="/tmp/test.sock", stream_interval=0.5)
+
+    assert cli.stream_interval == 0.5
+
+
+def test_telegram_cli_main():
+    """Test main entry point creates CLI."""
+    from psi_agent.channel.telegram.cli import main
+
+    # Just verify it's callable
+    assert callable(main)

--- a/tests/channel/telegram/test_client.py
+++ b/tests/channel/telegram/test_client.py
@@ -100,3 +100,221 @@ class TestTelegramClient:
 
             assert result.startswith("Error:")
             assert "No response" in result
+
+    @pytest.mark.asyncio
+    async def test_send_message_stream_without_context(self, client):
+        """Test send_message_stream raises error without context."""
+        with pytest.raises(RuntimeError, match="not initialized"):
+            await client.send_message_stream("test", "telegram:123")
+
+    @pytest.mark.asyncio
+    async def test_send_message_stream_success(self, client):
+        """Test send_message_stream sends correct request and parses SSE."""
+        # Mock SSE response
+        sse_lines = [
+            b'data: {"choices": [{"delta": {"content": "Hello"}}]}',
+            b'data: {"choices": [{"delta": {"content": " world"}}]}',
+            b"data: [DONE]",
+        ]
+
+        # Create async iterator
+        async def async_iter():
+            for line in sse_lines:
+                yield line
+
+        mock_response = AsyncMock()
+        mock_response.status = 200
+        mock_response.content = async_iter()
+
+        chunks_received: list[str] = []
+
+        def on_chunk(chunk: str) -> None:
+            chunks_received.append(chunk)
+
+        async with client:
+            client._session.post = MagicMock(
+                return_value=AsyncMock(__aenter__=AsyncMock(return_value=mock_response))
+            )
+
+            result = await client.send_message_stream("Hi", "telegram:123", on_chunk)
+
+            assert result == "Hello world"
+            assert chunks_received == ["Hello", " world"]
+
+    @pytest.mark.asyncio
+    async def test_send_message_stream_error_status(self, client):
+        """Test send_message_stream handles error status."""
+        mock_response = AsyncMock()
+        mock_response.status = 500
+        mock_response.text = AsyncMock(return_value="Internal error")
+
+        async with client:
+            client._session.post = MagicMock(
+                return_value=AsyncMock(__aenter__=AsyncMock(return_value=mock_response))
+            )
+
+            result = await client.send_message_stream("Hi", "telegram:123")
+
+            assert result.startswith("Error:")
+            assert "500" in result
+
+    @pytest.mark.asyncio
+    async def test_send_message_stream_without_callback(self, client):
+        """Test send_message_stream works without callback."""
+        sse_lines = [
+            b'data: {"choices": [{"delta": {"content": "Test"}}]}',
+            b"data: [DONE]",
+        ]
+
+        # Create async iterator
+        async def async_iter():
+            for line in sse_lines:
+                yield line
+
+        mock_response = AsyncMock()
+        mock_response.status = 200
+        mock_response.content = async_iter()
+
+        async with client:
+            client._session.post = MagicMock(
+                return_value=AsyncMock(__aenter__=AsyncMock(return_value=mock_response))
+            )
+
+            result = await client.send_message_stream("Hi", "telegram:123")
+
+            assert result == "Test"
+
+    @pytest.mark.asyncio
+    async def test_send_message_connection_error(self, client):
+        """Test send_message handles connection error."""
+        import aiohttp
+
+        async with client:
+            client._session.post = MagicMock(
+                side_effect=aiohttp.ClientConnectorError(
+                    MagicMock(), MagicMock(connection_key="test")
+                )
+            )
+
+            result = await client.send_message("Hello", "telegram:123")
+
+            assert result.startswith("Error:")
+            assert "connect" in result.lower()
+
+    @pytest.mark.asyncio
+    async def test_send_message_client_error(self, client):
+        """Test send_message handles generic client error."""
+        import aiohttp
+
+        async with client:
+            client._session.post = MagicMock(side_effect=aiohttp.ClientError("Network error"))
+
+            result = await client.send_message("Hello", "telegram:123")
+
+            assert result.startswith("Error:")
+            assert "failed" in result.lower()
+
+    @pytest.mark.asyncio
+    async def test_send_message_timeout(self, client):
+        """Test send_message handles timeout."""
+        async with client:
+            client._session.post = MagicMock(side_effect=TimeoutError())
+
+            result = await client.send_message("Hello", "telegram:123")
+
+            assert result.startswith("Error:")
+            assert "timeout" in result.lower()
+
+    @pytest.mark.asyncio
+    async def test_send_message_stream_connection_error(self, client):
+        """Test send_message_stream handles connection error."""
+        import aiohttp
+
+        async with client:
+            client._session.post = MagicMock(
+                side_effect=aiohttp.ClientConnectorError(
+                    MagicMock(), MagicMock(connection_key="test")
+                )
+            )
+
+            result = await client.send_message_stream("Hi", "telegram:123")
+
+            assert result.startswith("Error:")
+            assert "connect" in result.lower()
+
+    @pytest.mark.asyncio
+    async def test_send_message_stream_client_error(self, client):
+        """Test send_message_stream handles generic client error."""
+        import aiohttp
+
+        async with client:
+            client._session.post = MagicMock(side_effect=aiohttp.ClientError("Network error"))
+
+            result = await client.send_message_stream("Hi", "telegram:123")
+
+            assert result.startswith("Error:")
+            assert "failed" in result.lower()
+
+    @pytest.mark.asyncio
+    async def test_send_message_stream_timeout(self, client):
+        """Test send_message_stream handles timeout."""
+        async with client:
+            client._session.post = MagicMock(side_effect=TimeoutError())
+
+            result = await client.send_message_stream("Hi", "telegram:123")
+
+            assert result.startswith("Error:")
+            assert "timeout" in result.lower()
+
+    @pytest.mark.asyncio
+    async def test_send_message_stream_invalid_json(self, client):
+        """Test send_message_stream handles invalid JSON in SSE."""
+        sse_lines = [
+            b"data: invalid json",
+            b"data: [DONE]",
+        ]
+
+        async def async_iter():
+            for line in sse_lines:
+                yield line
+
+        mock_response = AsyncMock()
+        mock_response.status = 200
+        mock_response.content = async_iter()
+
+        async with client:
+            client._session.post = MagicMock(
+                return_value=AsyncMock(__aenter__=AsyncMock(return_value=mock_response))
+            )
+
+            result = await client.send_message_stream("Hi", "telegram:123")
+
+            # Should return empty string since no valid content was parsed
+            assert result == ""
+
+    @pytest.mark.asyncio
+    async def test_send_message_stream_empty_lines(self, client):
+        """Test send_message_stream skips empty lines."""
+        sse_lines = [
+            b"",
+            b'data: {"choices": [{"delta": {"content": "Test"}}]}',
+            b"",
+            b"data: [DONE]",
+        ]
+
+        async def async_iter():
+            for line in sse_lines:
+                yield line
+
+        mock_response = AsyncMock()
+        mock_response.status = 200
+        mock_response.content = async_iter()
+
+        async with client:
+            client._session.post = MagicMock(
+                return_value=AsyncMock(__aenter__=AsyncMock(return_value=mock_response))
+            )
+
+            result = await client.send_message_stream("Hi", "telegram:123")
+
+            assert result == "Test"

--- a/tests/channel/telegram/test_config.py
+++ b/tests/channel/telegram/test_config.py
@@ -63,3 +63,33 @@ def test_telegram_config_with_proxy_auth():
     )
 
     assert config.proxy == "socks5://user:password@proxy.example.com:1080"
+
+
+def test_telegram_config_stream_default_true():
+    """Test TelegramConfig stream defaults to True."""
+    config = TelegramConfig(token="test-token", session_socket="/tmp/test.sock")
+
+    assert config.stream is True
+
+
+def test_telegram_config_stream_interval_default():
+    """Test TelegramConfig stream_interval defaults to 1.0."""
+    config = TelegramConfig(token="test-token", session_socket="/tmp/test.sock")
+
+    assert config.stream_interval == 1.0
+
+
+def test_telegram_config_with_stream_disabled():
+    """Test TelegramConfig can be created with stream disabled."""
+    config = TelegramConfig(token="test-token", session_socket="/tmp/test.sock", stream=False)
+
+    assert config.stream is False
+
+
+def test_telegram_config_with_custom_stream_interval():
+    """Test TelegramConfig can be created with custom stream_interval."""
+    config = TelegramConfig(
+        token="test-token", session_socket="/tmp/test.sock", stream_interval=0.5
+    )
+
+    assert config.stream_interval == 0.5


### PR DESCRIPTION
## Summary

- Implement real-time message editing for streaming responses in Telegram channel
- Add `--no-stream` and `--stream-interval` CLI arguments for configuration
- Add `send_message_stream()` method with SSE parsing for streaming requests
- Implement time-based buffering to avoid Telegram API rate limits
- Handle message length exceeding 4096 characters during streaming
- Add comprehensive unit tests for streaming functionality

## Test plan

- [x] Run `uv run pytest tests/channel/telegram/` - all 43 tests pass
- [x] Run `uv run ruff check src/psi_agent/channel/telegram/` - all checks pass
- [x] Run `uv run ruff format --check src/psi_agent/channel/telegram/` - formatted
- [x] Run `uv run ty check src/psi_agent/channel/telegram/` - all checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)