### PR TITLE
Fix provider-specific parameters causing TypeError in OpenAI SDK

### DIFF
--- a/openspec/changes/archive/2026-05-01-fix-thinking-param-unsupported/.openspec.yaml
+++ b/openspec/changes/archive/2026-05-01-fix-thinking-param-unsupported/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-30

--- a/openspec/changes/archive/2026-05-01-fix-thinking-param-unsupported/design.md
+++ b/openspec/changes/archive/2026-05-01-fix-thinking-param-unsupported/design.md
@@ -1,0 +1,62 @@
+## Context
+
+The OpenAI completions AI component (`psi-ai-openai-completions`) forwards chat completion requests to OpenAI-compatible APIs using the official `openai` Python SDK. When reasoning parameters (`thinking`, `reasoning_effort`) are configured via CLI flags, the server injects them into the request body before forwarding to the upstream API.
+
+The issue: The official OpenAI SDK's `chat.completions.create()` method validates parameters and raises `TypeError` for unknown parameters like `thinking`. These parameters are provider-specific extensions (e.g., Anthropic models via OpenRouter) that the SDK doesn't recognize.
+
+Current flow:
+1. Server receives request from session
+2. Server injects `thinking` and `reasoning_effort` into request body
+3. Client passes entire body to `client.chat.completions.create(**body)`
+4. SDK raises `TypeError: got an unexpected keyword argument 'thinking'`
+
+## Goals / Non-Goals
+
+**Goals:**
+- Enable provider-specific parameters to be passed through without crashing the SDK
+- Maintain backward compatibility with existing behavior
+- Keep the solution minimal and focused
+
+**Non-Goals:**
+- Validating which providers support which parameters
+- Adding new reasoning parameters beyond `thinking` and `reasoning_effort`
+- Changing the CLI interface or configuration structure
+
+## Decisions
+
+### Decision: Use OpenAI SDK's `extra_body` parameter
+
+The OpenAI SDK supports an `extra_body` parameter in `chat.completions.create()` for passing non-standard parameters directly to the HTTP request body. This is the intended mechanism for provider extensions.
+
+**Rationale:**
+- Officially supported by the SDK
+- Cleanly separates standard vs. non-standard parameters
+- No risk of future SDK version conflicts
+- Parameters in `extra_body` are passed directly to the HTTP request without SDK validation
+
+**Alternatives considered:**
+1. **Filter parameters at server level**: Would lose the parameters entirely - they need to reach the upstream API
+2. **Use `default_headers` or custom client**: Overkill for this simple parameter forwarding case
+3. **Bypass SDK and use raw HTTP**: Would lose SDK benefits (retries, error handling, typing)
+
+### Decision: Define known SDK parameters explicitly
+
+Create a set of known OpenAI SDK parameters and filter the request body into two parts:
+- `sdk_params`: Known parameters passed directly to `create()`
+- `extra_params`: Unknown parameters passed via `extra_body`
+
+**Known parameters (core):**
+- `model`, `messages`, `temperature`, `top_p`, `n`, `stream`, `stop`
+- `max_tokens`, `presence_penalty`, `frequency_penalty`, `logit_bias`
+- `user`, `response_format`, `tools`, `tool_choice`, `seed`
+
+**Known parameters (extensions we want to support via SDK):**
+- None currently - `thinking` and `reasoning_effort` are provider-specific
+
+## Risks / Trade-offs
+
+**Risk: SDK parameter list may change** → Mitigation: Use conservative list of core parameters; new SDK parameters will be filtered into `extra_body` (harmless) until we update the known list.
+
+**Risk: Provider-specific parameters may conflict** → Mitigation: Parameters are passed as-is; provider returns error if unsupported (expected behavior).
+
+**Trade-off: Slight complexity increase** → The filtering logic is simple and isolated to one method.

