### PR TITLE
Fix streaming null tool_calls handling

### DIFF
--- a/openspec/changes/archive/2026-04-30-fix-streaming-null-tool-calls/.openspec.yaml
+++ b/openspec/changes/archive/2026-04-30-fix-streaming-null-tool-calls/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-30

--- a/openspec/changes/archive/2026-04-30-fix-streaming-null-tool-calls/design.md
+++ b/openspec/changes/archive/2026-04-30-fix-streaming-null-tool-calls/design.md
@@ -1,0 +1,54 @@
+## Context
+
+The session component's `_stream_conversation()` method processes streaming responses from the AI component. When parsing SSE chunks, it extracts delta fields including `tool_calls`. The current implementation checks for key presence but doesn't handle null values.
+
+**Current problematic code** (runner.py:561-562):
+```python
+if "tool_calls" in delta:
+    tool_calls_data.extend(delta["tool_calls"])
+```
+
+**Observed behavior from Tencent hy3 model via OpenRouter**:
+```json
+{"delta":{"content":"","function_call":null,"refusal":null,"role":"assistant","tool_calls":null,...}
+```
+
+The `tool_calls` key exists but has value `null`, causing `list.extend(None)` to fail.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Fix the crash when `tool_calls` field has null value in streaming delta
+- Make streaming delta processing robust against null values for any field that expects an iterable
+- Maintain backward compatibility with existing providers
+
+**Non-Goals:**
+- Changing the streaming protocol or API
+- Adding new features or capabilities
+- Modifying error handling beyond the null check
+
+## Decisions
+
+**Decision 1: Add explicit null check before extend**
+
+Use `if delta.get("tool_calls")` instead of `if "tool_calls" in delta` to handle both missing key and null value cases.
+
+Rationale:
+- Simple one-line fix with minimal risk
+- `dict.get()` returns `None` for both missing key and null value
+- Empty list `[]` is falsy, but we don't want to extend with empty list anyway (no-op)
+- Alternative: explicit `is not None` check - more verbose, same effect
+
+**Decision 2: Apply same pattern to other delta fields**
+
+Review all delta field accesses in the streaming loop and apply defensive null checks where appropriate.
+
+## Risks / Trade-offs
+
+**Risk: Provider behavior variation**
+- Some providers might send empty list `[]` vs null vs missing key
+- Mitigation: The fix handles all three cases correctly - `None`, `[]`, and missing key all result in no extend operation
+
+**Risk: Missing other null-prone fields**
+- Other fields like `content` might also have null values
+- Mitigation: Check all delta field accesses in the streaming loop; `content` is handled differently (string concatenation, not extend)

