### PR TITLE
Fix streaming null content handling

### DIFF
--- a/openspec/changes/archive/2026-04-30-fix-streaming-null-content/.openspec.yaml
+++ b/openspec/changes/archive/2026-04-30-fix-streaming-null-content/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-30

--- a/openspec/changes/archive/2026-04-30-fix-streaming-null-content/design.md
+++ b/openspec/changes/archive/2026-04-30-fix-streaming-null-content/design.md
@@ -1,0 +1,43 @@
+## Context
+
+The session runner's `_stream_conversation` method processes streaming SSE responses from the AI component. When the LLM returns a tool call without text content, the delta object contains `content: null`. The current code at line 559 attempts to log the content chunk by slicing `delta['content'][:100]`, which fails when content is `None`.
+
+This is a straightforward null-safety bug. The OpenAI API specification allows `content` to be `null` in streaming deltas, particularly when tool calls are being streamed.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Fix the crash when `delta['content']` is `None`
+- Maintain existing behavior for non-null content
+- Ensure debug logging continues to work correctly
+
+**Non-Goals:**
+- Changing the streaming protocol or API
+- Modifying how tool calls are processed
+- Adding new features or capabilities
+
+## Decisions
+
+**Decision 1: Guard the debug log statement**
+
+Add a null check before slicing the content string:
+```python
+if delta.get("content") is not None:
+    content_chunks.append(delta["content"])
+    logger.debug(f"Stream content chunk: {delta['content'][:100]}...")
+```
+
+Rationale: This is the minimal fix that addresses the root cause. Using `delta.get("content")` is safer than `delta["content"]` and the explicit `is not None` check handles the null case correctly.
+
+**Alternative considered**: Using `delta.get("content", "")` with a default empty string. Rejected because:
+- `None` and `""` have different semantic meanings in the OpenAI API
+- We should preserve the distinction between "no content" and "empty content"
+- The content_chunks list should only contain actual content, not placeholders
+
+## Risks / Trade-offs
+
+**Risk: Other code paths may have similar null-safety issues**
+→ Mitigation: The fix is localized and tested. If similar issues exist elsewhere, they can be addressed separately.
+
+**Risk: The fix changes behavior for empty string content**
+→ Mitigation: Empty string `""` is truthy-falsy different from `None`. The check `is not None` correctly handles both cases - empty strings will still be logged (though `[:100]` of `""` is just `""`).

--- a/openspec/changes/archive/2026-04-30-fix-streaming-null-content/proposal.md
+++ b/openspec/changes/archive/2026-04-30-fix-streaming-null-content/proposal.md
@@ -1,0 +1,25 @@
+## Why
+
+When streaming LLM responses that contain tool calls but no text content, the session runner crashes with `TypeError: 'NoneType' object is not subscriptable`. This occurs because the code attempts to slice `delta['content']` without checking if it's `None` first. The LLM (tencent/hy3-preview via OpenRouter) returns `content: null` in the delta when making tool calls, which is valid OpenAI API behavior.
+
+## What Changes
+
+- Fix null-safety check in `_stream_conversation` method in `runner.py`
+- Add guard to check if `delta['content']` is not `None` before slicing for debug logging
+- Ensure streaming continues correctly when tool calls are present without text content
+
+## Capabilities
+
+### New Capabilities
+
+None - this is a bug fix, not a new capability.
+
+### Modified Capabilities
+
+None - this is an implementation fix that doesn't change spec-level behavior. The streaming response handling should already support tool calls; this fix ensures it doesn't crash when content is null.
+
+## Impact
+
+- **Affected Code**: `src/psi_agent/session/runner.py` - line 559 in `_stream_conversation` method
+- **Affected Components**: psi-session
+- **User Impact**: Streaming responses with tool calls will no longer crash the session

--- a/openspec/changes/archive/2026-04-30-fix-streaming-null-content/specs/streaming-null-handling/spec.md
+++ b/openspec/changes/archive/2026-04-30-fix-streaming-null-content/specs/streaming-null-handling/spec.md
@@ -1,0 +1,16 @@
+## ADDED Requirements
+
+### Requirement: Streaming handles null content in delta
+The session runner SHALL handle streaming delta objects where `content` is `null` without crashing.
+
+#### Scenario: Tool call with null content
+- **WHEN** LLM returns a streaming delta with `content: null` and `tool_calls` present
+- **THEN** session continues processing without TypeError
+
+#### Scenario: Empty string content
+- **WHEN** LLM returns a streaming delta with `content: ""`
+- **THEN** session logs the empty content and continues normally
+
+#### Scenario: Normal text content
+- **WHEN** LLM returns a streaming delta with actual text content
+- **THEN** session logs first 100 characters and processes content normally

--- a/openspec/changes/archive/2026-04-30-fix-streaming-null-content/tasks.md
+++ b/openspec/changes/archive/2026-04-30-fix-streaming-null-content/tasks.md
@@ -1,0 +1,15 @@
+## 1. Code Fix
+
+- [x] 1.1 Fix null-safety check in `_stream_conversation` method at line 559 in `src/psi_agent/session/runner.py`
+
+## 2. Testing
+
+- [x] 2.1 Add unit test for streaming with null content in delta
+- [x] 2.2 Add unit test for streaming with empty string content
+- [x] 2.3 Run existing test suite to verify no regressions
+
+## 3. Quality Checks
+
+- [x] 3.1 Run `ruff check` to verify lint passes
+- [x] 3.2 Run `ruff format` to verify formatting
+- [x] 3.3 Run `ty check` to verify type checking passes

