### PR TITLE
Improve session logging for AI response fields

### DIFF
--- a/openspec/changes/archive/2026-04-30-skip-empty-content-log/.openspec.yaml
+++ b/openspec/changes/archive/2026-04-30-skip-empty-content-log/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-30

--- a/openspec/changes/archive/2026-04-30-skip-empty-content-log/design.md
+++ b/openspec/changes/archive/2026-04-30-skip-empty-content-log/design.md
@@ -1,0 +1,25 @@
+## Context
+
+当前 Session 在流式响应处理时，`content` 为空字符串 `""` 时仍然打印日志行，产生大量无意义的空行日志。这发生在 delta 中其他字段（如 `reasoning`）非空时。
+
+## Goals / Non-Goals
+
+**Goals:**
+- 只有当 `content` 非空（truthy）时才记录日志
+- 同样适用于 `reasoning` 字段
+
+**Non-Goals:**
+- 不修改 SSE 流式响应逻辑
+- 不修改其他字段的日志行为
+
+## Decisions
+
+### 1. 空字符串检查
+
+**决定**: 使用 `if content:` 检查，这会同时排除 `None` 和空字符串
+
+**理由**: Python 中 `if content:` 等价于 `if content is not None and content != ""`，更简洁
+
+## Risks / Trade-offs
+
+无显著风险。

--- a/openspec/changes/archive/2026-04-30-skip-empty-content-log/proposal.md
+++ b/openspec/changes/archive/2026-04-30-skip-empty-content-log/proposal.md
@@ -1,0 +1,22 @@
+## Why
+
+Session 日志在 `content` 为空字符串时仍然打印日志行，产生无意义的空行日志。当 delta 中其他字段（如 `reasoning`）非空时，空的 `content` 日志是多余的。
+
+## What Changes
+
+- 修改 Session 日志逻辑：只有当 `content` 非空（不是 `None` 且不是空字符串）时才记录日志
+- 同样适用于 `reasoning` 字段
+
+## Capabilities
+
+### New Capabilities
+
+（无）
+
+### Modified Capabilities
+
+- `session-response-logging`: 修改日志行为，空字符串不记录
+
+## Impact
+
+- `src/psi_agent/session/runner.py` - 修改 `_stream_conversation` 中的日志逻辑

--- a/openspec/changes/archive/2026-04-30-skip-empty-content-log/specs/session-response-logging/spec.md
+++ b/openspec/changes/archive/2026-04-30-skip-empty-content-log/specs/session-response-logging/spec.md
@@ -1,4 +1,4 @@
-## ADDED Requirements
+## MODIFIED Requirements
 
 ### Requirement: Session logs all AI response fields
 

--- a/openspec/changes/archive/2026-04-30-skip-empty-content-log/tasks.md
+++ b/openspec/changes/archive/2026-04-30-skip-empty-content-log/tasks.md
@@ -1,0 +1,11 @@
+## 1. Session Runner Logging
+
+- [x] 1.1 Update `_stream_conversation` to skip logging when content is empty string
+- [x] 1.2 Update `_stream_conversation` to skip logging when reasoning is empty string
+
+## 2. Testing and Quality
+
+- [x] 2.1 Run existing test suite to verify no regressions
+- [x] 2.2 Run `ruff check` to verify lint passes
+- [x] 2.3 Run `ruff format` to verify formatting
+- [x] 2.4 Run `ty check` to verify type checking passes

--- a/openspec/changes/archive/2026-04-30-stream-thinking-field/.openspec.yaml
+++ b/openspec/changes/archive/2026-04-30-stream-thinking-field/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-30

