### PR TITLE
Fix Anthropic Messages API streaming: remove invalid stream parameter

### DIFF
--- a/openspec/changes/archive/2026-04-30-add-streaming-tests/.openspec.yaml
+++ b/openspec/changes/archive/2026-04-30-add-streaming-tests/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-30

--- a/openspec/changes/archive/2026-04-30-add-streaming-tests/design.md
+++ b/openspec/changes/archive/2026-04-30-add-streaming-tests/design.md
@@ -1,0 +1,24 @@
+## Context
+
+The `_stream_request` method in `AnthropicMessagesClient` was recently modified to filter out the `stream` key before calling `messages.stream()`. This code path has no test coverage, causing codecov to report insufficient patch coverage.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Add tests for `_stream_request` method
+- Cover the `stream` key filtering logic
+- Cover error handling in streaming requests
+
+**Non-Goals:**
+- No changes to production code
+- No changes to other test files
+
+## Decisions
+
+**Use mock for Anthropic SDK streaming API**
+
+The tests will mock `AsyncAnthropic` and its `messages.stream()` method to avoid making real API calls. This follows the existing pattern in `test_client.py`.
+
+## Risks / Trade-offs
+
+No risks. This is purely adding test coverage.

--- a/openspec/changes/archive/2026-04-30-add-streaming-tests/proposal.md
+++ b/openspec/changes/archive/2026-04-30-add-streaming-tests/proposal.md
@@ -1,0 +1,25 @@
+## Why
+
+Codecov reports insufficient test coverage for the `_stream_request` method in `AnthropicMessagesClient`. The recent fix for the streaming parameter bug (PR #83) added code that is not covered by existing tests.
+
+## What Changes
+
+- Add tests for `_stream_request` method covering:
+  - Successful streaming request with proper `stream` key removal
+  - Streaming request error handling (authentication, rate limit, connection errors)
+  - Model injection during streaming requests
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+None.
+
+## Impact
+
+- **Affected code**: `tests/ai/anthropic_messages/test_client.py` — add new test cases
+- **Coverage target**: Cover the `_stream_request` method and the `stream` key filtering logic

--- a/openspec/changes/archive/2026-04-30-add-streaming-tests/specs/spec.md
+++ b/openspec/changes/archive/2026-04-30-add-streaming-tests/specs/spec.md
@@ -1,0 +1,3 @@
+## No Spec Changes
+
+This change adds test coverage only. No new capabilities or requirement changes.

--- a/openspec/changes/archive/2026-04-30-add-streaming-tests/tasks.md
+++ b/openspec/changes/archive/2026-04-30-add-streaming-tests/tasks.md
@@ -1,0 +1,13 @@
+## 1. Implementation
+
+- [x] 1.1 Add test for successful streaming request with `stream` key removal
+- [x] 1.2 Add test for streaming request model injection
+- [x] 1.3 Add test for streaming request error handling (authentication error)
+- [x] 1.4 Add test for streaming request error handling (rate limit error)
+- [x] 1.5 Add test for streaming request error handling (connection error)
+
+## 2. Verification
+
+- [x] 2.1 Run `ruff check` and `ruff format`
+- [x] 2.2 Run `ty check` for type checking
+- [x] 2.3 Run tests with `pytest tests/ai/anthropic_messages/`

--- a/openspec/changes/archive/2026-04-30-fix-anthropic-stream-arg/.openspec.yaml
+++ b/openspec/changes/archive/2026-04-30-fix-anthropic-stream-arg/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-30

--- a/openspec/changes/archive/2026-04-30-fix-anthropic-stream-arg/design.md
+++ b/openspec/changes/archive/2026-04-30-fix-anthropic-stream-arg/design.md
@@ -1,0 +1,37 @@
+## Context
+
+The `AnthropicMessagesClient._stream_request()` method in `src/psi_agent/ai/anthropic_messages/client.py` incorrectly passes a `stream` parameter to the Anthropic SDK's `messages.stream()` method. The SDK's streaming API doesn't accept this parameter because streaming is implied by using `.stream()` instead of `.create()`.
+
+Current problematic code (line 127):
+```python
+body["stream"] = True
+try:
+    logger.info("Starting streaming request")
+
+    async def anthropic_event_stream() -> AsyncGenerator[str]:
+        async with client.messages.stream(**body) as stream:  # Error: 'stream' kwarg
+            ...
+```
+
+## Goals / Non-Goals
+
+**Goals:**
+- Fix the `TypeError` by removing the `stream` key from the body before calling `messages.stream()`
+
+**Non-Goals:**
+- No API changes
+- No behavioral changes to streaming functionality
+- No changes to non-streaming code path
+
+## Decisions
+
+**Decision: Remove `stream` key before calling `.stream()`**
+
+The `stream` key is set on line 127 and passed to `messages.stream()` on line 133. The fix is to simply remove this line since:
+1. The `stream` parameter is not accepted by `messages.stream()`
+2. Streaming is already implied by using `.stream()` instead of `.create()`
+3. The `stream` key is already present in the body from the translator (line 65 in `translator.py`)
+
+## Risks / Trade-offs
+
+No risks. This is a straightforward bug fix with no behavioral changes.

--- a/openspec/changes/archive/2026-04-30-fix-anthropic-stream-arg/proposal.md
+++ b/openspec/changes/archive/2026-04-30-fix-anthropic-stream-arg/proposal.md
@@ -1,0 +1,25 @@
+## Why
+
+The Anthropic Messages API client fails when making streaming requests because it incorrectly passes a `stream` parameter to `messages.stream()`. The Anthropic SDK's `.stream()` method doesn't accept a `stream` parameter—streaming is implied by using `.stream()` instead of `.create()`.
+
+This causes a `TypeError: AsyncMessages.stream() got an unexpected keyword argument 'stream'` when attempting any streaming request through the Anthropic Messages adapter.
+
+## What Changes
+
+- Remove the `stream` key from the request body before passing it to `client.messages.stream()` in `AnthropicMessagesClient._stream_request()`
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+None.
+
+## Impact
+
+- **Affected code**: `src/psi_agent/ai/anthropic_messages/client.py` — single line fix in `_stream_request()` method
+- **API compatibility**: No API changes, purely internal fix
+- **Dependencies**: No dependency changes

--- a/openspec/changes/archive/2026-04-30-fix-anthropic-stream-arg/specs/spec.md
+++ b/openspec/changes/archive/2026-04-30-fix-anthropic-stream-arg/specs/spec.md
@@ -1,0 +1,5 @@
+## No Spec Changes
+
+This change is a bug fix with no capability changes. The existing behavior (streaming requests) remains unchanged—only the implementation is corrected to remove an invalid parameter.
+
+No new requirements are added, modified, or removed.

--- a/openspec/changes/archive/2026-04-30-fix-anthropic-stream-arg/tasks.md
+++ b/openspec/changes/archive/2026-04-30-fix-anthropic-stream-arg/tasks.md
@@ -1,0 +1,9 @@
+## 1. Implementation
+
+- [x] 1.1 Remove `body["stream"] = True` line in `_stream_request()` method in `src/psi_agent/ai/anthropic_messages/client.py`
+
+## 2. Verification
+
+- [x] 2.1 Run `ruff check` and `ruff format`
+- [x] 2.2 Run `ty check` for type checking
+- [x] 2.3 Run tests with `pytest tests/ai/anthropic_messages/`

--- a/src/psi_agent/ai/anthropic_messages/client.py
+++ b/src/psi_agent/ai/anthropic_messages/client.py
@@ -124,7 +124,9 @@ class AnthropicMessagesClient:
         assert self._client is not None
         client = self._client  # Capture for closure
 
-        body["stream"] = True
+        # Remove 'stream' key - messages.stream() doesn't accept this parameter
+        body = {k: v for k, v in body.items() if k != "stream"}
+
         try:
             logger.info("Starting streaming request")
 

--- a/tests/ai/anthropic_messages/test_client.py
+++ b/tests/ai/anthropic_messages/test_client.py
@@ -259,3 +259,235 @@ class TestAnthropicMessagesClient:
                 assert not isinstance(result, AsyncGenerator)
                 assert "error" in result
                 assert result["status_code"] == 500
+
+    @pytest.mark.asyncio
+    async def test_streaming_request_success(self, client: AnthropicMessagesClient) -> None:
+        """Test successful streaming request with stream key removal."""
+        from unittest.mock import MagicMock
+
+        # Create mock stream events
+        mock_event = MagicMock()
+        mock_event.type = "content_block_delta"
+        mock_event.model_dump = MagicMock(
+            return_value={
+                "type": "content_block_delta",
+                "index": 0,
+                "delta": {"type": "text_delta", "text": "Hello"},
+            }
+        )
+
+        # Create mock stream context manager
+        mock_stream = AsyncMock()
+        mock_stream.__aenter__ = AsyncMock(return_value=mock_stream)
+        mock_stream.__aexit__ = AsyncMock(return_value=None)
+        mock_stream.__aiter__ = MagicMock(return_value=iter([mock_event]))
+
+        with patch("psi_agent.ai.anthropic_messages.client.AsyncAnthropic") as mock_anthropic:
+            mock_instance = AsyncMock()
+            mock_instance.messages.stream = MagicMock(return_value=mock_stream)
+            mock_instance.close = AsyncMock()
+            mock_anthropic.return_value = mock_instance
+
+            async with client:
+                result = await client.messages(
+                    {
+                        "messages": [{"role": "user", "content": "Hello"}],
+                        "max_tokens": 1024,
+                        "stream": True,  # This should be filtered out
+                    },
+                    stream=True,
+                )
+
+                # Type narrowing: streaming returns AsyncGenerator
+                assert isinstance(result, AsyncGenerator)
+
+                # Collect chunks from the generator
+                chunks = []
+                async for chunk in result:
+                    chunks.append(chunk)
+
+                # Verify we got chunks
+                assert len(chunks) > 0
+
+                # Verify stream key was NOT passed to messages.stream()
+                call_kwargs = mock_instance.messages.stream.call_args[1]
+                assert "stream" not in call_kwargs
+
+    @pytest.mark.asyncio
+    async def test_streaming_request_model_injection(self, client: AnthropicMessagesClient) -> None:
+        """Test model is injected during streaming request."""
+        from unittest.mock import MagicMock
+
+        mock_event = MagicMock()
+        mock_event.type = "message_start"
+        mock_event.model_dump = MagicMock(
+            return_value={
+                "type": "message_start",
+                "message": {"id": "msg_123", "model": "claude-sonnet-4-20250514"},
+            }
+        )
+
+        mock_stream = AsyncMock()
+        mock_stream.__aenter__ = AsyncMock(return_value=mock_stream)
+        mock_stream.__aexit__ = AsyncMock(return_value=None)
+        mock_stream.__aiter__ = MagicMock(return_value=iter([mock_event]))
+
+        with patch("psi_agent.ai.anthropic_messages.client.AsyncAnthropic") as mock_anthropic:
+            mock_instance = AsyncMock()
+            mock_instance.messages.stream = MagicMock(return_value=mock_stream)
+            mock_instance.close = AsyncMock()
+            mock_anthropic.return_value = mock_instance
+
+            async with client:
+                result = await client.messages(
+                    {
+                        "messages": [{"role": "user", "content": "Hello"}],
+                        "max_tokens": 1024,
+                    },
+                    stream=True,
+                )
+
+                # Type narrowing: streaming returns AsyncGenerator
+                assert isinstance(result, AsyncGenerator)
+
+                # Consume the generator
+                async for _ in result:
+                    pass
+
+                # Check that model was injected
+                call_kwargs = mock_instance.messages.stream.call_args[1]
+                assert call_kwargs["model"] == "claude-sonnet-4-20250514"
+
+    @pytest.mark.asyncio
+    async def test_streaming_request_authentication_error(
+        self, client: AnthropicMessagesClient
+    ) -> None:
+        """Test streaming request authentication error handling."""
+        from unittest.mock import MagicMock
+
+        mock_stream = AsyncMock()
+        mock_stream.__aenter__ = AsyncMock(
+            side_effect=AuthenticationError(
+                message="Invalid API key",
+                response=MagicMock(status_code=401),
+                body={"error": {"message": "Invalid API key"}},
+            )
+        )
+        mock_stream.__aexit__ = AsyncMock(return_value=None)
+
+        with patch("psi_agent.ai.anthropic_messages.client.AsyncAnthropic") as mock_anthropic:
+            mock_instance = AsyncMock()
+            mock_instance.messages.stream = MagicMock(return_value=mock_stream)
+            mock_instance.close = AsyncMock()
+            mock_anthropic.return_value = mock_instance
+
+            async with client:
+                result = await client.messages(
+                    {
+                        "messages": [{"role": "user", "content": "Hello"}],
+                        "max_tokens": 1024,
+                    },
+                    stream=True,
+                )
+
+                # Type narrowing: streaming returns AsyncGenerator
+                assert isinstance(result, AsyncGenerator)
+
+                # Collect chunks from the generator
+                chunks = []
+                async for chunk in result:
+                    chunks.append(chunk)
+
+                # Should have error chunk
+                assert len(chunks) == 1
+                import json
+
+                error_data = json.loads(chunks[0].replace("data: ", "").strip())
+                assert "error" in error_data
+                assert error_data["status_code"] == 401
+
+    @pytest.mark.asyncio
+    async def test_streaming_request_rate_limit_error(
+        self, client: AnthropicMessagesClient
+    ) -> None:
+        """Test streaming request rate limit error handling."""
+        from unittest.mock import MagicMock
+
+        mock_stream = AsyncMock()
+        mock_stream.__aenter__ = AsyncMock(
+            side_effect=RateLimitError(
+                message="Rate limit exceeded",
+                response=MagicMock(status_code=429),
+                body={"error": {"message": "Rate limit exceeded"}},
+            )
+        )
+        mock_stream.__aexit__ = AsyncMock(return_value=None)
+
+        with patch("psi_agent.ai.anthropic_messages.client.AsyncAnthropic") as mock_anthropic:
+            mock_instance = AsyncMock()
+            mock_instance.messages.stream = MagicMock(return_value=mock_stream)
+            mock_instance.close = AsyncMock()
+            mock_anthropic.return_value = mock_instance
+
+            async with client:
+                result = await client.messages(
+                    {
+                        "messages": [{"role": "user", "content": "Hello"}],
+                        "max_tokens": 1024,
+                    },
+                    stream=True,
+                )
+
+                # Type narrowing: streaming returns AsyncGenerator
+                assert isinstance(result, AsyncGenerator)
+
+                chunks = []
+                async for chunk in result:
+                    chunks.append(chunk)
+
+                assert len(chunks) == 1
+                import json
+
+                error_data = json.loads(chunks[0].replace("data: ", "").strip())
+                assert "error" in error_data
+                assert error_data["status_code"] == 429
+
+    @pytest.mark.asyncio
+    async def test_streaming_request_connection_error(
+        self, client: AnthropicMessagesClient
+    ) -> None:
+        """Test streaming request connection error handling."""
+        from unittest.mock import MagicMock
+
+        mock_stream = AsyncMock()
+        mock_stream.__aenter__ = AsyncMock(side_effect=APIConnectionError(request=MagicMock()))
+        mock_stream.__aexit__ = AsyncMock(return_value=None)
+
+        with patch("psi_agent.ai.anthropic_messages.client.AsyncAnthropic") as mock_anthropic:
+            mock_instance = AsyncMock()
+            mock_instance.messages.stream = MagicMock(return_value=mock_stream)
+            mock_instance.close = AsyncMock()
+            mock_anthropic.return_value = mock_instance
+
+            async with client:
+                result = await client.messages(
+                    {
+                        "messages": [{"role": "user", "content": "Hello"}],
+                        "max_tokens": 1024,
+                    },
+                    stream=True,
+                )
+
+                # Type narrowing: streaming returns AsyncGenerator
+                assert isinstance(result, AsyncGenerator)
+
+                chunks = []
+                async for chunk in result:
+                    chunks.append(chunk)
+
+                assert len(chunks) == 1
+                import json
+
+                error_data = json.loads(chunks[0].replace("data: ", "").strip())
+                assert "error" in error_data
+                assert error_data["status_code"] == 500


### PR DESCRIPTION
## Summary

- Fix `TypeError: AsyncMessages.stream() got an unexpected keyword argument 'stream'` when making streaming requests through the Anthropic Messages adapter
- The `messages.stream()` method doesn't accept a `stream` parameter — streaming is implied by using `.stream()` instead of `.create()`
- Filter out the `stream` key from the request body before calling `messages.stream()`

## Test plan

- [x] Run `ruff check` and `ruff format`
- [x] Run `ty check` for type checking
- [x] Run `pytest tests/ai/anthropic_messages/` (56 tests passed)
- [x] Manual testing with streaming requests

🤖 Generated with [Claude Code](https://claude.com/claude-code)