--- a/openspec/changes/archive/2026-05-01-fix-thinking-param-unsupported/proposal.md
+++ b/openspec/changes/archive/2026-05-01-fix-thinking-param-unsupported/proposal.md
@@ -1,0 +1,25 @@
+## Why
+
+The OpenAI completions AI component crashes when reasoning parameters (`thinking`, `reasoning_effort`) are configured, because these provider-specific parameters are passed directly to the official OpenAI SDK which doesn't recognize them. These parameters are extensions used by certain providers (like Anthropic via OpenRouter), but not part of the standard OpenAI API.
+
+## What Changes
+
+- Add parameter filtering in `OpenAICompletionsClient` to separate known OpenAI SDK parameters from extra parameters
+- Pass extra parameters via the `extra_body` parameter supported by the OpenAI SDK
+- This allows provider-specific extensions like `thinking` and `reasoning_effort` to work without crashing the SDK
+
+## Capabilities
+
+### New Capabilities
+
+- `provider-specific-params`: Support for passing provider-specific parameters (like `thinking`, `reasoning_effort`) through the OpenAI SDK using `extra_body`
+
+### Modified Capabilities
+
+- `psi-ai-openai-completions`: Extend the AI component to properly handle non-standard API parameters without crashing
+
+## Impact
+
+- Affected files: `src/psi_agent/ai/openai_completions/client.py`
+- No breaking changes - existing functionality remains intact
+- Enables reasoning parameter support for compatible providers

--- a/openspec/changes/archive/2026-05-01-fix-thinking-param-unsupported/specs/provider-specific-params/spec.md
+++ b/openspec/changes/archive/2026-05-01-fix-thinking-param-unsupported/specs/provider-specific-params/spec.md
@@ -1,0 +1,43 @@
+## ADDED Requirements
+
+### Requirement: Provider-specific parameters passed via extra_body
+
+The OpenAI completions client SHALL separate provider-specific parameters from standard OpenAI SDK parameters and pass them via the `extra_body` argument.
+
+#### Scenario: Thinking parameter forwarded correctly
+- **WHEN** a request includes `thinking` parameter
+- **THEN** the client SHALL pass it via `extra_body` to the SDK
+- **AND** the request to upstream API SHALL include `thinking` in the body
+
+#### Scenario: Reasoning effort parameter forwarded correctly
+- **WHEN** a request includes `reasoning_effort` parameter
+- **THEN** the client SHALL pass it via `extra_body` to the SDK
+- **AND** the request to upstream API SHALL include `reasoning_effort` in the body
+
+#### Scenario: Multiple provider parameters forwarded together
+- **WHEN** a request includes both `thinking` and `reasoning_effort` parameters
+- **THEN** the client SHALL pass both via `extra_body`
+- **AND** the upstream request SHALL include both parameters
+
+### Requirement: Standard SDK parameters passed directly
+
+The client SHALL pass known OpenAI SDK parameters directly to `chat.completions.create()`.
+
+#### Scenario: Core parameters passed to SDK
+- **WHEN** a request includes standard parameters like `model`, `messages`, `temperature`, `stream`
+- **THEN** these parameters SHALL be passed directly to the SDK method
+- **AND** NOT included in `extra_body`
+
+### Requirement: No crash on unknown parameters
+
+The client SHALL NOT raise `TypeError` when encountering unknown parameters in the request body.
+
+#### Scenario: Unknown parameter handled gracefully
+- **WHEN** a request includes an unknown parameter (not in known SDK parameters list)
+- **THEN** the client SHALL pass it via `extra_body`
+- **AND** the SDK SHALL NOT raise a `TypeError`
+
+#### Scenario: Empty extra_body when no provider parameters
+- **WHEN** a request contains only standard SDK parameters
+- **THEN** `extra_body` SHALL be omitted or empty
+- **AND** behavior SHALL be identical to current implementation