--- a/openspec/changes/archive/2026-04-30-stream-thinking-field/design.md
+++ b/openspec/changes/archive/2026-04-30-stream-thinking-field/design.md
@@ -1,0 +1,76 @@
+## Context
+
+当前 Session 在流式响应中将思考内容（reasoning + 工具调用）包装在 `<thinking>` 标签中作为 `content` 字段发送。这导致 Channel 无法区分思考内容和最终回答。
+
+**当前 SSE 格式：**
+```
+data: {"choices": [{"delta": {"content": "<thinking>...</thinking>"}}]}
+data: {"choices": [{"delta": {"content": "最终回答..."}}]}
+```
+
+**期望 SSE 格式：**
+```
+data: {"choices": [{"delta": {"reasoning": "思考内容..."}}]}
+data: {"choices": [{"delta": {"content": "回答内容..."}}]}
+```
+
+**信息流动示例：**
+```
+AI -> Session: reasoning: 也许我应该
+Session -> Channel: reasoning: 也许我应该
+AI -> Session: reasoning: 用一下date这个工具
+Session -> Channel: reasoning: 用一下date这个工具
+AI -> Session: content: 让我用一下date
+Session -> Channel: content: 让我用一下date
+AI -> Session: func tool: bash call date
+Session -> Channel: reasoning: [Tool: bash] Arguments: {"command": "date"} Result: ...
+Session -> AI: 请求信息: 20260430 xx:xx:xx
+Session -> Channel: reasoning: 20260430 xx:xx:xx
+AI -> Session: reasoning: 哦，我知道了是xxxx
+Session -> Channel: reasoning: 哦，我知道了是xxxx
+AI -> Session: content: 现在是xxxx
+Session -> Channel: content: 现在是xxxx
+```
+
+## Goals / Non-Goals
+
+**Goals:**
+- Session 在流式响应中直接转发 AI 返回的 `reasoning` 字段
+- 工具调用过程作为 `reasoning` 字段发送
+- `content` 字段保持原样转发（包括 tool_calls 时的 content）
+- 保持向后兼容：如果 channel 不处理 `reasoning` 字段，仍能正常工作
+
+**Non-Goals:**
+- 不修改非流式响应格式
+- 不修改 history 存储格式
+
+## Decisions
+
+### 1. SSE delta 字段结构
+
+**决定**: 在 delta 中直接转发 AI 的 `reasoning` 字段，工具调用过程也作为 `reasoning` 发送，`content` 保持原样转发
+
+**格式：**
+```json
+{"choices": [{"delta": {"reasoning": "思考内容..."}}]}
+{"choices": [{"delta": {"content": "回答内容..."}}]}
+```
+
+**理由**: 
+- 保持 OpenAI SSE 格式兼容性（AI 已经返回 reasoning 字段）
+- `content` 保持原样，用户看到连贯的对话流
+- Channel 可以根据需要处理或忽略 `reasoning` 字段
+
+### 2. reasoning 内容来源
+
+**决定**: reasoning 内容包括：
+1. LLM 返回的 `reasoning` 字段（直接转发）
+2. 工具调用过程（工具名、参数、结果）- 格式化为文本发送
+3. 工具执行结果 - 作为 reasoning 发送
+
+**理由**: 这些都是"思考过程"，应该独立于 content 发送。
+
+## Risks / Trade-offs
+
+- **字段命名**: 使用 `reasoning` 字段，与 AI 返回的字段名一致
+- **Channel 兼容性**: 现有 channel 可能不处理 `reasoning` 字段，但这不影响基本功能

--- a/openspec/changes/archive/2026-04-30-stream-thinking-field/proposal.md
+++ b/openspec/changes/archive/2026-04-30-stream-thinking-field/proposal.md
@@ -1,0 +1,30 @@
+## Why
+
+Session 当前将思考内容（reasoning 和工具调用）包装在 `<thinking>` 标签中作为 `content` 字段发送给 channel。这导致：
+1. Channel 无法区分思考内容和最终回答
+2. 思考内容被嵌入在 content 中，而不是作为独立字段
+3. Channel 无法正确处理/显示思考过程
+
+## What Changes
+
+- 修改 Session 流式响应格式，将 AI 返回的 `reasoning` 字段直接流式转发给 channel
+- 工具调用过程作为 `reasoning` 字段发送
+- `content` 字段保持原样：AI 返回什么 content 就转发什么 content（包括 tool_calls 时的 content）
+- Channel 可以根据 `reasoning` 字段独立处理思考过程
+
+## Capabilities
+
+### New Capabilities
+
+- `stream-reasoning-field`: Session 在流式响应中转发 AI 的 reasoning 字段，并将工具调用过程也作为 reasoning 发送
+
+### Modified Capabilities
+
+（无）
+
+## Impact
+
+- `src/psi_agent/session/runner.py` - 修改 `_stream_conversation` 方法，流式转发 reasoning 字段
+- `src/psi_agent/channel/cli/cli.py` - 可能需要更新以处理 reasoning 字段
+- `src/psi_agent/channel/repl/client.py` - 可能需要更新以处理 reasoning 字段
+- `src/psi_agent/channel/telegram/client.py` - 可能需要更新以处理 reasoning 字段