--- a/openspec/specs/streaming-null-handling/spec.md
+++ b/openspec/specs/streaming-null-handling/spec.md
@@ -15,3 +15,19 @@ The session component SHALL gracefully handle null values in streaming delta fie
 #### Scenario: tool_calls field has valid data
 - **WHEN** LLM provider returns a streaming delta with valid `tool_calls` array
 - **THEN** the session SHALL process tool calls normally
+
+### Requirement: Streaming handles null content in delta
+
+The session runner SHALL handle streaming delta objects where `content` is `null` without crashing.
+
+#### Scenario: Tool call with null content
+- **WHEN** LLM returns a streaming delta with `content: null` and `tool_calls` present
+- **THEN** session continues processing without TypeError
+
+#### Scenario: Empty string content
+- **WHEN** LLM returns a streaming delta with `content: ""`
+- **THEN** session logs the empty content and continues normally
+
+#### Scenario: Normal text content
+- **WHEN** LLM returns a streaming delta with actual text content
+- **THEN** session logs first 100 characters and processes content normally

--- a/src/psi_agent/session/runner.py
+++ b/src/psi_agent/session/runner.py
@@ -385,7 +385,7 @@ class SessionRunner:
                             chunk = json.loads(line_str[6:])
                             delta = chunk.get("choices", [{}])[0].get("delta", {})
 
-                            if "content" in delta:
+                            if "content" in delta and delta["content"] is not None:
                                 content_chunks.append(delta["content"])
                                 logger.debug(f"Stream content chunk: {delta['content'][:100]}...")
 
@@ -554,7 +554,7 @@ class SessionRunner:
                             chunk = json.loads(line_str[6:])
                             delta = chunk.get("choices", [{}])[0].get("delta", {})
 
-                            if "content" in delta:
+                            if "content" in delta and delta["content"] is not None:
                                 content_chunks.append(delta["content"])
                                 logger.debug(f"Stream content chunk: {delta['content'][:100]}...")
 

--- a/tests/session/test_runner.py
+++ b/tests/session/test_runner.py
@@ -907,3 +907,75 @@ async def tool(message: str) -> str:
                 full_content = "".join(chunks)
                 assert "<thinking>" in full_content
                 assert "[Tool: echo]" in full_content
+
+    @pytest.mark.asyncio
+    async def test_stream_conversation_handles_null_content(self, config):
+        """Test _stream_conversation handles null content in delta."""
+        runner = SessionRunner(config)
+        async with runner:
+            # Response with null content (as observed from Tencent hy3 model)
+            # This happens when tool_calls are present but no text content
+            sse_lines = [
+                (
+                    b'data: {"choices":[{"delta":{"content":null,"tool_calls":'
+                    b'[{"index":0,"id":"call_1","function":{"name":"bash","arguments":""}}]}}]}\n'
+                ),
+                (
+                    b'data: {"choices":[{"delta":{"content":null,"tool_calls":'
+                    b'[{"index":0,"function":{"arguments":"{\\"com"}}]}}]}\n'
+                ),
+                b"data: [DONE]\n",
+            ]
+
+            async def async_iter():
+                for line in sse_lines:
+                    yield line
+
+            mock_response = AsyncMock()
+            mock_response.status = 200
+            mock_response.content = async_iter()
+            mock_response.__aenter__ = AsyncMock(return_value=mock_response)
+            mock_response.__aexit__ = AsyncMock(return_value=None)
+
+            with patch.object(runner.client, "post", return_value=mock_response):
+                messages = [{"role": "user", "content": "Hi"}]
+                chunks = []
+                # This should not crash with TypeError
+                async for chunk in runner._stream_conversation(messages):
+                    chunks.append(chunk)
+
+                # Should complete without error
+                assert len(chunks) >= 0
+
+    @pytest.mark.asyncio
+    async def test_stream_conversation_handles_empty_string_content(self, config):
+        """Test _stream_conversation handles empty string content in delta."""
+        runner = SessionRunner(config)
+        async with runner:
+            # Response with empty string content
+            sse_lines = [
+                b'data: {"choices":[{"delta":{"content":""}}]}\n',
+                b'data: {"choices":[{"delta":{"content":"Hello"}}]}\n',
+                b'data: {"choices":[{"delta":{},"finish_reason":"stop"}]}\n',
+                b"data: [DONE]\n",
+            ]
+
+            async def async_iter():
+                for line in sse_lines:
+                    yield line
+
+            mock_response = AsyncMock()
+            mock_response.status = 200
+            mock_response.content = async_iter()
+            mock_response.__aenter__ = AsyncMock(return_value=mock_response)
+            mock_response.__aexit__ = AsyncMock(return_value=None)
+
+            with patch.object(runner.client, "post", return_value=mock_response):
+                messages = [{"role": "user", "content": "Hi"}]
+                chunks = []
+                async for chunk in runner._stream_conversation(messages):
+                    chunks.append(chunk)
+
+                # Should not crash and should yield content
+                full_content = "".join(chunks)
+                assert "Hello" in full_content


### PR DESCRIPTION
## Summary
- Fix crash when streaming LLM responses contain `content: null` in delta
- Add null-safety check before slicing content for debug logging
- Add unit tests for null and empty string content handling

## Root Cause
When the LLM returns a tool call without text content, `delta['content']` is `None`. The code checked `"content" in delta` (True - key exists) but then tried to slice `None[:100]`, causing `TypeError: 'NoneType' object is not subscriptable`.

## Fix
```python
if "content" in delta and delta["content"] is not None:
    content_chunks.append(delta["content"])
    logger.debug(f"Stream content chunk: {delta['content'][:100]}...")
```

## Test plan
- [x] Unit test for streaming with null content in delta
- [x] Unit test for streaming with empty string content
- [x] All existing tests pass (33 tests)
- [x] `ruff check` passes
- [x] `ruff format` passes
- [x] `ty check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)