--- a/openspec/changes/archive/2026-05-01-fix-thinking-param-unsupported/specs/psi-ai-openai-completions/spec.md
+++ b/openspec/changes/archive/2026-05-01-fix-thinking-param-unsupported/specs/psi-ai-openai-completions/spec.md
@@ -1,0 +1,20 @@
+## ADDED Requirements
+
+### Requirement: Provider-specific parameter handling
+
+The psi-ai-openai-completions client SHALL handle provider-specific parameters (like `thinking`, `reasoning_effort`) by passing them through the OpenAI SDK's `extra_body` mechanism.
+
+#### Scenario: Thinking parameter does not cause TypeError
+- **WHEN** a request is made with `thinking` parameter configured
+- **THEN** the client SHALL NOT raise `TypeError: got an unexpected keyword argument 'thinking'`
+- **AND** the parameter SHALL be forwarded to the upstream API
+
+#### Scenario: Reasoning effort parameter does not cause TypeError
+- **WHEN** a request is made with `reasoning_effort` parameter configured
+- **THEN** the client SHALL NOT raise `TypeError`
+- **AND** the parameter SHALL be forwarded to the upstream API
+
+#### Scenario: Backward compatibility maintained
+- **WHEN** a request is made without any provider-specific parameters
+- **THEN** the client behavior SHALL be identical to the previous implementation
+- **AND** all standard OpenAI parameters SHALL work as before

--- a/openspec/changes/archive/2026-05-01-fix-thinking-param-unsupported/tasks.md
+++ b/openspec/changes/archive/2026-05-01-fix-thinking-param-unsupported/tasks.md
@@ -1,0 +1,20 @@
+## 1. Implementation
+
+- [x] 1.1 Define `KNOWN_SDK_PARAMS` set in `client.py` containing standard OpenAI API parameters
+- [x] 1.2 Add `_split_params()` method to separate request body into SDK params and extra params
+- [x] 1.3 Modify `_non_stream_request()` to use `extra_body` for provider-specific parameters
+- [x] 1.4 Modify `_stream_request()` to use `extra_body` for provider-specific parameters
+
+## 2. Testing
+
+- [x] 2.1 Add unit test for `_split_params()` method
+- [x] 2.2 Add unit test for request with `thinking` parameter
+- [x] 2.3 Add unit test for request with `reasoning_effort` parameter
+- [x] 2.4 Add unit test for request with both provider parameters
+- [x] 2.5 Add unit test verifying backward compatibility (no provider params)
+
+## 3. Verification
+
+- [x] 3.1 Run `ruff check` and `ruff format`
+- [x] 3.2 Run `ty check` for type checking
+- [x] 3.3 Run `pytest` to ensure all tests pass

--- a/openspec/specs/provider-specific-params/spec.md
+++ b/openspec/specs/provider-specific-params/spec.md
@@ -1,0 +1,51 @@
+# provider-specific-params
+
+Support for passing provider-specific parameters through the OpenAI SDK.
+
+## Purpose
+
+Enable provider-specific extensions (like `thinking`, `reasoning_effort`) to be passed through the OpenAI SDK without causing TypeError.
+
+## Requirements
+
+### Requirement: Provider-specific parameters passed via extra_body
+
+The OpenAI completions client SHALL separate provider-specific parameters from standard OpenAI SDK parameters and pass them via the `extra_body` argument.
+
+#### Scenario: Thinking parameter forwarded correctly
+- **WHEN** a request includes `thinking` parameter
+- **THEN** the client SHALL pass it via `extra_body` to the SDK
+- **AND** the request to upstream API SHALL include `thinking` in the body
+
+#### Scenario: Reasoning effort parameter forwarded correctly
+- **WHEN** a request includes `reasoning_effort` parameter
+- **THEN** the client SHALL pass it via `extra_body` to the SDK
+- **AND** the request to upstream API SHALL include `reasoning_effort` in the body
+
+#### Scenario: Multiple provider parameters forwarded together
+- **WHEN** a request includes both `thinking` and `reasoning_effort` parameters
+- **THEN** the client SHALL pass both via `extra_body`
+- **AND** the upstream request SHALL include both parameters
+
+### Requirement: Standard SDK parameters passed directly
+
+The client SHALL pass known OpenAI SDK parameters directly to `chat.completions.create()`.
+
+#### Scenario: Core parameters passed to SDK
+- **WHEN** a request includes standard parameters like `model`, `messages`, `temperature`, `stream`
+- **THEN** these parameters SHALL be passed directly to the SDK method
+- **AND** NOT included in `extra_body`
+
+### Requirement: No crash on unknown parameters
+
+The client SHALL NOT raise `TypeError` when encountering unknown parameters in the request body.
+
+#### Scenario: Unknown parameter handled gracefully
+- **WHEN** a request includes an unknown parameter (not in known SDK parameters list)
+- **THEN** the client SHALL pass it via `extra_body`
+- **AND** the SDK SHALL NOT raise a `TypeError`
+
+#### Scenario: Empty extra_body when no provider parameters
+- **WHEN** a request contains only standard SDK parameters
+- **THEN** `extra_body` SHALL be omitted or empty
+- **AND** behavior SHALL be identical to current implementation