--- a/openspec/changes/archive/2026-04-30-stream-thinking-field/specs/stream-reasoning-field/spec.md
+++ b/openspec/changes/archive/2026-04-30-stream-thinking-field/specs/stream-reasoning-field/spec.md
@@ -1,0 +1,33 @@
+## ADDED Requirements
+
+### Requirement: Session streams reasoning field separately
+
+Session SHALL stream reasoning content as a separate `reasoning` field in SSE delta, not embedded in `content`.
+
+#### Scenario: LLM returns reasoning content
+- **WHEN** AI returns streaming chunk with `reasoning` field
+- **THEN** Session SHALL stream the reasoning content as `reasoning` field in SSE delta
+
+#### Scenario: Tool call is executed
+- **WHEN** Session executes a tool call
+- **THEN** Session SHALL stream the tool call information (name, arguments, result) as `reasoning` field in SSE delta
+
+#### Scenario: LLM returns content
+- **WHEN** AI returns streaming chunk with `content` field
+- **THEN** Session SHALL stream the content as `content` field in SSE delta, regardless of whether tool_calls is present
+
+#### Scenario: No reasoning content
+- **WHEN** AI returns response without reasoning or tool calls
+- **THEN** Session SHALL only stream `content` field, without `reasoning` field
+
+### Requirement: Reasoning field format
+
+The `reasoning` field SHALL contain plain text content without XML-style tags.
+
+#### Scenario: Reasoning content format
+- **WHEN** streaming reasoning content from AI
+- **THEN** `reasoning` field SHALL contain the raw reasoning text without `<thinking>` tags
+
+#### Scenario: Tool call format
+- **WHEN** streaming tool call information
+- **THEN** `reasoning` field SHALL contain formatted text like `[Tool: name]\nArguments: {...}\nResult: ...`

--- a/openspec/changes/archive/2026-04-30-stream-thinking-field/tasks.md
+++ b/openspec/changes/archive/2026-04-30-stream-thinking-field/tasks.md
@@ -1,0 +1,12 @@
+## 1. Session Runner Streaming
+
+- [x] 1.1 Modify `_stream_conversation` to stream AI's `reasoning` field directly as `reasoning` in SSE delta
+- [x] 1.2 Modify `_stream_conversation` to stream tool calls as `reasoning` field (without `<thinking>` tags)
+- [x] 1.3 Ensure final content is streamed as `content` field without thinking tags
+
+## 2. Testing and Quality
+
+- [x] 2.1 Run existing test suite to verify no regressions
+- [x] 2.2 Run `ruff check` to verify lint passes
+- [x] 2.3 Run `ruff format` to verify formatting
+- [x] 2.4 Run `ty check` to verify type checking passes

--- a/openspec/changes/archive/2026-04-30-sync-channel-logging/.openspec.yaml
+++ b/openspec/changes/archive/2026-04-30-sync-channel-logging/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-30

--- a/openspec/changes/archive/2026-04-30-sync-channel-logging/design.md
+++ b/openspec/changes/archive/2026-04-30-sync-channel-logging/design.md
@@ -1,0 +1,42 @@
+## Context
+
+三个 channel 组件的日志风格不一致：
+- **cli**: 只记录 `content` 字段，不记录 `reasoning`
+- **repl**: 没有任何 stream 相关的日志
+- **telegram**: 日志风格与 session 不一致
+
+Session 的日志风格已经统一：
+- 记录 `reasoning` 字段（非空时）
+- 记录 `content` 字段（非空时）
+- 使用 DEBUG 级别
+
+## Goals / Non-Goals
+
+**Goals:**
+- 统一三个 channel 的日志风格，与 session 保持一致
+- 记录 `reasoning` 和 `content` 字段（非空时）
+- 使用相同的日志格式
+
+**Non-Goals:**
+- 不修改 channel 的业务逻辑
+- 不修改 SSE 解析逻辑
+
+## Decisions
+
+### 1. 日志格式
+
+**决定**: 使用与 session 相同的日志格式：
+- `Stream reasoning chunk: {content}` - reasoning 字段
+- `Stream content chunk: {content}` - content 字段
+
+**理由**: 保持一致性，便于调试和监控。
+
+### 2. 空值处理
+
+**决定**: 只有当字段非空时才记录日志
+
+**理由**: 避免无意义的空行日志，与 session 行为一致。
+
+## Risks / Trade-offs
+
+无显著风险。

