### PR TITLE
Add defensive coding guidelines for null-safety across all components

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -509,6 +509,40 @@ async def request(url: str) -> dict[str, Any]:
         return {"error": "Request timeout", "status_code": 500}
 ```
 
+### 防御性编程规范
+
+**外部数据处理原则：**
+
+所有来自外部源（LLM 响应、用户输入、API 响应）的数据字段都可能为 `null` 或缺失。代码必须在操作前验证字段值。
+
+**Null 检查模式：**
+
+```python
+# 正确 ✓ - 使用 dict.get() 检查 null
+if data.get("field") is not None:
+    result += data["field"]
+
+# 正确 ✓ - 字符串切片前检查
+content = delta.get("content")
+if content is not None:
+    logger.debug(f"Content: {content[:100]}...")
+
+# 错误 ✗ - 假设字段非 null
+result += data["field"]  # 可能 TypeError
+
+# 错误 ✗ - "key" in dict 不检查 null 值
+if "field" in data:  # data["field"] 可能是 None
+    result += data["field"]
+```
+
+**适用场景：**
+- Streaming delta 字段处理（content、tool_calls、arguments 等）
+- LLM 响应解析
+- 用户输入验证
+- 外部 API 响应处理
+
+**核心规则：** 在字符串拼接 (`+=`)、切片 (`[:]`)、迭代等操作前，必须确认值非 `None`。
+
 ### 日志规范
 
 - 使用 **loguru** 进行日志记录

--- a/openspec/changes/archive/2026-04-30-defensive-coding-guidelines/.openspec.yaml
+++ b/openspec/changes/archive/2026-04-30-defensive-coding-guidelines/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-30

--- a/openspec/changes/archive/2026-04-30-defensive-coding-guidelines/design.md
+++ b/openspec/changes/archive/2026-04-30-defensive-coding-guidelines/design.md
@@ -1,0 +1,60 @@
+## Context
+
+psi-agent processes data from external sources (LLM providers, user input) that may have null or missing fields. The OpenAI streaming API specification explicitly allows fields to be `null` or absent in delta chunks. Different providers (OpenRouter, Tencent hy3, Anthropic) may have slightly different implementations.
+
+The current codebase has inconsistent null-handling patterns:
+- Some places use `dict.get("key", default)` with defaults
+- Some places use `"key" in dict` checks
+- Some places assume non-null without checks
+
+## Goals / Non-Goals
+
+**Goals:**
+- Establish consistent defensive coding patterns for null-safety
+- Add guidelines to CLAUDE.md for future development
+- Fix all identified null-safety issues in streaming code paths
+
+**Non-Goals:**
+- Changing the streaming protocol or API
+- Refactoring unrelated code
+- Adding validation for all possible fields (focus on crash points)
+
+## Decisions
+
+**Decision 1: Standardize on `dict.get()` pattern for null checks**
+
+Use `dict.get("key") is not None` for null checks before operations:
+
+```python
+# Preferred pattern
+if data.get("field") is not None:
+    result += data["field"]
+
+# Also acceptable for optional defaults
+value = data.get("field", "")
+```
+
+Rationale: `dict.get()` handles both missing keys and null values uniformly.
+
+**Decision 2: Add defensive coding guidelines to CLAUDE.md**
+
+Add a ~20 line section covering:
+- Null-safety patterns for external data
+- When to use defensive checks
+- Common patterns to avoid
+
+**Decision 3: Apply fixes systematically by component**
+
+Order of fixes (by crash risk):
+1. psi-session/runner.py - streaming delta processing (highest risk)
+2. psi-ai/*/client.py - streaming response handling
+3. psi-channel/*/client.py - streaming display
+4. Other utility code
+
+## Risks / Trade-offs
+
+**Risk: Changes may introduce subtle behavior differences**
+→ Mitigation: Use `is not None` checks that preserve empty string behavior
+
+**Risk: Guidelines may not be followed in future code**
+→ Mitigation: Add to CLAUDE.md so AI assistants and developers see it

--- a/openspec/changes/archive/2026-04-30-defensive-coding-guidelines/proposal.md
+++ b/openspec/changes/archive/2026-04-30-defensive-coding-guidelines/proposal.md
@@ -1,0 +1,49 @@
+## Why
+
+The psi-agent system has experienced multiple crashes due to null-safety issues when processing streaming responses from LLM providers. These issues stem from inconsistent defensive coding practices across components. The OpenAI streaming API specification allows fields to be `null` or absent in delta chunks, but our code often assumes non-null values. This change establishes systematic defensive coding guidelines and applies them consistently across all components.
+
+## What Changes
+
+- Add defensive coding guidelines section to CLAUDE.md (~20 lines)
+- Apply null-safety patterns across all components:
+  - **psi-ai-***: OpenAI completions client/server, Anthropic messages translator
+  - **psi-session**: Runner, server, tool executor
+  - **psi-channel-***: REPL client, Telegram client, CLI client
+- Standardize on `dict.get("key") is not None` pattern for null checks before operations
+
+## Capabilities
+
+### New Capabilities
+
+- `defensive-coding`: Guidelines and patterns for null-safe handling of external data
+
+### Modified Capabilities
+
+- `streaming-null-handling`: Extend to cover all streaming code paths across all components
+
+## Impact
+
+- **Affected Components**: All components that handle external data (LLM responses, user input)
+- **Affected Files**:
+  - `src/psi_agent/session/runner.py` - streaming delta processing
+  - `src/psi_agent/session/server.py` - request handling
+  - `src/psi_agent/session/tool_executor.py` - tool call processing
+  - `src/psi_agent/ai/openai_completions/client.py` - streaming response handling
+  - `src/psi_agent/ai/anthropic_messages/translator.py` - response translation
+  - `src/psi_agent/channel/repl/client.py` - streaming display
+  - `src/psi_agent/channel/telegram/client.py` - streaming display
+  - `src/psi_agent/channel/cli/cli.py` - streaming display
+- **CLAUDE.md**: Add defensive coding guidelines section
+
+## Root Cause Pattern
+
+All crashes share the same pattern: **assuming external data fields are non-null without verification**.
+
+```python
+# Problematic: assumes value is a string
+result += data["field"]
+
+# Safe: checks for null before operation
+if data.get("field") is not None:
+    result += data["field"]
+```

--- a/openspec/changes/archive/2026-04-30-defensive-coding-guidelines/specs/defensive-coding/spec.md
+++ b/openspec/changes/archive/2026-04-30-defensive-coding-guidelines/specs/defensive-coding/spec.md
@@ -1,0 +1,33 @@
+## ADDED Requirements
+
+### Requirement: External data null-safety
+
+All code that processes data from external sources (LLM responses, user input, API responses) SHALL use defensive null checks before operating on field values.
+
+#### Scenario: String concatenation on potentially null field
+- **WHEN** code concatenates a field value that may be null
+- **THEN** the code SHALL check `field is not None` before concatenation
+
+#### Scenario: String slicing on potentially null field
+- **WHEN** code slices a field value that may be null
+- **THEN** the code SHALL check `field is not None` before slicing
+
+#### Scenario: Dictionary access with potentially null value
+- **WHEN** code accesses a dictionary field that may have null value
+- **THEN** the code SHALL use `dict.get("key")` pattern for safe access
+
+### Requirement: Streaming delta field handling
+
+All streaming delta processing code SHALL handle null values in any field without crashing.
+
+#### Scenario: Delta field is null
+- **WHEN** LLM returns streaming delta with any field set to null
+- **THEN** the code SHALL skip processing that field without error
+
+#### Scenario: Delta field is missing
+- **WHEN** LLM returns streaming delta without a field
+- **THEN** the code SHALL skip processing that field without error
+
+#### Scenario: Delta field has valid value
+- **WHEN** LLM returns streaming delta with valid field value
+- **THEN** the code SHALL process the field normally

--- a/openspec/changes/archive/2026-04-30-defensive-coding-guidelines/tasks.md
+++ b/openspec/changes/archive/2026-04-30-defensive-coding-guidelines/tasks.md
@@ -1,0 +1,28 @@
+## 1. Guidelines Documentation
+
+- [x] 1.1 Add defensive coding guidelines section (~20 lines) to CLAUDE.md
+
+## 2. psi-session Component
+
+- [x] 2.1 Fix null-safety in `session/runner.py` streaming delta content slicing (already done)
+- [x] 2.2 Fix null-safety in `session/runner.py` `_reconstruct_tool_calls` (already done)
+- [x] 2.3 Review and fix null-safety in `session/server.py` request handling
+- [x] 2.4 Review and fix null-safety in `session/tool_executor.py` tool call processing
+
+## 3. psi-ai Components
+
+- [x] 3.1 Review and fix null-safety in `ai/openai_completions/client.py` streaming handling
+- [x] 3.2 Review and fix null-safety in `ai/anthropic_messages/translator.py` response translation
+
+## 4. psi-channel Components
+
+- [x] 4.1 Review and fix null-safety in `channel/repl/client.py` streaming display
+- [x] 4.2 Review and fix null-safety in `channel/telegram/client.py` streaming display
+- [x] 4.3 Review and fix null-safety in `channel/cli/cli.py` streaming display
+
+## 5. Testing and Quality
+
+- [x] 5.1 Run existing test suite to verify no regressions
+- [x] 5.2 Run `ruff check` to verify lint passes
+- [x] 5.3 Run `ruff format` to verify formatting
+- [x] 5.4 Run `ty check` to verify type checking passes

--- a/openspec/specs/defensive-coding/spec.md
+++ b/openspec/specs/defensive-coding/spec.md
@@ -1,0 +1,33 @@
+## ADDED Requirements
+
+### Requirement: External data null-safety
+
+All code that processes data from external sources (LLM responses, user input, API responses) SHALL use defensive null checks before operating on field values.
+
+#### Scenario: String concatenation on potentially null field
+- **WHEN** code concatenates a field value that may be null
+- **THEN** the code SHALL check `field is not None` before concatenation
+
+#### Scenario: String slicing on potentially null field
+- **WHEN** code slices a field value that may be null
+- **THEN** the code SHALL check `field is not None` before slicing
+
+#### Scenario: Dictionary access with potentially null value
+- **WHEN** code accesses a dictionary field that may have null value
+- **THEN** the code SHALL use `dict.get("key")` pattern for safe access
+
+### Requirement: Streaming delta field handling
+
+All streaming delta processing code SHALL handle null values in any field without crashing.
+
+#### Scenario: Delta field is null
+- **WHEN** LLM returns streaming delta with any field set to null
+- **THEN** the code SHALL skip processing that field without error
+
+#### Scenario: Delta field is missing
+- **WHEN** LLM returns streaming delta without a field
+- **THEN** the code SHALL skip processing that field without error
+
+#### Scenario: Delta field has valid value
+- **WHEN** LLM returns streaming delta with valid field value
+- **THEN** the code SHALL process the field normally

--- a/src/psi_agent/channel/cli/cli.py
+++ b/src/psi_agent/channel/cli/cli.py
@@ -95,8 +95,8 @@ async def _handle_streaming(response: aiohttp.ClientResponse) -> str:
             try:
                 chunk = json.loads(line_str[6:])
                 delta = chunk.get("choices", [{}])[0].get("delta", {})
-                if "content" in delta:
-                    content = delta["content"]
+                content = delta.get("content")
+                if content is not None:
                     content_parts.append(content)
                     truncated = content[:100]
                     suffix = "..." if len(content) > 100 else ""

--- a/src/psi_agent/channel/repl/client.py
+++ b/src/psi_agent/channel/repl/client.py
@@ -156,7 +156,7 @@ class ReplClient:
                     return "Error: No response from session"
 
                 msg = choices[0].get("message", {})
-                content = msg.get("content", "")
+                content = msg.get("content") or ""
                 logger.debug(f"Received response: {content[:100]}...")
                 return content
 

--- a/src/psi_agent/channel/telegram/client.py
+++ b/src/psi_agent/channel/telegram/client.py
@@ -86,7 +86,7 @@ class TelegramClient:
                     return "Error: No response from session"
 
                 msg = choices[0].get("message", {})
-                content = msg.get("content", "")
+                content = msg.get("content") or ""
                 logger.debug(f"Received response: {content[:100]}...")
                 return content
 

--- a/src/psi_agent/session/runner.py
+++ b/src/psi_agent/session/runner.py
@@ -647,9 +647,9 @@ class SessionRunner:
                 tool_calls_map[index]["id"] = chunk["id"]
             if "function" in chunk:
                 func = chunk["function"]
-                if "name" in func:
+                if func.get("name") is not None:
                     tool_calls_map[index]["function"]["name"] += func["name"]
-                if "arguments" in func:
+                if func.get("arguments") is not None:
                     tool_calls_map[index]["function"]["arguments"] += func["arguments"]
 
         return list(tool_calls_map.values())

--- a/src/psi_agent/session/server.py
+++ b/src/psi_agent/session/server.py
@@ -76,7 +76,7 @@ class SessionServer:
         if user_message is None:
             return web.Response(status=400, text="No user message found")
 
-        logger.debug(f"Processing user message: {user_message.get('content', '')[:100]}...")
+        logger.debug(f"Processing user message: {(user_message.get('content') or '')[:100]}...")
 
         try:
             if stream:

--- a/tests/session/test_runner.py
+++ b/tests/session/test_runner.py
@@ -283,6 +283,41 @@ async def test_reconstruct_tool_calls_multiple(config):
     assert result[1]["function"]["name"] == "tool2"
 
 
+def test_reconstruct_tool_calls_null_name(config):
+    """Test _reconstruct_tool_calls handles null name in subsequent chunks."""
+    runner = SessionRunner(config)
+
+    # First chunk has name, subsequent chunks have name: null
+    chunk1 = {"index": 0, "id": "call_1", "function": {"name": "bash", "arguments": ""}}
+    chunk2 = {"index": 0, "function": {"name": None, "arguments": '{"com'}}
+    chunk3 = {"index": 0, "function": {"arguments": 'mand"'}}  # no name field
+    tool_calls_data = [chunk1, chunk2, chunk3]
+
+    # Should not crash
+    result = runner._reconstruct_tool_calls(tool_calls_data)
+
+    assert len(result) == 1
+    assert result[0]["function"]["name"] == "bash"
+    assert result[0]["function"]["arguments"] == '{"command"'
+
+
+def test_reconstruct_tool_calls_null_arguments(config):
+    """Test _reconstruct_tool_calls handles null arguments in chunks."""
+    runner = SessionRunner(config)
+
+    # Chunks with null arguments
+    chunk1 = {"index": 0, "id": "call_1", "function": {"name": "bash", "arguments": None}}
+    chunk2 = {"index": 0, "function": {"arguments": '{"com'}}
+    tool_calls_data = [chunk1, chunk2]
+
+    # Should not crash
+    result = runner._reconstruct_tool_calls(tool_calls_data)
+
+    assert len(result) == 1
+    assert result[0]["function"]["name"] == "bash"
+    assert result[0]["function"]["arguments"] == '{"com'
+
+
 class TestRunnerWorkspaceChanges:
     """Tests for workspace change handling."""
 


### PR DESCRIPTION
## Summary
- Add ~25 lines of defensive coding guidelines to CLAUDE.md for handling external data (LLM responses, user input, API responses)
- Fix null-safety issues across all components: session/runner.py, session/server.py, channel/repl/client.py, channel/telegram/client.py, channel/cli/cli.py
- Add tests for null name/arguments in tool call reconstruction

## Changes
- **CLAUDE.md**: New "防御性编程规范" section with null-check patterns
- **session/runner.py**: Fix `_reconstruct_tool_calls` to handle null `name` and `arguments` fields
- **session/server.py**: Fix user message content logging with null-safety
- **channel/repl/client.py**: Fix response content handling
- **channel/telegram/client.py**: Fix response content handling
- **channel/cli/cli.py**: Fix streaming delta content handling

## Core Pattern
Use `dict.get("key") is not None` for null checks before string concatenation, slicing, or iteration.

## Test plan
- [x] All 35 existing tests pass
- [x] New tests for null tool call fields pass
- [x] `ruff check` passes
- [x] `ruff format` passes
- [x] `ty check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)