--- a/openspec/specs/psi-ai-openai-completions/spec.md
+++ b/openspec/specs/psi-ai-openai-completions/spec.md
@@ -215,3 +215,22 @@ The AI component SHALL properly handle errors during streaming.
 - **WHEN** connection to upstream API fails
 - **THEN** server SHALL return error response before starting stream
 - **AND** NOT start SSE stream
+
+### Requirement: Provider-specific parameter handling
+
+The psi-ai-openai-completions client SHALL handle provider-specific parameters (like `thinking`, `reasoning_effort`) by passing them through the OpenAI SDK's `extra_body` mechanism.
+
+#### Scenario: Thinking parameter does not cause TypeError
+- **WHEN** a request is made with `thinking` parameter configured
+- **THEN** the client SHALL NOT raise `TypeError: got an unexpected keyword argument 'thinking'`
+- **AND** the parameter SHALL be forwarded to the upstream API
+
+#### Scenario: Reasoning effort parameter does not cause TypeError
+- **WHEN** a request is made with `reasoning_effort` parameter configured
+- **THEN** the client SHALL NOT raise `TypeError`
+- **AND** the parameter SHALL be forwarded to the upstream API
+
+#### Scenario: Backward compatibility maintained
+- **WHEN** a request is made without any provider-specific parameters
+- **THEN** the client behavior SHALL be identical to the previous implementation
+- **AND** all standard OpenAI parameters SHALL work as before

--- a/src/psi_agent/ai/openai_completions/client.py
+++ b/src/psi_agent/ai/openai_completions/client.py
@@ -19,6 +19,38 @@ from openai.types.chat import ChatCompletion
 
 from psi_agent.ai.openai_completions.config import OpenAICompletionsConfig
 
+# Known OpenAI SDK parameters for chat.completions.create()
+# Provider-specific parameters (like 'thinking', 'reasoning_effort') are NOT included
+# and will be passed via extra_body
+KNOWN_SDK_PARAMS: set[str] = {
+    "model",
+    "messages",
+    "temperature",
+    "top_p",
+    "n",
+    "stream",
+    "stop",
+    "max_tokens",
+    "presence_penalty",
+    "frequency_penalty",
+    "logit_bias",
+    "user",
+    "response_format",
+    "tools",
+    "tool_choice",
+    "seed",
+    "logprobs",
+    "top_logprobs",
+    "parallel_tool_calls",
+    "stream_options",
+    "service_tier",
+    "modalities",
+    "audio",
+    "prediction",
+    "metadata",
+    "store",
+}
+
 
 class OpenAICompletionsClient:
     """Client for forwarding requests to OpenAI-compatible APIs."""
@@ -31,6 +63,26 @@ class OpenAICompletionsClient:
         """
         self.config = config
         self._client: AsyncOpenAI | None = None
+
+    def _split_params(self, body: dict[str, Any]) -> tuple[dict[str, Any], dict[str, Any] | None]:
+        """Split request body into SDK params and extra params.
+
+        Args:
+            body: The request body to split.
+
+        Returns:
+            A tuple of (sdk_params, extra_params). extra_params is None if empty.
+        """
+        sdk_params: dict[str, Any] = {}
+        extra_params: dict[str, Any] = {}
+
+        for key, value in body.items():
+            if key in KNOWN_SDK_PARAMS:
+                sdk_params[key] = value
+            else:
+                extra_params[key] = value
+
+        return sdk_params, extra_params if extra_params else None
 
     async def __aenter__(self) -> OpenAICompletionsClient:
         """Enter async context."""
@@ -92,8 +144,12 @@ class OpenAICompletionsClient:
         """
         assert self._client is not None
 