--- a/openspec/changes/archive/2026-04-30-sync-channel-logging/proposal.md
+++ b/openspec/changes/archive/2026-04-30-sync-channel-logging/proposal.md
@@ -1,0 +1,29 @@
+## Why
+
+三个 channel（cli、repl、telegram）的日志风格与 session 不一致：
+1. cli channel 不记录 `reasoning` 字段内容
+2. repl channel 没有任何 stream 相关的日志
+3. 日志格式不统一，难以调试和监控
+
+## What Changes
+
+- 统一三个 channel 的日志风格，与 session 保持一致
+- 记录 `reasoning` 字段内容
+- 记录 `content` 字段内容（非空时）
+- 使用相同的日志格式和级别
+
+## Capabilities
+
+### New Capabilities
+
+- `channel-stream-logging`: Channel 组件对流式响应的日志记录规范
+
+### Modified Capabilities
+
+（无）
+
+## Impact
+
+- `src/psi_agent/channel/cli/cli.py` - 添加 reasoning 日志
+- `src/psi_agent/channel/repl/client.py` - 添加 stream 日志
+- `src/psi_agent/channel/telegram/client.py` - 统一日志风格

--- a/openspec/changes/archive/2026-04-30-sync-channel-logging/specs/channel-stream-logging/spec.md
+++ b/openspec/changes/archive/2026-04-30-sync-channel-logging/specs/channel-stream-logging/spec.md
@@ -1,0 +1,37 @@
+## ADDED Requirements
+
+### Requirement: Channel logs all AI response fields
+
+Channel SHALL log all non-empty fields from AI streaming response chunks at DEBUG level, without truncation.
+
+#### Scenario: Reasoning field is present and non-empty
+- **WHEN** Channel receives a streaming chunk with non-empty `reasoning` field
+- **THEN** Channel SHALL log `Stream reasoning chunk: {content}` with the complete reasoning content
+
+#### Scenario: Content field is present and non-empty
+- **WHEN** Channel receives a streaming chunk with non-empty `content` field
+- **THEN** Channel SHALL log `Stream content chunk: {content}` with the complete content
+
+#### Scenario: Content field is empty string
+- **WHEN** Channel receives a streaming chunk with `content: ""`
+- **THEN** Channel SHALL skip logging the content field
+
+#### Scenario: Content field is null
+- **WHEN** Channel receives a streaming chunk with `content: null`
+- **THEN** Channel SHALL skip logging the content field
+
+#### Scenario: Reasoning field is empty or null
+- **WHEN** Channel receives a streaming chunk with empty or null `reasoning` field
+- **THEN** Channel SHALL skip logging the reasoning field
+
+### Requirement: Defensive logging for null values
+
+All channel logging code SHALL use defensive null checks before accessing response fields.
+
+#### Scenario: Delta content is null
+- **WHEN** streaming delta has `content: null`
+- **THEN** logging code SHALL skip content logging without crash
+
+#### Scenario: Delta reasoning is null
+- **WHEN** streaming delta has `reasoning: null`
+- **THEN** logging code SHALL skip reasoning logging without crash

