### PR TITLE
Rename no_stream to stream for clearer CLI flags

### DIFF
--- a/openspec/changes/archive/2026-04-30-rename-no-stream-to-stream/.openspec.yaml
+++ b/openspec/changes/archive/2026-04-30-rename-no-stream-to-stream/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-30

--- a/openspec/changes/archive/2026-04-30-rename-no-stream-to-stream/design.md
+++ b/openspec/changes/archive/2026-04-30-rename-no-stream-to-stream/design.md
@@ -1,0 +1,56 @@
+## Context
+
+The CLI modules use tyro for argument parsing. Tyro automatically generates negation flags for boolean parameters:
+- `no_stream: bool = False` produces `--no-stream` (to set True) and `--no-no-stream` (to set False)
+
+This is confusing because:
+1. `--no-no-stream` is double-negative and unintuitive
+2. The parameter name `no_stream` suggests "disable streaming" but the default `False` means streaming is enabled
+
+The fix is straightforward: rename to `stream: bool = True`, which produces:
+- `--stream` (explicitly enable, though it's already the default)
+- `--no-stream` (disable streaming)
+
+## Goals / Non-Goals
+
+**Goals:**
+- Rename CLI parameter from `no_stream` to `stream` with inverted default value
+- Produce intuitive CLI flags: `--stream` (default) and `--no-stream` (disable)
+- Maintain backward compatibility in internal APIs (config objects already use `stream`)
+
+**Non-Goals:**
+- Changing the underlying streaming behavior
+- Modifying config classes (they already use `stream` parameter correctly)
+- Adding new streaming-related features
+
+## Decisions
+
+### Decision 1: Parameter rename with inverted default
+
+**Choice**: Rename `no_stream: bool = False` to `stream: bool = True`
+
+**Rationale**:
+- Produces clean CLI flags: `--stream` / `--no-stream`
+- Matches the internal config objects which already use `stream` parameter
+- Positive naming is more intuitive than negative naming
+
+**Alternatives considered**:
+1. Keep `no_stream` but change default to `True` - would make `--no-stream` the default flag, still confusing
+2. Use custom CLI parsing to override tyro's negation handling - adds complexity for a simple rename
+
+### Decision 2: Update all test assertions
+
+**Choice**: Update all test files to use `stream` parameter directly
+
+**Rationale**:
+- Tests should reflect the actual API
+- No value in maintaining backward compatibility in test code
+- Simpler assertions: `assert cli.stream is True` vs `assert cli.no_stream is False`
+
+## Risks / Trade-offs
+
+**Risk**: Users who have scripts using `--no-stream` will see different behavior
+→ **Mitigation**: This is technically a breaking change, but the previous `--no-stream` flag was setting `no_stream=True` (disabling streaming). After the change, `--no-stream` will still disable streaming. The behavior is identical, only the internal parameter name changes.
+
+**Risk**: Documentation may reference `no_stream` parameter
+→ **Mitigation**: Review and update any documentation. Based on codebase search, the parameter is only documented in docstrings which will be updated.

--- a/openspec/changes/archive/2026-04-30-rename-no-stream-to-stream/proposal.md
+++ b/openspec/changes/archive/2026-04-30-rename-no-stream-to-stream/proposal.md
@@ -1,0 +1,31 @@
+## Why
+
+The current CLI parameter `no_stream` produces confusing command-line flags (`--no-no-stream` and `--no-stream`) due to tyro's automatic negation handling for boolean flags. This is unintuitive for users. Renaming to `stream` with default `True` will produce cleaner flags: `--stream` (default) and `--no-stream` to disable.
+
+## What Changes
+
+- Rename `no_stream: bool = False` to `stream: bool = True` in three CLI modules:
+  - `src/psi_agent/channel/cli/cli.py`
+  - `src/psi_agent/channel/repl/cli.py`
+  - `src/psi_agent/channel/telegram/cli.py`
+- Update all internal logic from `not self.no_stream` to `self.stream`
+- Update docstrings to reflect the new parameter semantics
+- Update all test files to use the new parameter name
+
+## Capabilities
+
+### New Capabilities
+
+None - this is a pure refactoring of existing functionality.
+
+### Modified Capabilities
+
+- `channel-cli`: CLI parameter renamed from `no_stream` to `stream` with inverted default
+- `repl-channel`: CLI parameter renamed from `no_stream` to `stream` with inverted default
+- `telegram-channel`: CLI parameter renamed from `no_stream` to `stream` with inverted default
+
+## Impact
+
+- **CLI users**: Will use `--stream` (default) or `--no-stream` instead of `--no-no-stream`/`--no-stream`
+- **API users**: No impact - internal config objects already use `stream` parameter
+- **Tests**: All test assertions on `no_stream` will be updated to use `stream`

--- a/openspec/changes/archive/2026-04-30-rename-no-stream-to-stream/specs/channel-cli/spec.md
+++ b/openspec/changes/archive/2026-04-30-rename-no-stream-to-stream/specs/channel-cli/spec.md
@@ -1,0 +1,26 @@
+## MODIFIED Requirements
+
+### Requirement: CLI outputs response to stdout
+
+The CLI SHALL output the agent response to stdout.
+
+#### Scenario: Non-streaming response output
+- **WHEN** session returns a non-streaming response
+- **THEN** the response content is printed to stdout
+
+#### Scenario: Streaming response output
+- **WHEN** session returns a streaming response with `--stream` flag (default)
+- **THEN** each chunk is printed to stdout as it arrives
+
+#### Scenario: Disable streaming with flag
+- **WHEN** CLI is invoked with `--no-stream` flag
+- **THEN** streaming mode SHALL be disabled
+- **AND** the CLI SHALL wait for complete response before output
+
+## REMOVED Requirements
+
+### Requirement: CLI uses no_stream parameter
+
+**Reason**: Parameter renamed to `stream` with inverted default for clearer CLI flags.
+
+**Migration**: Use `stream: bool = True` instead of `no_stream: bool = False`. The CLI flags are now `--stream` (default) and `--no-stream` (to disable).

--- a/openspec/changes/archive/2026-04-30-rename-no-stream-to-stream/specs/repl-channel/spec.md
+++ b/openspec/changes/archive/2026-04-30-rename-no-stream-to-stream/specs/repl-channel/spec.md
@@ -1,0 +1,28 @@
+## MODIFIED Requirements
+
+### Requirement: REPL uses streaming by default
+
+The REPL SHALL use streaming requests by default for better user experience.
+
+#### Scenario: Default streaming request
+- **WHEN** user enters a message
+- **THEN** REPL SHALL send request with `stream: true`
+- **AND** display response chunks in real-time
+
+#### Scenario: Real-time output display
+- **WHEN** streaming response arrives
+- **THEN** REPL SHALL print each content chunk immediately
+- **AND** NOT wait for complete response
+
+#### Scenario: Disable streaming with flag
+- **WHEN** REPL is invoked with `--no-stream` flag
+- **THEN** streaming mode SHALL be disabled
+- **AND** REPL SHALL wait for complete response before displaying
+
+## REMOVED Requirements
+
+### Requirement: REPL uses no_stream parameter
+
+**Reason**: Parameter renamed to `stream` with inverted default for clearer CLI flags.
+
+**Migration**: Use `stream: bool = True` instead of `no_stream: bool = False`. The CLI flags are now `--stream` (default) and `--no-stream` (to disable).

--- a/openspec/changes/archive/2026-04-30-rename-no-stream-to-stream/specs/telegram-channel/spec.md
+++ b/openspec/changes/archive/2026-04-30-rename-no-stream-to-stream/specs/telegram-channel/spec.md
@@ -1,0 +1,50 @@
+## MODIFIED Requirements
+
+### Requirement: Telegram channel CLI supports streaming configuration
+
+The Telegram channel CLI SHALL support streaming mode configuration via command-line arguments.
+
+#### Scenario: Default streaming mode
+- **WHEN** `psi-agent channel telegram --token <token> --session-socket <path>` is invoked
+- **THEN** streaming mode SHALL be enabled by default
+
+#### Scenario: Disable streaming with flag
+- **WHEN** `psi-agent channel telegram --token <token> --session-socket <path> --no-stream` is invoked
+- **THEN** streaming mode SHALL be disabled
+- **AND** the channel SHALL wait for complete response before sending
+
+#### Scenario: Configure stream interval
+- **WHEN** `psi-agent channel telegram --token <token> --session-socket <path> --stream-interval 2.0` is invoked
+- **THEN** the channel SHALL use 2.0 second as the minimum edit interval
+
+#### Scenario: Stream interval is a float
+- **WHEN** `--stream-interval` is specified
+- **THEN** the value SHALL be parsed as a float
+- **AND** support values like 0.5, 1.0, 2.5
+
+### Requirement: Telegram channel supports streaming output via message editing
+
+The Telegram channel SHALL support streaming output by editing messages in real-time when streaming mode is enabled.
+
+#### Scenario: Streaming mode enabled by default
+- **WHEN** Telegram channel starts without `--no-stream` flag
+- **THEN** the channel SHALL use streaming mode for message responses
+- **AND** edit messages in real-time as content arrives
+
+#### Scenario: Streaming message editing
+- **WHEN** streaming mode is enabled and a chunk arrives from session
+- **THEN** the channel SHALL edit the previously sent message with new content
+- **AND** accumulate content across multiple edits
+
+#### Scenario: First chunk sends initial message
+- **WHEN** the first streaming chunk arrives
+- **THEN** the channel SHALL send a new message to Telegram
+- **AND** subsequent chunks SHALL edit this message
+
+## REMOVED Requirements
+
+### Requirement: Telegram channel uses no_stream parameter
+
+**Reason**: Parameter renamed to `stream` with inverted default for clearer CLI flags.
+
+**Migration**: Use `stream: bool = True` instead of `no_stream: bool = False`. The CLI flags are now `--stream` (default) and `--no-stream` (to disable).

--- a/openspec/changes/archive/2026-04-30-rename-no-stream-to-stream/tasks.md
+++ b/openspec/changes/archive/2026-04-30-rename-no-stream-to-stream/tasks.md
@@ -1,0 +1,29 @@
+## 1. CLI Parameter Rename
+
+- [x] 1.1 Rename `no_stream` to `stream` in `src/psi_agent/channel/cli/cli.py`
+- [x] 1.2 Rename `no_stream` to `stream` in `src/psi_agent/channel/repl/cli.py`
+- [x] 1.3 Rename `no_stream` to `stream` in `src/psi_agent/channel/telegram/cli.py`
+
+## 2. Internal Logic Update
+
+- [x] 2.1 Update `not self.no_stream` to `self.stream` in channel CLI
+- [x] 2.2 Update `not self.no_stream` to `self.stream` in REPL CLI
+- [x] 2.3 Update `not self.no_stream` to `self.stream` in Telegram CLI
+
+## 3. Docstring Update
+
+- [x] 3.1 Update docstring for `stream` parameter in channel CLI
+- [x] 3.2 Update docstring for `stream` parameter in REPL CLI
+- [x] 3.3 Update docstring for `stream` parameter in Telegram CLI
+
+## 4. Test Updates
+
+- [x] 4.1 Update `tests/channel/cli/test_cli.py` to use `stream` parameter
+- [x] 4.2 Update `tests/channel/repl/test_cli.py` to use `stream` parameter
+- [x] 4.3 Update `tests/channel/telegram/test_cli.py` to use `stream` parameter
+
+## 5. Quality Verification
+
+- [x] 5.1 Run `ruff check` and `ruff format` to ensure code quality
+- [x] 5.2 Run `ty check` to ensure type safety
+- [x] 5.3 Run `pytest` to ensure all tests pass

--- a/openspec/specs/channel-cli/spec.md
+++ b/openspec/specs/channel-cli/spec.md
@@ -25,8 +25,13 @@ The CLI SHALL output the agent response to stdout.
 - **THEN** the response content is printed to stdout
 
 #### Scenario: Streaming response output
-- **WHEN** session returns a streaming response with --stream flag
+- **WHEN** session returns a streaming response with `--stream` flag (default)
 - **THEN** each chunk is printed to stdout as it arrives
+
+#### Scenario: Disable streaming with flag
+- **WHEN** CLI is invoked with `--no-stream` flag
+- **THEN** streaming mode SHALL be disabled
+- **AND** the CLI SHALL wait for complete response before output
 
 ### Requirement: CLI exits after response
 

--- a/openspec/specs/repl-channel/spec.md
+++ b/openspec/specs/repl-channel/spec.md
@@ -30,6 +30,11 @@ The REPL SHALL use streaming requests by default for better user experience.
 - **THEN** REPL SHALL print each content chunk immediately
 - **AND** NOT wait for complete response
 
+#### Scenario: Disable streaming with flag
+- **WHEN** REPL is invoked with `--no-stream` flag
+- **THEN** streaming mode SHALL be disabled
+- **AND** REPL SHALL wait for complete response before displaying
+
 ### Requirement: REPL client provides streaming API
 
 The REPL client SHALL provide both streaming and non-streaming methods.

--- a/src/psi_agent/channel/cli/cli.py
+++ b/src/psi_agent/channel/cli/cli.py
@@ -117,18 +117,18 @@ class Cli:
 
     session_socket: str
     message: str
-    no_stream: bool = False
-    """Disable streaming mode (default: streaming enabled)."""
+    stream: bool = True
+    """Enable streaming mode (default: streaming enabled)."""
 
     def __call__(self) -> None:
         logger.debug(f"Connecting to session socket: {self.session_socket}")
         logger.debug(f"Sending message: {self.message[:50]}...")
 
-        result = asyncio.run(send_message(self.session_socket, self.message, not self.no_stream))
+        result = asyncio.run(send_message(self.session_socket, self.message, self.stream))
 
         # For non-streaming, print the result
         # For streaming, it's already printed
-        if self.no_stream:
+        if not self.stream:
             print(result)
 
         # Exit with appropriate code

--- a/src/psi_agent/channel/repl/cli.py
+++ b/src/psi_agent/channel/repl/cli.py
@@ -17,14 +17,14 @@ class Repl:
     """Run the REPL channel for interactive conversation."""
 
     session_socket: str
-    no_stream: bool = False
-    """Disable streaming mode (default: streaming enabled)."""
+    stream: bool = True
+    """Enable streaming mode (default: streaming enabled)."""
 
     def __call__(self) -> None:
         logger.info("Starting psi-channel-repl")
-        logger.debug(f"Config: session_socket={self.session_socket}, stream={not self.no_stream}")
+        logger.debug(f"Config: session_socket={self.session_socket}, stream={self.stream}")
 
-        config = ReplConfig(session_socket=self.session_socket, stream=not self.no_stream)
+        config = ReplConfig(session_socket=self.session_socket, stream=self.stream)
         repl = ReplRunner(config)
 
         asyncio.run(repl.run())

--- a/src/psi_agent/channel/telegram/cli.py
+++ b/src/psi_agent/channel/telegram/cli.py
@@ -22,7 +22,7 @@ class Telegram:
         session_socket: Path to the Unix socket for communication with psi-session.
         proxy: Optional proxy URL for connecting to Telegram API. Supports socks5://,
             http://, and https:// formats. Defaults to None (direct connection).
-        no_stream: Disable streaming mode (default: streaming enabled).
+        stream: Enable streaming mode (default: streaming enabled).
         stream_interval: Minimum time interval (in seconds) between message edits
             when streaming. Defaults to 1.0.
     """
@@ -30,7 +30,7 @@ class Telegram:
     token: str
     session_socket: str
     proxy: str | None = None
-    no_stream: bool = False
+    stream: bool = True
     stream_interval: float = 1.0
 
     def __call__(self) -> None:
@@ -39,7 +39,7 @@ class Telegram:
 
         logger.info("Starting psi-channel-telegram")
         logger.debug(
-            f"Config: session_socket={self.session_socket}, stream={not self.no_stream}, "
+            f"Config: session_socket={self.session_socket}, stream={self.stream}, "
             f"stream_interval={self.stream_interval}"
         )
 
@@ -47,7 +47,7 @@ class Telegram:
             token=self.token,
             session_socket=self.session_socket,
             proxy=self.proxy,
-            stream=not self.no_stream,
+            stream=self.stream,
             stream_interval=self.stream_interval,
         )
         bot = TelegramBot(config)

--- a/tests/channel/cli/test_cli.py
+++ b/tests/channel/cli/test_cli.py
@@ -46,17 +46,17 @@ class TestCliFlags:
         """Test CLI defaults to streaming enabled."""
         cli = Cli(session_socket="/tmp/test.sock", message="Hello")
 
-        assert cli.no_stream is False
+        assert cli.stream is True
 
     def test_cli_no_stream_flag(self) -> None:
         """Test CLI --no-stream flag disables streaming."""
-        cli = Cli(session_socket="/tmp/test.sock", message="Hello", no_stream=True)
+        cli = Cli(session_socket="/tmp/test.sock", message="Hello", stream=False)
 
-        assert cli.no_stream is True
+        assert cli.stream is False
 
     def test_cli_stream_passed_to_send_message(self) -> None:
         """Test CLI passes correct stream value to send_message."""
-        cli = Cli(session_socket="/tmp/test.sock", message="Hello", no_stream=True)
+        cli = Cli(session_socket="/tmp/test.sock", message="Hello", stream=False)
 
-        # no_stream=True means stream=False
-        assert cli.no_stream is not False
+        # stream=False means non-streaming mode
+        assert cli.stream is False

--- a/tests/channel/repl/test_cli.py
+++ b/tests/channel/repl/test_cli.py
@@ -12,18 +12,18 @@ class TestReplCli:
         """Test CLI defaults to streaming enabled."""
         cli = Repl(session_socket="/tmp/test.sock")
 
-        assert cli.no_stream is False
+        assert cli.stream is True
 
     def test_cli_no_stream_flag(self) -> None:
         """Test CLI --no-stream flag disables streaming."""
-        cli = Repl(session_socket="/tmp/test.sock", no_stream=True)
+        cli = Repl(session_socket="/tmp/test.sock", stream=False)
 
-        assert cli.no_stream is True
+        assert cli.stream is False
 
     def test_cli_passes_stream_to_config(self) -> None:
         """Test CLI passes correct stream value to config."""
-        cli = Repl(session_socket="/tmp/test.sock", no_stream=True)
+        cli = Repl(session_socket="/tmp/test.sock", stream=False)
 
-        # When no_stream=True, config.stream should be False
+        # When stream=False, config.stream should be False
         # This is verified by checking the logic in __call__
-        assert cli.no_stream is True
+        assert cli.stream is False

--- a/tests/channel/telegram/test_cli.py
+++ b/tests/channel/telegram/test_cli.py
@@ -64,15 +64,15 @@ def test_telegram_cli_streaming_defaults():
     """Test Telegram CLI streaming defaults to enabled."""
     cli = Telegram(token="test-token", session_socket="/tmp/test.sock")
 
-    assert cli.no_stream is False
+    assert cli.stream is True
     assert cli.stream_interval == 1.0
 
 
 def test_telegram_cli_no_stream_flag():
     """Test Telegram CLI with --no-stream flag."""
-    cli = Telegram(token="test-token", session_socket="/tmp/test.sock", no_stream=True)
+    cli = Telegram(token="test-token", session_socket="/tmp/test.sock", stream=False)
 
-    assert cli.no_stream is True
+    assert cli.stream is False
 
 
 def test_telegram_cli_custom_stream_interval():

--- a/tests/channel/test_cli.py
+++ b/tests/channel/test_cli.py
@@ -16,16 +16,16 @@ class TestCliDataclass:
         )
         assert cli.session_socket == "/tmp/test.sock"
         assert cli.message == "Hello, world!"
-        assert cli.no_stream is False  # default
+        assert cli.stream is True  # default
 
     def test_cli_with_no_stream(self) -> None:
-        """Test CLI with no_stream option."""
+        """Test CLI with stream=False option."""
         cli = Cli(
             session_socket="/tmp/test.sock",
             message="Hello",
-            no_stream=True,
+            stream=False,
         )
-        assert cli.no_stream is True
+        assert cli.stream is False
 
     def test_cli_message_attribute(self) -> None:
         """Test CLI message attribute."""

--- a/tests/channel/test_repl_cli.py
+++ b/tests/channel/test_repl_cli.py
@@ -13,27 +13,27 @@ class TestReplCli:
         """Test CLI class can be imported."""
         cli = Repl(session_socket="/tmp/test.sock")
         assert cli.session_socket == "/tmp/test.sock"
-        assert cli.no_stream is False  # default
+        assert cli.stream is True  # default
 
     def test_cli_with_no_stream(self) -> None:
-        """Test CLI with no_stream option."""
+        """Test CLI with stream=False option."""
         cli = Repl(
             session_socket="/tmp/test.sock",
-            no_stream=True,
+            stream=False,
         )
-        assert cli.no_stream is True
+        assert cli.stream is False
 
     def test_cli_config_creation(self) -> None:
         """Test CLI creates valid config."""
         cli = Repl(
             session_socket="/tmp/test.sock",
-            no_stream=False,
+            stream=True,
         )
 
         # Verify config can be created from CLI args
         config = ReplConfig(
             session_socket=cli.session_socket,
-            stream=not cli.no_stream,
+            stream=cli.stream,
         )
         assert config.session_socket == "/tmp/test.sock"
         assert config.stream is True
@@ -56,10 +56,10 @@ class TestReplMain:
 class TestReplDefaults:
     """Tests for default values."""
 
-    def test_default_no_stream(self) -> None:
-        """Test default no_stream is False."""
+    def test_default_stream(self) -> None:
+        """Test default stream is True."""
         cli = Repl(session_socket="/tmp/test.sock")
-        assert cli.no_stream is False
+        assert cli.stream is True
 
 
 class TestReplSocketPaths:

--- a/tests/channel/test_telegram_cli.py
+++ b/tests/channel/test_telegram_cli.py
@@ -18,7 +18,7 @@ class TestTelegramCli:
         assert cli.token == "test-token"
         assert cli.session_socket == "/tmp/test.sock"
         assert cli.proxy is None  # default
-        assert cli.no_stream is False  # default
+        assert cli.stream is True  # default
         assert cli.stream_interval == 1.0  # default
 
     def test_cli_with_proxy(self) -> None:
@@ -31,13 +31,13 @@ class TestTelegramCli:
         assert cli.proxy == "socks5://localhost:1080"
 
     def test_cli_with_no_stream(self) -> None:
-        """Test CLI with no_stream option."""
+        """Test CLI with stream=False option."""
         cli = Telegram(
             token="test-token",
             session_socket="/tmp/test.sock",
-            no_stream=True,
+            stream=False,
         )
-        assert cli.no_stream is True
+        assert cli.stream is False
 
     def test_cli_with_stream_interval(self) -> None:
         """Test CLI with custom stream_interval."""
@@ -54,7 +54,7 @@ class TestTelegramCli:
             token="test-token",
             session_socket="/tmp/test.sock",
             proxy=None,
-            no_stream=False,
+            stream=True,
             stream_interval=1.0,
         )
 
@@ -63,7 +63,7 @@ class TestTelegramCli:
             token=cli.token,
             session_socket=cli.session_socket,
             proxy=cli.proxy,
-            stream=not cli.no_stream,
+            stream=cli.stream,
             stream_interval=cli.stream_interval,
         )
         assert config.token == "test-token"
@@ -96,13 +96,13 @@ class TestTelegramDefaults:
         )
         assert cli.proxy is None
 
-    def test_default_no_stream(self) -> None:
-        """Test default no_stream is False."""
+    def test_default_stream(self) -> None:
+        """Test default stream is True."""
         cli = Telegram(
             token="test-token",
             session_socket="/tmp/test.sock",
         )
-        assert cli.no_stream is False
+        assert cli.stream is True
 
     def test_default_stream_interval(self) -> None:
         """Test default stream_interval is 1.0."""


### PR DESCRIPTION
## Summary
- Renamed `no_stream: bool = False` to `stream: bool = True` across all channel CLI modules
- This produces cleaner CLI flags: `--stream` (default) and `--no-stream` (to disable)
- Previous flags `--no-no-stream` and `--no-stream` were confusing due to tyro's negation handling

## Changes
- Updated CLI parameter in channel-cli, repl-channel, and telegram-channel
- Updated internal logic from `not self.no_stream` to `self.stream`
- Updated docstrings and tests
- Synced delta specs to main specs

## Test plan
- [x] All unit tests pass
- [x] Type checking passes (ty check)
- [x] Linting passes (ruff check)
- [x] Formatting verified (ruff format)

🤖 Generated with [Claude Code](https://claude.com/claude-code)