### PR TITLE
Add unified reasoning_effort parameter for consistent LLM behavior

### DIFF
--- a/openspec/changes/archive/2026-04-30-unified-reasoning/.openspec.yaml
+++ b/openspec/changes/archive/2026-04-30-unified-reasoning/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-30

--- a/openspec/changes/archive/2026-04-30-unified-reasoning/design.md
+++ b/openspec/changes/archive/2026-04-30-unified-reasoning/design.md
@@ -1,0 +1,71 @@
+## Context
+
+Different LLM providers have inconsistent default behavior for reasoning/extended thinking:
+- Some models (e.g., Claude with extended thinking) enable reasoning by default or require explicit opt-in
+- Others may not support reasoning at all or have different parameter names
+- This creates unpredictable agent behavior when switching between models
+
+The current architecture:
+- Session (`runner.py`) builds request body and sends to AI component
+- AI components (`openai_completions`, `anthropic_messages`) forward requests to upstream APIs
+- No reasoning parameter is currently passed in requests
+
+## Goals / Non-Goals
+
+**Goals:**
+- Session uniformly adds `reasoning_effort` parameter to all AI requests
+- AI components pass through reasoning-related parameters transparently
+- Consistent extended thinking behavior across different LLM providers
+
+**Non-Goals:**
+- Model-specific reasoning configuration (e.g., different reasoning levels per model)
+- Runtime detection of reasoning support (models that don't support it will ignore the parameter)
+- Exposing reasoning configuration to end users via CLI (can be added later if needed)
+
+## Decisions
+
+### Decision 1: Use `reasoning_effort` as the standard parameter name
+
+**Rationale:** OpenAI uses `reasoning_effort` for o1/o3 models. This is the most widely adopted naming convention.
+
+**Alternatives considered:**
+- `thinking_budget` - Anthropic-specific naming
+- `extended_thinking` - Too verbose
+- Provider-specific parameters - Would require mapping logic in session
+
+### Decision 2: Session adds reasoning parameter, AI components pass through
+
+**Rationale:** Separation of concerns. Session decides WHAT parameters to include, AI components handle HOW to format them for the upstream API.
+
+**Alternatives considered:**
+- AI components add reasoning parameter - Would require model-specific logic in AI layer
+- Channel provides reasoning parameter - Would leak LLM details to channel layer
+
+### Decision 3: Default reasoning_effort to "medium"
+
+**Rationale:** Provides a reasonable default that balances quality and cost. Users can override if needed.
+
+**Alternatives considered:**
+- No default (let model decide) - Inconsistent behavior across models
+- "high" as default - Higher cost, may not be needed for all use cases
+- "low" as default - May not provide sufficient reasoning quality
+
+### Decision 4: Anthropic translator maps `reasoning_effort` to `thinking.budget_tokens`
+
+**Rationale:** Anthropic uses a different parameter structure for extended thinking. The translator already handles format conversion between OpenAI and Anthropic formats.
+
+**Mapping:**
+- `reasoning_effort: "low"` → `thinking: { "budget_tokens": 1024 }`
+- `reasoning_effort: "medium"` → `thinking: { "budget_tokens": 4096 }`
+- `reasoning_effort: "high"` → `thinking: { "budget_tokens": 16384 }`
+
+## Risks / Trade-offs
+
+**Risk: Models that don't support reasoning may reject the parameter**
+→ Mitigation: Most APIs ignore unknown parameters. If an API rejects it, we can add provider-specific handling later.
+
+**Risk: Different models interpret reasoning_effort differently**
+→ Mitigation: This is acceptable - the goal is consistent enabling of reasoning, not identical behavior.
+
+**Risk: Increased token usage and cost**
+→ Mitigation: Default to "medium" which provides reasonable reasoning without excessive cost. Document this in configuration.

--- a/openspec/changes/archive/2026-04-30-unified-reasoning/proposal.md
+++ b/openspec/changes/archive/2026-04-30-unified-reasoning/proposal.md
@@ -1,0 +1,29 @@
+## Why
+
+Different LLM models have inconsistent default reasoning behavior - some enable extended thinking by default while others don't. This creates unpredictable agent behavior when switching models. We need session to uniformly enable reasoning for all requests, and AI components to pass through the reasoning parameter without modification.
+
+## What Changes
+
+- Session will add `reasoning_effort` parameter to all AI requests by default
+- AI components (openai-completions, anthropic-messages) will pass through `reasoning_effort` parameter to upstream APIs without modification
+- No model-specific logic in AI components - they act as transparent proxies for this parameter
+
+## Capabilities
+
+### New Capabilities
+
+- `unified-reasoning`: Session uniformly enables reasoning for all AI requests, ensuring consistent extended thinking behavior across different LLM providers
+
+### Modified Capabilities
+
+- `session-core`: Session now adds `reasoning_effort` parameter to AI requests
+- `psi-ai-openai-completions`: Pass through `reasoning_effort` parameter to upstream API
+- `anthropic-messages-client`: Pass through `reasoning_effort` parameter to Anthropic API (mapped to appropriate Anthropic parameter if needed)
+
+## Impact
+
+- `src/psi_agent/session/runner.py` - Add `reasoning_effort` to request body
+- `src/psi_agent/session/config.py` - Add reasoning configuration option
+- `src/psi_agent/ai/openai_completions/client.py` - Pass through reasoning parameter
+- `src/psi_agent/ai/anthropic_messages/client.py` - Pass through reasoning parameter
+- `src/psi_agent/ai/anthropic_messages/translator.py` - Handle reasoning parameter translation

--- a/openspec/changes/archive/2026-04-30-unified-reasoning/specs/unified-reasoning/spec.md
+++ b/openspec/changes/archive/2026-04-30-unified-reasoning/specs/unified-reasoning/spec.md
@@ -1,0 +1,58 @@
+## ADDED Requirements
+
+### Requirement: Session adds reasoning_effort to AI requests
+
+The session SHALL include a `reasoning_effort` parameter in all requests sent to AI components.
+
+#### Scenario: Reasoning effort included in request
+- **WHEN** session sends a request to AI component
+- **THEN** the request body SHALL contain `reasoning_effort` parameter
+- **AND** the default value SHALL be "medium"
+
+#### Scenario: Reasoning effort configurable
+- **WHEN** session is configured with a specific reasoning_effort level
+- **THEN** the request body SHALL contain the configured reasoning_effort value
+
+### Requirement: OpenAI completions client passes through reasoning_effort
+
+The `OpenAICompletionsClient` SHALL pass through the `reasoning_effort` parameter to the upstream OpenAI-compatible API without modification.
+
+#### Scenario: Reasoning effort forwarded to OpenAI API
+- **WHEN** request body contains `reasoning_effort` parameter
+- **THEN** the parameter SHALL be included in the upstream API request
+- **AND** the value SHALL NOT be modified
+
+### Requirement: Anthropic messages translator maps reasoning_effort
+
+The `translate_openai_to_anthropic` function SHALL map `reasoning_effort` to Anthropic's `thinking.budget_tokens` format.
+
+#### Scenario: Low reasoning effort mapped
+- **WHEN** request contains `reasoning_effort: "low"`
+- **THEN** the Anthropic request SHALL contain `thinking: { "budget_tokens": 1024 }`
+
+#### Scenario: Medium reasoning effort mapped
+- **WHEN** request contains `reasoning_effort: "medium"`
+- **THEN** the Anthropic request SHALL contain `thinking: { "budget_tokens": 4096 }`
+
+#### Scenario: High reasoning effort mapped
+- **WHEN** request contains `reasoning_effort: "high"`
+- **THEN** the Anthropic request SHALL contain `thinking: { "budget_tokens": 16384 }`
+
+#### Scenario: No reasoning effort parameter
+- **WHEN** request does not contain `reasoning_effort` parameter
+- **THEN** no `thinking` parameter SHALL be added to Anthropic request
+
+## MODIFIED Requirements
+
+### Requirement: Session acts as HTTP client to psi-ai
+
+The session SHALL act as an HTTP client connecting to psi-ai-* components via Unix socket, forwarding requests using OpenAI chat completion protocol.
+
+#### Scenario: Session forwards request to psi-ai
+- **WHEN** session needs to call LLM
+- **THEN** session sends HTTP POST request to psi-ai socket path
+- **AND** request body SHALL include `reasoning_effort` parameter
+
+#### Scenario: Session receives response from psi-ai
+- **WHEN** psi-ai returns chat completion response
+- **THEN** session receives the response for processing

--- a/openspec/changes/archive/2026-04-30-unified-reasoning/tasks.md
+++ b/openspec/changes/archive/2026-04-30-unified-reasoning/tasks.md
@@ -1,0 +1,27 @@
+## 1. Session Configuration
+
+- [x] 1.1 Add `reasoning_effort` field to `SessionConfig` in `src/psi_agent/session/config.py` with default value "medium"
+- [x] 1.2 Add `--reasoning-effort` CLI argument to session CLI in `src/psi_agent/session/cli.py`
+
+## 2. Session Request Building
+
+- [x] 2.1 Modify `_run_conversation` in `src/psi_agent/session/runner.py` to include `reasoning_effort` in request body
+- [x] 2.2 Modify `_stream_conversation` in `src/psi_agent/session/runner.py` to include `reasoning_effort` in request body
+- [x] 2.3 Modify `_complete_fn` in `src/psi_agent/session/runner.py` to include `reasoning_effort` in request body
+
+## 3. OpenAI Completions Pass-through
+
+- [x] 3.1 Verify `OpenAICompletionsClient.chat_completions` passes through `reasoning_effort` without modification
+- [x] 3.2 Add test for `reasoning_effort` pass-through in `tests/ai/openai_completions/test_client.py`
+
+## 4. Anthropic Messages Translation
+
+- [x] 4.1 Add `REASONING_EFFORT_TO_BUDGET_TOKENS` mapping constant in `src/psi_agent/ai/anthropic_messages/translator.py`
+- [x] 4.2 Modify `translate_openai_to_anthropic` to map `reasoning_effort` to `thinking.budget_tokens`
+- [x] 4.3 Add tests for reasoning effort translation in `tests/ai/anthropic_messages/test_translator.py`
+
+## 5. Integration Testing
+
+- [x] 5.1 Add integration test verifying session includes `reasoning_effort` in AI requests
+- [x] 5.2 Run full test suite to ensure no regressions
+- [x] 5.3 Run `ruff check`, `ruff format`, and `ty check` to ensure code quality

--- a/openspec/specs/unified-reasoning/spec.md
+++ b/openspec/specs/unified-reasoning/spec.md
@@ -1,0 +1,60 @@
+## Purpose
+
+Unified reasoning control across different LLM providers, ensuring consistent extended thinking behavior.
+
+## Requirements
+
+### Requirement: Session adds reasoning_effort to AI requests
+
+The session SHALL include a `reasoning_effort` parameter in all requests sent to AI components.
+
+#### Scenario: Reasoning effort included in request
+- **WHEN** session sends a request to AI component
+- **THEN** the request body SHALL contain `reasoning_effort` parameter
+- **AND** the default value SHALL be "medium"
+
+#### Scenario: Reasoning effort configurable
+- **WHEN** session is configured with a specific reasoning_effort level
+- **THEN** the request body SHALL contain the configured reasoning_effort value
+
+### Requirement: OpenAI completions client passes through reasoning_effort
+
+The `OpenAICompletionsClient` SHALL pass through the `reasoning_effort` parameter to the upstream OpenAI-compatible API without modification.
+
+#### Scenario: Reasoning effort forwarded to OpenAI API
+- **WHEN** request body contains `reasoning_effort` parameter
+- **THEN** the parameter SHALL be included in the upstream API request
+- **AND** the value SHALL NOT be modified
+
+### Requirement: Anthropic messages translator maps reasoning_effort
+
+The `translate_openai_to_anthropic` function SHALL map `reasoning_effort` to Anthropic's `thinking.budget_tokens` format.
+
+#### Scenario: Low reasoning effort mapped
+- **WHEN** request contains `reasoning_effort: "low"`
+- **THEN** the Anthropic request SHALL contain `thinking: { "budget_tokens": 1024 }`
+
+#### Scenario: Medium reasoning effort mapped
+- **WHEN** request contains `reasoning_effort: "medium"`
+- **THEN** the Anthropic request SHALL contain `thinking: { "budget_tokens": 4096 }`
+
+#### Scenario: High reasoning effort mapped
+- **WHEN** request contains `reasoning_effort: "high"`
+- **THEN** the Anthropic request SHALL contain `thinking: { "budget_tokens": 16384 }`
+
+#### Scenario: No reasoning effort parameter
+- **WHEN** request does not contain `reasoning_effort` parameter
+- **THEN** no `thinking` parameter SHALL be added to Anthropic request
+
+### Requirement: Session acts as HTTP client to psi-ai
+
+The session SHALL act as an HTTP client connecting to psi-ai-* components via Unix socket, forwarding requests using OpenAI chat completion protocol.
+
+#### Scenario: Session forwards request to psi-ai
+- **WHEN** session needs to call LLM
+- **THEN** session sends HTTP POST request to psi-ai socket path
+- **AND** request body SHALL include `reasoning_effort` parameter
+
+#### Scenario: Session receives response from psi-ai
+- **WHEN** psi-ai returns chat completion response
+- **THEN** session receives the response for processing

--- a/src/psi_agent/ai/anthropic_messages/translator.py
+++ b/src/psi_agent/ai/anthropic_messages/translator.py
@@ -6,6 +6,13 @@ import json
 from collections.abc import AsyncGenerator
 from typing import Any
 
+# Mapping from OpenAI reasoning_effort to Anthropic thinking.budget_tokens
+REASONING_EFFORT_TO_BUDGET_TOKENS: dict[str, int] = {
+    "low": 1024,
+    "medium": 4096,
+    "high": 16384,
+}
+
 
 def translate_openai_to_anthropic(
     openai_request: dict[str, Any], max_tokens: int = 4096
@@ -65,6 +72,13 @@ def translate_openai_to_anthropic(
     for param in ["model", "max_tokens", "temperature", "stream", "top_p", "stop"]:
         if param in openai_request:
             anthropic_request[param] = openai_request[param]
+
+    # Map reasoning_effort to Anthropic thinking.budget_tokens
+    reasoning_effort = openai_request.get("reasoning_effort")
+    if reasoning_effort is not None and reasoning_effort in REASONING_EFFORT_TO_BUDGET_TOKENS:
+        anthropic_request["thinking"] = {
+            "budget_tokens": REASONING_EFFORT_TO_BUDGET_TOKENS[reasoning_effort]
+        }
 
     # Add default max_tokens if not provided
     if "max_tokens" not in anthropic_request:

--- a/src/psi_agent/session/cli.py
+++ b/src/psi_agent/session/cli.py
@@ -20,6 +20,7 @@ class Session:
     ai_socket: str
     workspace: str
     history_file: str | None = None
+    reasoning_effort: str = "medium"
 
     def __call__(self) -> None:
         config = SessionConfig(
@@ -27,6 +28,7 @@ class Session:
             ai_socket=self.ai_socket,
             workspace=self.workspace,
             history_file=self.history_file,
+            reasoning_effort=self.reasoning_effort,
         )
 
         logger.info("Starting psi-session")

--- a/src/psi_agent/session/config.py
+++ b/src/psi_agent/session/config.py
@@ -16,12 +16,14 @@ class SessionConfig:
         ai_socket: Path to the Unix socket for communication with psi-ai.
         workspace: Path to the workspace directory containing tools/skills/systems.
         history_file: Optional path to JSON file for history persistence.
+        reasoning_effort: Reasoning effort level for LLM requests (low, medium, high).
     """
 
     channel_socket: str
     ai_socket: str
     workspace: str
     history_file: str | None = None
+    reasoning_effort: str = "medium"
 
     def channel_socket_path(self) -> anyio.Path:
         """Get channel socket path as Path object."""

--- a/src/psi_agent/session/runner.py
+++ b/src/psi_agent/session/runner.py
@@ -256,6 +256,7 @@ class SessionRunner:
         request_body = {
             "model": "session",  # Model is determined by psi-ai
             "messages": messages,
+            "reasoning_effort": self.config.reasoning_effort,
         }
 
         async with self.client.post(
@@ -358,6 +359,7 @@ class SessionRunner:
                 "messages": current_messages,
                 "tools": self.registry.list_tools(),
                 "stream": True,
+                "reasoning_effort": self.config.reasoning_effort,
             }
             logger.debug(
                 f"AI request body: {json.dumps(request_body, ensure_ascii=False, indent=2)}"
@@ -530,6 +532,7 @@ class SessionRunner:
                 "messages": current_messages,
                 "tools": self.registry.list_tools(),
                 "stream": True,
+                "reasoning_effort": self.config.reasoning_effort,
             }
 
             # Call psi-ai with streaming

--- a/tests/ai/anthropic_messages/test_translator.py
+++ b/tests/ai/anthropic_messages/test_translator.py
@@ -416,3 +416,61 @@ class TestTranslateAnthropicStream:
 
         assert len(chunks) == 3
         assert '"finish_reason": "stop"' in chunks[1]
+
+
+class TestReasoningEffortTranslation:
+    """Tests for reasoning_effort to thinking.budget_tokens translation."""
+
+    def test_low_reasoning_effort(self) -> None:
+        """Test low reasoning_effort maps to 1024 budget_tokens."""
+        openai_request = {
+            "messages": [{"role": "user", "content": "Hello"}],
+            "reasoning_effort": "low",
+        }
+
+        result = translate_openai_to_anthropic(openai_request)
+
+        assert result["thinking"] == {"budget_tokens": 1024}
+
+    def test_medium_reasoning_effort(self) -> None:
+        """Test medium reasoning_effort maps to 4096 budget_tokens."""
+        openai_request = {
+            "messages": [{"role": "user", "content": "Hello"}],
+            "reasoning_effort": "medium",
+        }
+
+        result = translate_openai_to_anthropic(openai_request)
+
+        assert result["thinking"] == {"budget_tokens": 4096}
+
+    def test_high_reasoning_effort(self) -> None:
+        """Test high reasoning_effort maps to 16384 budget_tokens."""
+        openai_request = {
+            "messages": [{"role": "user", "content": "Hello"}],
+            "reasoning_effort": "high",
+        }
+
+        result = translate_openai_to_anthropic(openai_request)
+
+        assert result["thinking"] == {"budget_tokens": 16384}
+
+    def test_no_reasoning_effort(self) -> None:
+        """Test no thinking parameter when reasoning_effort is absent."""
+        openai_request = {
+            "messages": [{"role": "user", "content": "Hello"}],
+        }
+
+        result = translate_openai_to_anthropic(openai_request)
+
+        assert "thinking" not in result
+
+    def test_invalid_reasoning_effort_ignored(self) -> None:
+        """Test invalid reasoning_effort value is ignored."""
+        openai_request = {
+            "messages": [{"role": "user", "content": "Hello"}],
+            "reasoning_effort": "invalid",
+        }
+
+        result = translate_openai_to_anthropic(openai_request)
+
+        assert "thinking" not in result

--- a/tests/ai/openai_completions/test_client.py
+++ b/tests/ai/openai_completions/test_client.py
@@ -238,3 +238,29 @@ class TestOpenAICompletionsClient:
                 assert not isinstance(result, AsyncGenerator)
                 assert "error" in result
                 assert result["status_code"] == 500
+
+    @pytest.mark.asyncio
+    async def test_reasoning_effort_passthrough(self, client: OpenAICompletionsClient) -> None:
+        """Test reasoning_effort parameter is passed through to upstream API."""
+        mock_response = MagicMock()
+        mock_response.id = "chatcmpl-123"
+        mock_response.model_dump = MagicMock(return_value={"id": "chatcmpl-123"})
+
+        with patch("psi_agent.ai.openai_completions.client.AsyncOpenAI") as mock_openai:
+            mock_instance = AsyncMock()
+            mock_instance.chat.completions.create = AsyncMock(return_value=mock_response)
+            mock_instance.close = AsyncMock()
+            mock_openai.return_value = mock_instance
+
+            async with client:
+                await client.chat_completions(
+                    {
+                        "messages": [{"role": "user", "content": "Hello"}],
+                        "reasoning_effort": "high",
+                    },
+                    stream=False,
+                )
+
+                # Check that reasoning_effort was passed through
+                call_kwargs = mock_instance.chat.completions.create.call_args
+                assert call_kwargs[1]["reasoning_effort"] == "high"

--- a/tests/session/test_runner.py
+++ b/tests/session/test_runner.py
@@ -1014,3 +1014,153 @@ async def tool(message: str) -> str:
                 # Should not crash and should yield content
                 full_content = "".join(chunks)
                 assert "Hello" in full_content
+
+
+class TestReasoningEffort:
+    """Tests for reasoning_effort parameter in session requests."""
+
+    @pytest.fixture
+    def config_with_reasoning(self):
+        """Create test config with custom reasoning_effort."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tools_dir = os.path.join(tmpdir, "tools")
+            os.makedirs(tools_dir)
+
+            yield SessionConfig(
+                channel_socket=os.path.join(tmpdir, "channel.sock"),
+                ai_socket=os.path.join(tmpdir, "ai.sock"),
+                workspace=tmpdir,
+                history_file=None,
+                reasoning_effort="high",
+            )
+
+    @pytest.mark.asyncio
+    async def test_run_conversation_includes_reasoning_effort(self, config_with_reasoning):
+        """Test _run_conversation includes reasoning_effort in request body."""
+        runner = SessionRunner(config_with_reasoning)
+        async with runner:
+            # Create streaming response mock
+            sse_lines = [
+                b'data: {"choices":[{"delta":{"content":"Response"}}]}\n',
+                b'data: {"choices":[{"delta":{},"finish_reason":"stop"}]}\n',
+                b"data: [DONE]\n",
+            ]
+
+            async def async_iter():
+                for line in sse_lines:
+                    yield line
+
+            mock_response = AsyncMock()
+            mock_response.status = 200
+            mock_response.content = async_iter()
+            mock_response.__aenter__ = AsyncMock(return_value=mock_response)
+            mock_response.__aexit__ = AsyncMock(return_value=None)
+
+            captured_body = {}
+
+            def capture_post(url, json=None, **kwargs):
+                captured_body.update(json or {})
+                return mock_response
+
+            with patch.object(runner.client, "post", side_effect=capture_post):
+                messages = [{"role": "user", "content": "Test"}]
+                await runner._run_conversation(messages)
+
+            # Check reasoning_effort was included
+            assert captured_body.get("reasoning_effort") == "high"
+
+    @pytest.mark.asyncio
+    async def test_stream_conversation_includes_reasoning_effort(self, config_with_reasoning):
+        """Test _stream_conversation includes reasoning_effort in request body."""
+        runner = SessionRunner(config_with_reasoning)
+        async with runner:
+            # Create streaming response mock
+            sse_lines = [
+                b'data: {"choices":[{"delta":{"content":"Response"}}]}\n',
+                b'data: {"choices":[{"delta":{},"finish_reason":"stop"}]}\n',
+                b"data: [DONE]\n",
+            ]
+
+            async def async_iter():
+                for line in sse_lines:
+                    yield line
+
+            mock_response = AsyncMock()
+            mock_response.status = 200
+            mock_response.content = async_iter()
+            mock_response.__aenter__ = AsyncMock(return_value=mock_response)
+            mock_response.__aexit__ = AsyncMock(return_value=None)
+
+            captured_body = {}
+
+            def capture_post(url, json=None, **kwargs):
+                captured_body.update(json or {})
+                return mock_response
+
+            with patch.object(runner.client, "post", side_effect=capture_post):
+                messages = [{"role": "user", "content": "Test"}]
+                async for _chunk in runner._stream_conversation(messages):
+                    pass
+
+            # Check reasoning_effort was included
+            assert captured_body.get("reasoning_effort") == "high"
+
+    @pytest.mark.asyncio
+    async def test_complete_fn_includes_reasoning_effort(self, config_with_reasoning):
+        """Test _complete_fn includes reasoning_effort in request body."""
+        runner = SessionRunner(config_with_reasoning)
+        async with runner:
+            mock_response = AsyncMock()
+            mock_response.status = 200
+            mock_response.json = AsyncMock(
+                return_value={"choices": [{"message": {"content": "Summary"}}]}
+            )
+            mock_response.__aenter__ = AsyncMock(return_value=mock_response)
+            mock_response.__aexit__ = AsyncMock(return_value=None)
+
+            captured_body = {}
+
+            def capture_post(url, json=None, **kwargs):
+                captured_body.update(json or {})
+                return mock_response
+
+            with patch.object(runner.client, "post", side_effect=capture_post):
+                await runner._complete_fn([{"role": "user", "content": "Test"}])
+
+            # Check reasoning_effort was included
+            assert captured_body.get("reasoning_effort") == "high"
+
+    @pytest.mark.asyncio
+    async def test_default_reasoning_effort_is_medium(self, config):
+        """Test default reasoning_effort is 'medium'."""
+        runner = SessionRunner(config)
+        async with runner:
+            # Create streaming response mock
+            sse_lines = [
+                b'data: {"choices":[{"delta":{"content":"Response"}}]}\n',
+                b'data: {"choices":[{"delta":{},"finish_reason":"stop"}]}\n',
+                b"data: [DONE]\n",
+            ]
+
+            async def async_iter():
+                for line in sse_lines:
+                    yield line
+
+            mock_response = AsyncMock()
+            mock_response.status = 200
+            mock_response.content = async_iter()
+            mock_response.__aenter__ = AsyncMock(return_value=mock_response)
+            mock_response.__aexit__ = AsyncMock(return_value=None)
+
+            captured_body = {}
+
+            def capture_post(url, json=None, **kwargs):
+                captured_body.update(json or {})
+                return mock_response
+
+            with patch.object(runner.client, "post", side_effect=capture_post):
+                messages = [{"role": "user", "content": "Test"}]
+                await runner._run_conversation(messages)
+
+            # Check default reasoning_effort is medium
+            assert captured_body.get("reasoning_effort") == "medium"


### PR DESCRIPTION
## Summary

- Session uniformly adds `reasoning_effort` parameter to all AI requests
- AI components pass through the parameter without modification
- Anthropic translator maps `reasoning_effort` to `thinking.budget_tokens`

Different LLM models have inconsistent default reasoning behavior. This change ensures consistent extended thinking behavior across different LLM providers by having session uniformly enable reasoning for all requests.

## Changes

- Add `reasoning_effort` field to `SessionConfig` with default "medium"
- Add `--reasoning-effort` CLI argument to session
- Include `reasoning_effort` in all AI request bodies (`_run_conversation`, `_stream_conversation`, `_complete_fn`)
- Add `REASONING_EFFORT_TO_BUDGET_TOKENS` mapping constant for Anthropic
- Map `reasoning_effort` to `thinking.budget_tokens` in translator

## Test plan

- [x] Unit tests for reasoning_effort pass-through in OpenAI completions client
- [x] Unit tests for reasoning_effort translation in Anthropic translator
- [x] Integration tests for session including reasoning_effort in AI requests
- [x] Full test suite passes (509 passed, 1 skipped)
- [x] Code quality checks pass (ruff check, ruff format, ty check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)