--- a/openspec/changes/archive/2026-04-30-sync-channel-logging/tasks.md
+++ b/openspec/changes/archive/2026-04-30-sync-channel-logging/tasks.md
@@ -1,0 +1,20 @@
+## 1. CLI Channel
+
+- [x] 1.1 Add reasoning field logging to cli channel stream handler
+- [x] 1.2 Add defensive null checks for content and reasoning fields
+
+## 2. REPL Channel
+
+- [x] 2.1 Add stream logging to repl channel (reasoning and content)
+- [x] 2.2 Add defensive null checks for content and reasoning fields
+
+## 3. Telegram Channel
+
+- [x] 3.1 Update telegram channel logging to match session format
+- [x] 3.2 Add defensive null checks for content and reasoning fields
+
+## 4. Testing
+
+- [x] 4.1 Run ruff check and format
+- [x] 4.2 Run ty check
+- [x] 4.3 Run tests

--- a/openspec/specs/channel-stream-logging/spec.md
+++ b/openspec/specs/channel-stream-logging/spec.md
@@ -1,0 +1,37 @@
+## ADDED Requirements
+
+### Requirement: Channel logs all AI response fields
+
+Channel SHALL log all non-empty fields from AI streaming response chunks at DEBUG level, without truncation.
+
+#### Scenario: Reasoning field is present and non-empty
+- **WHEN** Channel receives a streaming chunk with non-empty `reasoning` field
+- **THEN** Channel SHALL log `Stream reasoning chunk: {content}` with the complete reasoning content
+
+#### Scenario: Content field is present and non-empty
+- **WHEN** Channel receives a streaming chunk with non-empty `content` field
+- **THEN** Channel SHALL log `Stream content chunk: {content}` with the complete content
+
+#### Scenario: Content field is empty string
+- **WHEN** Channel receives a streaming chunk with `content: ""`
+- **THEN** Channel SHALL skip logging the content field
+
+#### Scenario: Content field is null
+- **WHEN** Channel receives a streaming chunk with `content: null`
+- **THEN** Channel SHALL skip logging the content field
+
+#### Scenario: Reasoning field is empty or null
+- **WHEN** Channel receives a streaming chunk with empty or null `reasoning` field
+- **THEN** Channel SHALL skip logging the reasoning field
+
+### Requirement: Defensive logging for null values
+
+All channel logging code SHALL use defensive null checks before accessing response fields.
+
+#### Scenario: Delta content is null
+- **WHEN** streaming delta has `content: null`
+- **THEN** logging code SHALL skip content logging without crash
+
+#### Scenario: Delta reasoning is null
+- **WHEN** streaming delta has `reasoning: null`
+- **THEN** logging code SHALL skip reasoning logging without crash

--- a/openspec/specs/stream-reasoning-field/spec.md
+++ b/openspec/specs/stream-reasoning-field/spec.md
@@ -1,0 +1,33 @@
+## ADDED Requirements
+
+### Requirement: Session streams reasoning field separately
+
+Session SHALL stream reasoning content as a separate `reasoning` field in SSE delta, not embedded in `content`.
+
+#### Scenario: LLM returns reasoning content
+- **WHEN** AI returns streaming chunk with `reasoning` field
+- **THEN** Session SHALL stream the reasoning content as `reasoning` field in SSE delta
+
+#### Scenario: Tool call is executed
+- **WHEN** Session executes a tool call
+- **THEN** Session SHALL stream the tool call information (name, arguments, result) as `reasoning` field in SSE delta
+
+#### Scenario: LLM returns content
+- **WHEN** AI returns streaming chunk with `content` field
+- **THEN** Session SHALL stream the content as `content` field in SSE delta, regardless of whether tool_calls is present
+
+#### Scenario: No reasoning content
+- **WHEN** AI returns response without reasoning or tool calls
+- **THEN** Session SHALL only stream `content` field, without `reasoning` field
+
+### Requirement: Reasoning field format
+
+The `reasoning` field SHALL contain plain text content without XML-style tags.
+
+#### Scenario: Reasoning content format
+- **WHEN** streaming reasoning content from AI
+- **THEN** `reasoning` field SHALL contain the raw reasoning text without `<thinking>` tags
+
+#### Scenario: Tool call format
+- **WHEN** streaming tool call information
+- **THEN** `reasoning` field SHALL contain formatted text like `[Tool: name]\nArguments: {...}\nResult: ...`

