### PR TITLE
Add typing indicator for Telegram streaming responses

### DIFF
--- a/openspec/changes/archive/2026-04-30-telegram-typing-indicator/.openspec.yaml
+++ b/openspec/changes/archive/2026-04-30-telegram-typing-indicator/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-30

--- a/openspec/changes/archive/2026-04-30-telegram-typing-indicator/design.md
+++ b/openspec/changes/archive/2026-04-30-telegram-typing-indicator/design.md
@@ -1,0 +1,44 @@
+## Context
+
+当前 Telegram channel 在流式模式下处理用户消息时，会发送初始占位消息 `"..."`，然后通过编辑消息来更新内容。用户在等待期间看不到任何反馈指示 bot 正在处理。
+
+Telegram Bot API 提供了 `send_chat_action` 方法，可以显示"正在输入"等状态指示器。这个指示器会在 5 秒后自动消失，或者在发送消息时消失。
+
+## Goals / Non-Goals
+
+**Goals:**
+- 在流式响应开始时发送 typing 指示器
+- 提供用户反馈，改善用户体验
+- 保持现有流式更新逻辑不变
+
+**Non-Goals:**
+- 非 streaming 模式不需要 typing 指示器（响应足够快）
+- 不需要持续发送 typing 指示器（Telegram 自动处理 5 秒超时）
+
+## Decisions
+
+### Decision 1: 在发送初始占位消息前发送 typing 指示器
+
+**选择**: 在 `_handle_message_streaming` 方法中，在 `await update.message.reply_text("...")` 之前调用 `send_chat_action`。
+
+**理由**:
+- Telegram 的 typing 指示器会在发送消息时自动消失
+- 在发送初始消息前发送 typing 可以覆盖从接收消息到发送第一个响应的等待时间
+- 无需额外管理指示器的取消逻辑
+
+**替代方案**:
+- 持续发送 typing 指示器：增加 API 调用次数，收益有限
+- 使用后台任务定期发送：复杂度高，不必要
+
+### Decision 2: 使用 `update.message.chat_id` 作为目标
+
+**选择**: 使用 `update.message.chat_id` 调用 `send_chat_action`。
+
+**理由**:
+- 确保指示器发送到正确的聊天
+- 与现有消息回复逻辑一致
+
+## Risks / Trade-offs
+
+- **API 调用增加**: 每次流式响应增加一次 API 调用 → 影响极小，Telegram API 限制宽松
+- **typing 指示器超时**: 如果 LLM 响应超过 5 秒，指示器会消失 → 可接受，用户已看到初始占位消息

--- a/openspec/changes/archive/2026-04-30-telegram-typing-indicator/proposal.md
+++ b/openspec/changes/archive/2026-04-30-telegram-typing-indicator/proposal.md
@@ -1,0 +1,25 @@
+## Why
+
+当 Telegram bot 在流式更新响应时，用户在等待期间看不到任何反馈，不知道 bot 是否正在处理。Telegram Bot API 提供了 "typing" 动作指示器，可以在 bot 正在输入时显示给用户。这能显著改善用户体验，让用户知道 bot 正在处理他们的请求。
+
+## What Changes
+
+- 在流式响应开始时，发送 `send_chat_action(chat_id, "typing")` 显示"正在输入"指示器
+- 在流式响应结束时，自动取消 typing 指示器（Telegram 会在 5 秒后自动取消，或发送消息时取消）
+- 仅在 streaming 模式下启用此功能
+
+## Capabilities
+
+### New Capabilities
+
+- `telegram-typing-indicator`: 在 Telegram bot 流式响应期间显示"正在输入"指示器
+
+### Modified Capabilities
+
+- `telegram-streaming-output`: 扩展现有流式输出功能，在流式更新开始时发送 typing 动作
+
+## Impact
+
+- 受影响文件: `src/psi_agent/channel/telegram/bot.py`
+- 使用 Telegram Bot API 的 `send_chat_action` 方法
+- 无破坏性变更，仅增强用户体验