--- a/openspec/changes/archive/2026-04-30-fix-streaming-null-tool-calls/proposal.md
+++ b/openspec/changes/archive/2026-04-30-fix-streaming-null-tool-calls/proposal.md
@@ -1,0 +1,28 @@
+## Why
+
+When processing streaming responses from LLM providers, the session component crashes when encountering delta chunks where `tool_calls` field exists but has a `null` value. This occurs because the code checks for key presence (`"tool_calls" in delta`) but doesn't handle the case where the value is `None`, leading to `TypeError: 'NoneType' object is not iterable` when calling `list.extend(None)`.
+
+This is a critical bug that breaks the entire streaming flow when using certain LLM providers (like Tencent's hy3 model via OpenRouter) that include `tool_calls: null` in their streaming delta chunks.
+
+## What Changes
+
+- Fix null value handling in streaming delta processing for `tool_calls` field
+- Add defensive null checks before calling `list.extend()` on delta fields
+- Ensure robust handling of LLM provider variations in streaming response format
+
+## Capabilities
+
+### New Capabilities
+
+None - this is a bug fix.
+
+### Modified Capabilities
+
+None - this is an implementation-level fix, not a spec-level behavior change.
+
+## Impact
+
+- **Affected code**: `src/psi_agent/session/runner.py` - `_stream_conversation()` method, lines 561-562
+- **Affected components**: psi-session
+- **Affected providers**: Any LLM provider that returns `tool_calls: null` in streaming delta chunks (observed with Tencent hy3 model via OpenRouter)
+- **No API changes**: Internal fix only, no external API modifications

--- a/openspec/changes/archive/2026-04-30-fix-streaming-null-tool-calls/specs/streaming-null-handling/spec.md
+++ b/openspec/changes/archive/2026-04-30-fix-streaming-null-tool-calls/specs/streaming-null-handling/spec.md
@@ -1,0 +1,17 @@
+## ADDED Requirements
+
+### Requirement: Streaming delta null value handling
+
+The session component SHALL gracefully handle null values in streaming delta fields that expect iterable types.
+
+#### Scenario: tool_calls field is null
+- **WHEN** LLM provider returns a streaming delta with `tool_calls: null`
+- **THEN** the session SHALL skip processing tool calls without crashing
+
+#### Scenario: tool_calls field is missing
+- **WHEN** LLM provider returns a streaming delta without `tool_calls` field
+- **THEN** the session SHALL skip processing tool calls without crashing
+
+#### Scenario: tool_calls field has valid data
+- **WHEN** LLM provider returns a streaming delta with valid `tool_calls` array
+- **THEN** the session SHALL process tool calls normally

--- a/openspec/changes/archive/2026-04-30-fix-streaming-null-tool-calls/tasks.md
+++ b/openspec/changes/archive/2026-04-30-fix-streaming-null-tool-calls/tasks.md
@@ -1,0 +1,17 @@
+## 1. Fix Implementation
+
+- [x] 1.1 Fix null value handling in `runner.py:_stream_conversation()` - change `if "tool_calls" in delta:` to `if delta.get("tool_calls"):`
+- [x] 1.2 Review and fix any other delta field accesses that might have similar null value issues
+
+## 2. Testing
+
+- [x] 2.1 Add unit test for streaming delta with null `tool_calls` value
+- [x] 2.2 Add unit test for streaming delta with missing `tool_calls` field
+- [x] 2.3 Add unit test for streaming delta with valid `tool_calls` array
+- [x] 2.4 Run all tests to verify no regression
+
+## 3. Quality Checks
+
+- [x] 3.1 Run `ruff check` to verify lint compliance
+- [x] 3.2 Run `ruff format` to verify formatting
+- [x] 3.3 Run `ty check` to verify type checking

--- a/openspec/specs/streaming-null-handling/spec.md
+++ b/openspec/specs/streaming-null-handling/spec.md
@@ -1,0 +1,17 @@
+## ADDED Requirements
+
+### Requirement: Streaming delta null value handling
+
+The session component SHALL gracefully handle null values in streaming delta fields that expect iterable types.
+
+#### Scenario: tool_calls field is null
+- **WHEN** LLM provider returns a streaming delta with `tool_calls: null`
+- **THEN** the session SHALL skip processing tool calls without crashing
+
+#### Scenario: tool_calls field is missing
+- **WHEN** LLM provider returns a streaming delta without `tool_calls` field
+- **THEN** the session SHALL skip processing tool calls without crashing
+
+#### Scenario: tool_calls field has valid data
+- **WHEN** LLM provider returns a streaming delta with valid `tool_calls` array
+- **THEN** the session SHALL process tool calls normally

--- a/src/psi_agent/session/runner.py
+++ b/src/psi_agent/session/runner.py
@@ -389,7 +389,7 @@ class SessionRunner:
                                 content_chunks.append(delta["content"])
                                 logger.debug(f"Stream content chunk: {delta['content'][:100]}...")
 
-                            if "tool_calls" in delta:
+                            if delta.get("tool_calls"):
                                 tool_calls_data.extend(delta["tool_calls"])
                         except json.JSONDecodeError:
                             pass
@@ -558,7 +558,7 @@ class SessionRunner:
                                 content_chunks.append(delta["content"])
                                 logger.debug(f"Stream content chunk: {delta['content'][:100]}...")
 
-                            if "tool_calls" in delta:
+                            if delta.get("tool_calls"):
                                 tool_calls_data.extend(delta["tool_calls"])
                         except json.JSONDecodeError:
                             pass

--- a/tests/session/test_runner.py
+++ b/tests/session/test_runner.py
@@ -766,3 +766,144 @@ async def tool(message: str) -> str:
                 full_content = "".join(chunks)
                 assert "<thinking>" in full_content
                 assert "[Tool: echo]" in full_content
+
+    @pytest.mark.asyncio
+    async def test_stream_conversation_handles_null_tool_calls(self, config):
+        """Test _stream_conversation handles null tool_calls value."""
+        runner = SessionRunner(config)
+        async with runner:
+            # Response with null tool_calls (as observed from Tencent hy3 model)
+            sse_lines = [
+                b'data: {"choices":[{"delta":{"content":"","tool_calls":null}}]}\n',
+                b'data: {"choices":[{"delta":{"content":"Hello"}}]}\n',
+                b'data: {"choices":[{"delta":{},"finish_reason":"stop"}]}\n',
+                b"data: [DONE]\n",
+            ]
+
+            async def async_iter():
+                for line in sse_lines:
+                    yield line
+
+            mock_response = AsyncMock()
+            mock_response.status = 200
+            mock_response.content = async_iter()
+            mock_response.__aenter__ = AsyncMock(return_value=mock_response)
+            mock_response.__aexit__ = AsyncMock(return_value=None)
+
+            with patch.object(runner.client, "post", return_value=mock_response):
+                messages = [{"role": "user", "content": "Hi"}]
+                chunks = []
+                async for chunk in runner._stream_conversation(messages):
+                    chunks.append(chunk)
+
+                # Should not crash and should yield content
+                full_content = "".join(chunks)
+                assert "Hello" in full_content
+
+    @pytest.mark.asyncio
+    async def test_stream_conversation_handles_missing_tool_calls(self, config):
+        """Test _stream_conversation handles missing tool_calls field."""
+        runner = SessionRunner(config)
+        async with runner:
+            # Response without tool_calls field at all
+            sse_lines = [
+                b'data: {"choices":[{"delta":{"content":"Hello"}}]}\n',
+                b'data: {"choices":[{"delta":{},"finish_reason":"stop"}]}\n',
+                b"data: [DONE]\n",
+            ]
+
+            async def async_iter():
+                for line in sse_lines:
+                    yield line
+
+            mock_response = AsyncMock()
+            mock_response.status = 200
+            mock_response.content = async_iter()
+            mock_response.__aenter__ = AsyncMock(return_value=mock_response)
+            mock_response.__aexit__ = AsyncMock(return_value=None)
+
+            with patch.object(runner.client, "post", return_value=mock_response):
+                messages = [{"role": "user", "content": "Hi"}]
+                chunks = []
+                async for chunk in runner._stream_conversation(messages):
+                    chunks.append(chunk)
+
+                # Should not crash and should yield content
+                full_content = "".join(chunks)
+                assert "Hello" in full_content
+
+    @pytest.mark.asyncio
+    async def test_stream_conversation_handles_valid_tool_calls(self, config):
+        """Test _stream_conversation handles valid tool_calls array."""
+        runner = SessionRunner(config)
+        async with runner:
+            # Create a tool
+            tool_file = config.tools_dir() / "echo.py"
+            await tool_file.write_text(
+                """
+async def tool(message: str) -> str:
+    '''Echo tool.
+
+    Args:
+        message: The message to echo.
+
+    Returns:
+        The echoed message.
+    '''
+    return message
+"""
+            )
+            tool_schema = await load_tool_from_file(tool_file)
+            if tool_schema:
+                runner.registry.register(tool_schema)
+
+            # Response with valid tool_calls array
+            sse_lines_tool = [
+                b'data: {"choices":[{"delta":{"tool_calls":[{"index":0,"id":"call_1",'
+                b'"function":{"name":"echo","arguments":"{\\"mes"}}]}}]}\n',
+                b'data: {"choices":[{"delta":{"tool_calls":[{"index":0,'
+                b'"function":{"arguments":"sage\\": \\"test\\"}"}}]}}\n',
+                b"data: [DONE]\n",
+            ]
+
+            sse_lines_final = [
+                b'data: {"choices":[{"delta":{"content":"Done"}}]}\n',
+                b'data: {"choices":[{"delta":{},"finish_reason":"stop"}]}\n',
+                b"data: [DONE]\n",
+            ]
+
+            call_count = 0
+
+            def make_async_iter(lines):
+                async def async_iter():
+                    for line in lines:
+                        yield line
+
+                return async_iter()
+
+            def mock_post_side_effect(*_args, **_kwargs):
+                nonlocal call_count
+                call_count += 1
+
+                mock_response = AsyncMock()
+                mock_response.status = 200
+                mock_response.__aenter__ = AsyncMock(return_value=mock_response)
+                mock_response.__aexit__ = AsyncMock(return_value=None)
+
+                if call_count == 1:
+                    mock_response.content = make_async_iter(sse_lines_tool)
+                else:
+                    mock_response.content = make_async_iter(sse_lines_final)
+
+                return mock_response
+
+            with patch.object(runner.client, "post", side_effect=mock_post_side_effect):
+                messages = [{"role": "user", "content": "Test"}]
+                chunks = []
+                async for chunk in runner._stream_conversation(messages):
+                    chunks.append(chunk)
+
+                # Should process tool calls and include thinking block
+                full_content = "".join(chunks)
+                assert "<thinking>" in full_content
+                assert "[Tool: echo]" in full_content


### PR DESCRIPTION
## Summary
- Fix crash when LLM providers return `tool_calls: null` in streaming delta chunks
- Use `delta.get("tool_calls")` instead of `"tool_calls" in delta` to handle both missing key and null value cases
- Add 3 unit tests covering null, missing, and valid tool_calls scenarios

## Problem
When using certain LLM providers (like Tencent hy3 model via OpenRouter), the session component crashed with `TypeError: 'NoneType' object is not iterable` because the streaming delta contained `tool_calls: null` instead of an empty array or missing field.

## Solution
Changed the null-unsafe check `"tool_calls" in delta` to the null-safe `delta.get("tool_calls")` which returns `None` for both missing keys and null values, preventing the crash.

## Test plan
- [x] Unit test for streaming delta with null `tool_calls` value
- [x] Unit test for streaming delta with missing `tool_calls` field  
- [x] Unit test for streaming delta with valid `tool_calls` array
- [x] All 31 existing tests pass
- [x] `ruff check` passes
- [x] `ruff format` passes
- [x] `ty check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)