--- a/src/psi_agent/channel/cli/cli.py
+++ b/src/psi_agent/channel/cli/cli.py
@@ -95,12 +95,18 @@ async def _handle_streaming(response: aiohttp.ClientResponse) -> str:
             try:
                 chunk = json.loads(line_str[6:])
                 delta = chunk.get("choices", [{}])[0].get("delta", {})
+
+                # Log reasoning field if present and non-empty
+                reasoning = delta.get("reasoning")
+                if reasoning:
+                    logger.debug(f"Stream reasoning chunk: {reasoning}")
+
+                # Log content field if present and non-empty
                 content = delta.get("content")
                 if content is not None:
                     content_parts.append(content)
-                    truncated = content[:100]
-                    suffix = "..." if len(content) > 100 else ""
-                    logger.debug(f"Stream chunk: {truncated}{suffix}")
+                    if content:
+                        logger.debug(f"Stream content chunk: {content}")
                     # Print chunk immediately for streaming
                     print(content, end="", flush=True)
             except json.JSONDecodeError:

--- a/src/psi_agent/channel/repl/client.py
+++ b/src/psi_agent/channel/repl/client.py
@@ -93,9 +93,17 @@ class ReplClient:
                             choices = chunk.get("choices", [])
                             if choices:
                                 delta = choices[0].get("delta", {})
-                                content = delta.get("content", "")
+
+                                # Log reasoning field if present and non-empty
+                                reasoning = delta.get("reasoning")
+                                if reasoning:
+                                    logger.debug(f"Stream reasoning chunk: {reasoning}")
+
+                                # Log content field if present and non-empty
+                                content = delta.get("content")
                                 if content:
                                     content_chunks.append(content)
+                                    logger.debug(f"Stream content chunk: {content}")
                                     if on_chunk is not None:
                                         on_chunk(content)
                         except json.JSONDecodeError:

--- a/src/psi_agent/channel/telegram/client.py
+++ b/src/psi_agent/channel/telegram/client.py
@@ -153,9 +153,17 @@ class TelegramClient:
                             choices = chunk.get("choices", [])
                             if choices:
                                 delta = choices[0].get("delta", {})
-                                content = delta.get("content", "")
+
+                                # Log reasoning field if present and non-empty
+                                reasoning = delta.get("reasoning")
+                                if reasoning:
+                                    logger.debug(f"Stream reasoning chunk: {reasoning}")
+
+                                # Log content field if present and non-empty
+                                content = delta.get("content")
                                 if content:
                                     content_chunks.append(content)
+                                    logger.debug(f"Stream content chunk: {content}")
                                     if on_chunk is not None:
                                         on_chunk(content)
                         except json.JSONDecodeError:

--- a/src/psi_agent/session/runner.py
+++ b/src/psi_agent/session/runner.py
@@ -562,10 +562,28 @@ class SessionRunner:
                             chunk = json.loads(line_str[6:])
                             delta = chunk.get("choices", [{}])[0].get("delta", {})
 
+                            # Stream reasoning field directly if present
+                            reasoning = delta.get("reasoning")
+                            if reasoning:
+                                logger.debug(f"Stream reasoning chunk: {reasoning}")
+                                reasoning_data = {
+                                    "choices": [
+                                        {"delta": {"reasoning": reasoning}, "finish_reason": None}
+                                    ]
+                                }
+                                yield f"data: {json.dumps(reasoning_data)}\n\n"
+
+                            # Stream content field directly if present
                             content = delta.get("content")
                             if content is not None:
                                 content_chunks.append(content)
                                 logger.debug(f"Stream content chunk: {content}")
+                                content_data = {
+                                    "choices": [
+                                        {"delta": {"content": content}, "finish_reason": None}
+                                    ]
+                                }
+                                yield f"data: {json.dumps(content_data)}\n\n"
 
                             tool_calls = delta.get("tool_calls")
                             if tool_calls is not None:
@@ -595,7 +613,7 @@ class SessionRunner:
                 # Execute tools
                 tool_messages = await execute_tools_parallel(self.registry, tool_calls)
 
-                # Yield thinking blocks for each tool call immediately
+                # Yield tool call information as reasoning field
                 for i, tool_call in enumerate(tool_calls):
                     tool_name = tool_call.get("function", {}).get("name", "unknown")
                     arguments = tool_call.get("function", {}).get("arguments", "{}")