--- a/openspec/changes/archive/2026-04-30-telegram-typing-indicator/specs/telegram-streaming-output/spec.md
+++ b/openspec/changes/archive/2026-04-30-telegram-typing-indicator/specs/telegram-streaming-output/spec.md
@@ -1,0 +1,10 @@
+## ADDED Requirements
+
+### Requirement: Telegram streaming output includes typing indicator
+
+The Telegram streaming output feature SHALL include typing indicator feedback during message processing.
+
+#### Scenario: Typing indicator shown during streaming
+- **WHEN** streaming mode is enabled and a user message is received
+- **THEN** the channel SHALL display a typing indicator to the user
+- **AND** the indicator SHALL remain visible until the first message is sent

--- a/openspec/changes/archive/2026-04-30-telegram-typing-indicator/specs/telegram-typing-indicator/spec.md
+++ b/openspec/changes/archive/2026-04-30-telegram-typing-indicator/specs/telegram-typing-indicator/spec.md
@@ -1,0 +1,19 @@
+## ADDED Requirements
+
+### Requirement: Telegram channel sends typing indicator during streaming
+
+The Telegram channel SHALL send a "typing" chat action indicator when streaming mode is enabled and a message is being processed.
+
+#### Scenario: Typing indicator sent before streaming starts
+- **WHEN** streaming mode is enabled and a user message is received
+- **THEN** the channel SHALL send `send_chat_action(chat_id, "typing")` before sending the initial placeholder message
+- **AND** the typing indicator SHALL be visible to the user
+
+#### Scenario: Typing indicator cancelled when message sent
+- **WHEN** the initial placeholder message is sent
+- **THEN** the typing indicator SHALL be automatically cancelled by Telegram
+
+#### Scenario: Non-streaming mode does not send typing indicator
+- **WHEN** streaming mode is disabled
+- **THEN** the channel SHALL NOT send typing indicator
+- **AND** proceed directly to sending the response

--- a/openspec/changes/archive/2026-04-30-telegram-typing-indicator/tasks.md
+++ b/openspec/changes/archive/2026-04-30-telegram-typing-indicator/tasks.md
@@ -1,0 +1,16 @@
+## 1. Core Implementation
+
+- [x] 1.1 Add typing indicator in `_handle_message_streaming` method before sending initial placeholder message
+- [x] 1.2 Import `ChatAction` from `telegram` module for typing action constant
+
+## 2. Testing
+
+- [x] 2.1 Add unit test for typing indicator being sent in streaming mode
+- [x] 2.2 Add unit test verifying typing indicator is NOT sent in non-streaming mode
+- [x] 2.3 Run all tests to ensure no regressions
+
+## 3. Code Quality
+
+- [x] 3.1 Run `ruff check` and fix any lint issues
+- [x] 3.2 Run `ruff format` to ensure code formatting
+- [x] 3.3 Run `ty check` to verify type checking passes

--- a/openspec/specs/telegram-streaming-output/spec.md
+++ b/openspec/specs/telegram-streaming-output/spec.md
@@ -49,3 +49,12 @@ The Telegram channel SHALL handle streaming messages that exceed Telegram's 4096
 - **WHEN** streaming completes and total content exceeds 4096 characters
 - **THEN** the channel SHALL split the complete content into multiple messages
 - **AND** use existing `split_message()` function for splitting
+
+### Requirement: Telegram streaming output includes typing indicator
+
+The Telegram streaming output feature SHALL include typing indicator feedback during message processing.
+
+#### Scenario: Typing indicator shown during streaming
+- **WHEN** streaming mode is enabled and a user message is received
+- **THEN** the channel SHALL display a typing indicator to the user
+- **AND** the indicator SHALL remain visible until the first message is sent

--- a/openspec/specs/telegram-typing-indicator/spec.md
+++ b/openspec/specs/telegram-typing-indicator/spec.md
@@ -1,0 +1,19 @@
+## ADDED Requirements
+
+### Requirement: Telegram channel sends typing indicator during streaming
+
+The Telegram channel SHALL send a "typing" chat action indicator when streaming mode is enabled and a message is being processed.
+
+#### Scenario: Typing indicator sent before streaming starts
+- **WHEN** streaming mode is enabled and a user message is received
+- **THEN** the channel SHALL send `send_chat_action(chat_id, "typing")` before sending the initial placeholder message
+- **AND** the typing indicator SHALL be visible to the user
+
+#### Scenario: Typing indicator cancelled when message sent
+- **WHEN** the initial placeholder message is sent
+- **THEN** the typing indicator SHALL be automatically cancelled by Telegram
+
+#### Scenario: Non-streaming mode does not send typing indicator
+- **WHEN** streaming mode is disabled
+- **THEN** the channel SHALL NOT send typing indicator
+- **AND** proceed directly to sending the response