+        sdk_params, extra_params = self._split_params(body)
+
         try:
-            response: ChatCompletion = await self._client.chat.completions.create(**body)
+            response: ChatCompletion = await self._client.chat.completions.create(
+                **sdk_params, extra_body=extra_params
+            )
             logger.info("Received successful non-streaming response")
             logger.debug(f"Response id: {response.id}")
             logger.debug(
@@ -116,9 +172,13 @@ class OpenAICompletionsClient:
         assert self._client is not None
 
         body["stream"] = True
+        sdk_params, extra_params = self._split_params(body)
+
         try:
             logger.info("Starting streaming request")
-            stream = await self._client.chat.completions.create(**body)
+            stream = await self._client.chat.completions.create(
+                **sdk_params, extra_body=extra_params
+            )
             async for chunk in stream:
                 logger.debug(f"Stream chunk: {chunk.model_dump_json()}")
                 yield f"data: {chunk.model_dump_json()}\n\n"

--- a/tests/ai/openai_completions/test_client.py
+++ b/tests/ai/openai_completions/test_client.py
@@ -238,3 +238,140 @@ class TestOpenAICompletionsClient:
                 assert not isinstance(result, AsyncGenerator)
                 assert "error" in result
                 assert result["status_code"] == 500
+
+    def test_split_params_sdk_only(self, client: OpenAICompletionsClient) -> None:
+        """Test _split_params with only SDK parameters."""
+        body = {
+            "model": "test-model",
+            "messages": [{"role": "user", "content": "Hello"}],
+            "temperature": 0.7,
+            "max_tokens": 1024,
+        }
+        sdk_params, extra_params = client._split_params(body)
+
+        assert sdk_params == body
+        assert extra_params is None
+
+    def test_split_params_with_thinking(self, client: OpenAICompletionsClient) -> None:
+        """Test _split_params with thinking parameter."""
+        body = {
+            "model": "test-model",
+            "messages": [{"role": "user", "content": "Hello"}],
+            "thinking": {"type": "enabled"},
+        }
+        sdk_params, extra_params = client._split_params(body)
+
+        assert sdk_params == {
+            "model": "test-model",
+            "messages": [{"role": "user", "content": "Hello"}],
+        }
+        assert extra_params == {"thinking": {"type": "enabled"}}
+
+    def test_split_params_with_reasoning_effort(self, client: OpenAICompletionsClient) -> None:
+        """Test _split_params with reasoning_effort parameter."""
+        body = {
+            "model": "test-model",
+            "messages": [{"role": "user", "content": "Hello"}],
+            "reasoning_effort": "high",
+        }
+        sdk_params, extra_params = client._split_params(body)
+
+        assert sdk_params == {
+            "model": "test-model",
+            "messages": [{"role": "user", "content": "Hello"}],
+        }
+        assert extra_params == {"reasoning_effort": "high"}
+
+    def test_split_params_with_both_provider_params(self, client: OpenAICompletionsClient) -> None:
+        """Test _split_params with both thinking and reasoning_effort."""
+        body = {
+            "model": "test-model",
+            "messages": [{"role": "user", "content": "Hello"}],
+            "thinking": {"type": "enabled"},
+            "reasoning_effort": "high",
+        }
+        sdk_params, extra_params = client._split_params(body)
+
+        assert sdk_params == {
+            "model": "test-model",
+            "messages": [{"role": "user", "content": "Hello"}],
+        }
+        assert extra_params == {
+            "thinking": {"type": "enabled"},
+            "reasoning_effort": "high",
+        }
+
+    @pytest.mark.asyncio
+    async def test_non_streaming_with_thinking_param(self, client: OpenAICompletionsClient) -> None:
+        """Test non-streaming request with thinking parameter passes via extra_body."""
+        mock_response = MagicMock()
+        mock_response.id = "chatcmpl-123"
+        mock_response.model_dump = MagicMock(return_value={"id": "chatcmpl-123"})
+
+        with patch("psi_agent.ai.openai_completions.client.AsyncOpenAI") as mock_openai:
+            mock_instance = AsyncMock()
+            mock_instance.chat.completions.create = AsyncMock(return_value=mock_response)
+            mock_instance.close = AsyncMock()
+            mock_openai.return_value = mock_instance
+
+            async with client:
+                result = await client.chat_completions(
+                    {
+                        "messages": [{"role": "user", "content": "Hello"}],
+                        "thinking": {"type": "enabled"},
+                    },
+                    stream=False,
+                )
+
+                # Verify extra_body was passed with thinking
+                call_kwargs = mock_instance.chat.completions.create.call_args
+                assert "extra_body" in call_kwargs[1]
+                assert call_kwargs[1]["extra_body"] == {"thinking": {"type": "enabled"}}
+                # Verify thinking is NOT in SDK params
+                assert "thinking" not in call_kwargs[1]
+
+                # Type narrowing: non-streaming returns dict
+                assert not isinstance(result, AsyncGenerator)
+                assert result["id"] == "chatcmpl-123"
+
+    @pytest.mark.asyncio
+    async def test_streaming_with_reasoning_effort_param(
+        self, client: OpenAICompletionsClient
+    ) -> None:
+        """Test streaming request with reasoning_effort parameter passes via extra_body."""
+        mock_chunk = MagicMock()
+        mock_chunk.model_dump_json = MagicMock(return_value='{"id": "chatcmpl-123"}')
+
+        async def mock_stream():
+            yield mock_chunk
+
+        with patch("psi_agent.ai.openai_completions.client.AsyncOpenAI") as mock_openai:
+            mock_instance = AsyncMock()
+            mock_instance.chat.completions.create = AsyncMock(return_value=mock_stream())
+            mock_instance.close = AsyncMock()
+            mock_openai.return_value = mock_instance
+
+            async with client:
+                result = await client.chat_completions(
+                    {
+                        "messages": [{"role": "user", "content": "Hello"}],
+                        "reasoning_effort": "high",
+                    },
+                    stream=True,
+                )
+
+                # Type narrowing: streaming returns AsyncGenerator
+                stream_gen = cast(AsyncGenerator[str], result)
+                chunks = []
+                async for chunk in stream_gen:
+                    chunks.append(chunk)
+
+                # Verify extra_body was passed with reasoning_effort
+                # Note: call_args is only available after consuming the generator
+                call_kwargs = mock_instance.chat.completions.create.call_args
+                assert "extra_body" in call_kwargs[1]
+                assert call_kwargs[1]["extra_body"] == {"reasoning_effort": "high"}
+                # Verify reasoning_effort is NOT in SDK params
+                assert "reasoning_effort" not in call_kwargs[1]
+
+                assert len(chunks) == 2


### PR DESCRIPTION
## Summary

- Fix `TypeError: AsyncCompletions.create() got an unexpected keyword argument 'thinking'` when using reasoning parameters with OpenAI-compatible APIs
- Provider-specific parameters (`thinking`, `reasoning_effort`) are now passed via the SDK's `extra_body` parameter instead of directly
- Add comprehensive unit tests for parameter splitting and forwarding

## Changes

- Add `KNOWN_SDK_PARAMS` set listing standard OpenAI API parameters
- Add `_split_params()` method to separate SDK params from extra params
- Pass provider-specific params via `extra_body` in both streaming and non-streaming requests
- Sync delta specs to main specs (new `provider-specific-params` capability)

## Test plan

- [x] Unit tests for `_split_params()` method
- [x] Unit tests for request with `thinking` parameter
- [x] Unit tests for request with `reasoning_effort` parameter
- [x] Unit tests for request with both provider parameters
- [x] Unit tests verifying backward compatibility (no provider params)
- [x] All existing tests pass
- [x] `ruff check` and `ruff format` pass
- [x] `ty check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)