@@ -603,14 +621,18 @@ class SessionRunner:
                         tool_result = tool_messages[i].get("content", "")
                     else:
                         tool_result = ""
-                    thinking_block = format_tool_call_thinking(tool_name, arguments, tool_result)
 
-                    # Yield thinking block as SSE event
-                    thinking_data = {
-                        "choices": [{"delta": {"content": thinking_block}, "finish_reason": None}]
+                    # Format tool call info without thinking tags
+                    tool_info = (
+                        f"[Tool: {tool_name}]\nArguments: {arguments}\nResult: {tool_result}"
+                    )
+                    logger.debug(f"Stream tool call reasoning: {tool_info}")
+
+                    # Yield as reasoning field
+                    reasoning_data = {
+                        "choices": [{"delta": {"reasoning": tool_info}, "finish_reason": None}]
                     }
-                    data = json.dumps(thinking_data)
-                    yield f"data: {data}\n\n"
+                    yield f"data: {json.dumps(reasoning_data)}\n\n"
 
                 # Add tool results to history and current messages
                 for tool_msg in tool_messages:
@@ -626,13 +648,7 @@ class SessionRunner:
             self.history.add_message({"role": "assistant", "content": final_content})
             await persist_history(self.history)
 
-            # Yield final content
-            for chunk in content_chunks:
-                chunk_data = {"choices": [{"delta": {"content": chunk}, "finish_reason": None}]}
-                data = json.dumps(chunk_data)
-                yield f"data: {data}\n\n"
-
-            # Send done marker
+            # Yield final content (already yielded during streaming, just send done)
             yield "data: [DONE]\n\n"
             return
 

--- a/src/psi_agent/session/runner.py
+++ b/src/psi_agent/session/runner.py
@@ -577,7 +577,8 @@ class SessionRunner:
                             content = delta.get("content")
                             if content is not None:
                                 content_chunks.append(content)
-                                logger.debug(f"Stream content chunk: {content}")
+                                if content:  # Only log non-empty content
+                                    logger.debug(f"Stream content chunk: {content}")
                                 content_data = {
                                     "choices": [
                                         {"delta": {"content": content}, "finish_reason": None}

--- a/tests/session/test_runner.py
+++ b/tests/session/test_runner.py
@@ -797,9 +797,9 @@ async def tool(message: str) -> str:
                 async for chunk in runner._stream_conversation(messages):
                     chunks.append(chunk)
 
-                # Should include thinking block
+                # Should include reasoning field with tool call info
                 full_content = "".join(chunks)
-                assert "<thinking>" in full_content
+                assert '"reasoning"' in full_content
                 assert "[Tool: echo]" in full_content
 
     @pytest.mark.asyncio
@@ -938,9 +938,9 @@ async def tool(message: str) -> str:
                 async for chunk in runner._stream_conversation(messages):
                     chunks.append(chunk)
 
-                # Should process tool calls and include thinking block
+                # Should process tool calls and include reasoning field
                 full_content = "".join(chunks)
-                assert "<thinking>" in full_content
+                assert '"reasoning"' in full_content
                 assert "[Tool: echo]" in full_content
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- Stream `reasoning` field separately from `content` in SSE responses (not embedded in `<thinking>` tags)
- Skip logging for empty content/reasoning fields to reduce noise
- Synchronize channel logging (cli, repl, telegram) with session logging style

## Changes

### Session Runner
- Stream `reasoning` field directly in SSE chunks
- Stream `content` field directly in SSE chunks
- Skip logging when content or reasoning is empty/null

### Channel Logging
- CLI: Add reasoning field logging, remove truncation
- REPL: Add stream logging for reasoning and content fields
- Telegram: Add reasoning logging during streaming

All channels now use consistent format:
- `Stream reasoning chunk: {content}`
- `Stream content chunk: {content}`

## Test plan

- [x] Run `ruff check` and `ruff format`
- [x] Run `ty check` for type safety
- [x] Run `pytest` - all tests pass
- [x] Manual testing with cli channel

🤖 Generated with [Claude Code](https://claude.com/claude-code)