--- a/src/psi_agent/channel/telegram/bot.py
+++ b/src/psi_agent/channel/telegram/bot.py
@@ -8,6 +8,7 @@ from typing import Any
 
 from loguru import logger
 from telegram import Update
+from telegram.constants import ChatAction
 from telegram.ext import Application, CommandHandler, ContextTypes, MessageHandler, filters
 
 from psi_agent.channel.telegram.client import TelegramClient
@@ -228,6 +229,12 @@ class TelegramBot:
         # Send initial message placeholder
         if update.message is None:
             return
+
+        # Send typing indicator before streaming starts
+        try:
+            await update.message.chat.send_action(ChatAction.TYPING)
+        except Exception as e:
+            logger.debug(f"Failed to send typing indicator: {e}")
 
         try:
             sent_message = await update.message.reply_text("...")

--- a/tests/channel/telegram/test_bot_streaming.py
+++ b/tests/channel/telegram/test_bot_streaming.py
@@ -584,3 +584,59 @@ class TestTelegramBotStreaming:
         # At least one edit should contain multiple characters (batched)
         has_batched = any(len(edit) > 1 for edit in captured_edits if edit)
         assert has_batched or len(captured_edits) >= 1  # Either batched or final edit
+
+    @pytest.mark.asyncio
+    async def test_streaming_sends_typing_indicator(self, config):
+        """Test streaming handler sends typing indicator before streaming starts."""
+        bot = TelegramBot(config)
+
+        mock_chat = AsyncMock()
+        mock_chat.send_action = AsyncMock()
+
+        mock_message = AsyncMock()
+        mock_message.text = "Hello"
+        mock_message.chat = mock_chat
+        mock_message.reply_text = AsyncMock()
+
+        mock_sent_message = AsyncMock()
+        mock_sent_message.edit_text = AsyncMock()
+        mock_message.reply_text.return_value = mock_sent_message
+
+        mock_update = MagicMock()
+        mock_update.message = mock_message
+        mock_update.effective_user = MagicMock(id=123)
+
+        async def mock_stream(_message: str, _user_id: str, on_chunk) -> str:
+            on_chunk("Test")
+            return "Test"
+
+        with patch.object(bot.client, "send_message_stream", mock_stream):
+            async with bot.client:
+                await bot._handle_message_streaming(mock_update, "telegram:123", "Hello")
+
+        # Typing indicator should be sent
+        mock_chat.send_action.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_non_streaming_does_not_send_typing_indicator(self, config_no_stream):
+        """Test non-streaming handler does not send typing indicator."""
+        bot = TelegramBot(config_no_stream)
+
+        mock_chat = AsyncMock()
+        mock_chat.send_action = AsyncMock()
+
+        mock_message = AsyncMock()
+        mock_message.text = "Hello"
+        mock_message.chat = mock_chat
+        mock_message.reply_text = AsyncMock()
+
+        mock_update = MagicMock()
+        mock_update.message = mock_message
+        mock_update.effective_user = MagicMock(id=123)
+
+        with patch.object(bot.client, "send_message", AsyncMock(return_value="Test response")):
+            async with bot.client:
+                await bot._handle_message_non_streaming(mock_update, "telegram:123", "Hello")
+
+        # Typing indicator should NOT be sent in non-streaming mode
+        mock_chat.send_action.assert_not_called()


### PR DESCRIPTION
## Summary

- Send "typing" chat action before streaming starts to provide user feedback
- Only enabled in streaming mode (non-streaming mode unchanged)
- Typing indicator is automatically cancelled when the first message is sent

## Test plan

- [x] Unit test for typing indicator in streaming mode
- [x] Unit test verifying no typing indicator in non-streaming mode
- [x] All existing tests pass
- [x] Code quality checks pass (ruff, ty)

🤖 Generated with [Claude Code](https://claude.com/claude-code)