### PR TITLE
Fix Anthropic stream event duplication by filtering non-standard events

### DIFF
--- a/openspec/changes/archive/2026-05-01-fix-anthropic-stream-duplication/.openspec.yaml
+++ b/openspec/changes/archive/2026-05-01-fix-anthropic-stream-duplication/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-30

--- a/openspec/changes/archive/2026-05-01-fix-anthropic-stream-duplication/design.md
+++ b/openspec/changes/archive/2026-05-01-fix-anthropic-stream-duplication/design.md
@@ -1,0 +1,47 @@
+## Context
+
+The Anthropic Python SDK's streaming API emits multiple event types for text content:
+1. `content_block_delta` - Standard protocol events containing incremental text deltas
+2. `text` - Convenience events with `snapshot` field showing accumulated text
+
+When using certain Anthropic-compatible providers (like astron-code-latest), both event types are emitted for the same content. Our current implementation in `client.py` yields all events from the SDK, and the translator only processes `content_block_delta`, but the `text` events still appear in logs and may cause confusion.
+
+The root cause: the `anthropic_event_stream()` generator in `client.py` yields ALL events from the SDK without filtering.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Filter out non-standard events (`text`, `snapshot`) before yielding to translator
+- Only yield protocol-standard events that the translator expects
+
+**Non-Goals:**
+- Changing the translator logic (it already correctly ignores unknown events)
+- Modifying any other AI provider implementations
+
+## Decisions
+
+**Decision 1: Filter events in client.py before yielding**
+
+Rationale: The translator's job is to convert Anthropic events to OpenAI format. It shouldn't need to know about SDK-specific convenience events. Filtering at the source (client) keeps the translator focused on protocol translation.
+
+Alternative considered: Filter in translator - rejected because it mixes protocol concerns with SDK-specific quirks.
+
+**Decision 2: Maintain a whitelist of known event types**
+
+Known standard events from Anthropic Messages API:
+- `message_start`
+- `content_block_start`
+- `content_block_delta`
+- `content_block_stop`
+- `message_delta`
+- `message_stop`
+- `ping` (keep-alive)
+
+Events to filter out:
+- `text` (SDK convenience event)
+- Any other unknown events
+
+## Risks / Trade-offs
+
+- **Risk**: Future SDK versions may introduce new standard events
+  - Mitigation: Log filtered events at DEBUG level for visibility; update whitelist when new events are documented

--- a/openspec/changes/archive/2026-05-01-fix-anthropic-stream-duplication/proposal.md
+++ b/openspec/changes/archive/2026-05-01-fix-anthropic-stream-duplication/proposal.md
@@ -1,0 +1,23 @@
+## Why
+
+The Anthropic Messages AI component produces duplicated streaming content when using certain Anthropic-compatible providers (e.g., astron-code-latest). The SDK emits both `content_block_delta` events (incremental text) and `text` events (convenience events with snapshot), causing the same content to be streamed twice to the client.
+
+## What Changes
+
+- Filter out non-standard streaming events from Anthropic SDK before translation to OpenAI format
+- Only process `content_block_delta` events for text content, ignore `text` convenience events
+
+## Capabilities
+
+### New Capabilities
+
+- `anthropic-stream-filtering`: Filter Anthropic SDK streaming events to only process protocol-standard events
+
+### Modified Capabilities
+
+None - this is a bug fix, not a behavior change.
+
+## Impact
+
+- `src/psi_agent/ai/anthropic_messages/client.py` - filter events before yielding
+- `src/psi_agent/ai/anthropic_messages/translator.py` - potentially add event type validation

--- a/openspec/changes/archive/2026-05-01-fix-anthropic-stream-duplication/specs/anthropic-stream-filtering/spec.md
+++ b/openspec/changes/archive/2026-05-01-fix-anthropic-stream-duplication/specs/anthropic-stream-filtering/spec.md
@@ -1,0 +1,19 @@
+## ADDED Requirements
+
+### Requirement: Filter non-standard Anthropic SDK events
+
+The Anthropic Messages client SHALL filter out non-standard SDK convenience events before yielding to the translator.
+
+#### Scenario: Standard events are passed through
+- **WHEN** the SDK emits a standard event (`message_start`, `content_block_start`, `content_block_delta`, `content_block_stop`, `message_delta`, `message_stop`, or `ping`)
+- **THEN** the event SHALL be yielded to the translator
+
+#### Scenario: Text convenience events are filtered
+- **WHEN** the SDK emits a `text` event (SDK convenience event with snapshot field)
+- **THEN** the event SHALL NOT be yielded to the translator
+- **AND** the event SHALL be logged at DEBUG level
+
+#### Scenario: Unknown events are filtered
+- **WHEN** the SDK emits an event type not in the known standard events list
+- **THEN** the event SHALL NOT be yielded to the translator
+- **AND** the event SHALL be logged at DEBUG level

--- a/openspec/changes/archive/2026-05-01-fix-anthropic-stream-duplication/tasks.md
+++ b/openspec/changes/archive/2026-05-01-fix-anthropic-stream-duplication/tasks.md
@@ -1,0 +1,17 @@
+## 1. Implementation
+
+- [x] 1.1 Add event type whitelist constant in `client.py`
+- [x] 1.2 Filter events in `anthropic_event_stream()` generator
+- [x] 1.3 Add DEBUG logging for filtered events
+
+## 2. Testing
+
+- [x] 2.1 Add unit test for standard event passthrough
+- [x] 2.2 Add unit test for `text` event filtering
+- [x] 2.3 Add unit test for unknown event filtering
+
+## 3. Quality Assurance
+
+- [x] 3.1 Run `ruff check` and `ruff format`
+- [x] 3.2 Run `ty check`
+- [x] 3.3 Run `pytest`

--- a/openspec/specs/anthropic-stream-filtering/spec.md
+++ b/openspec/specs/anthropic-stream-filtering/spec.md
@@ -1,0 +1,19 @@
+## ADDED Requirements
+
+### Requirement: Filter non-standard Anthropic SDK events
+
+The Anthropic Messages client SHALL filter out non-standard SDK convenience events before yielding to the translator.
+
+#### Scenario: Standard events are passed through
+- **WHEN** the SDK emits a standard event (`message_start`, `content_block_start`, `content_block_delta`, `content_block_stop`, `message_delta`, `message_stop`, or `ping`)
+- **THEN** the event SHALL be yielded to the translator
+
+#### Scenario: Text convenience events are filtered
+- **WHEN** the SDK emits a `text` event (SDK convenience event with snapshot field)
+- **THEN** the event SHALL NOT be yielded to the translator
+- **AND** the event SHALL be logged at DEBUG level
+
+#### Scenario: Unknown events are filtered
+- **WHEN** the SDK emits an event type not in the known standard events list
+- **THEN** the event SHALL NOT be yielded to the translator
+- **AND** the event SHALL be logged at DEBUG level

--- a/src/psi_agent/ai/anthropic_messages/client.py
+++ b/src/psi_agent/ai/anthropic_messages/client.py
@@ -23,6 +23,20 @@ from psi_agent.ai.anthropic_messages.translator import (
     translate_anthropic_to_openai,
 )
 
+# Standard Anthropic Messages API event types that should be processed
+# Non-standard events (e.g., 'text' convenience events) are filtered out
+ANTHROPIC_STANDARD_EVENT_TYPES: frozenset[str] = frozenset(
+    {
+        "message_start",
+        "content_block_start",
+        "content_block_delta",
+        "content_block_stop",
+        "message_delta",
+        "message_stop",
+        "ping",
+    }
+)
+
 
 class AnthropicMessagesClient:
     """Client for forwarding requests to Anthropic Messages API."""
@@ -134,6 +148,10 @@ class AnthropicMessagesClient:
                 """Generate Anthropic SSE events."""
                 async with client.messages.stream(**body) as stream:
                     async for event in stream:
+                        # Filter out non-standard SDK events (e.g., 'text' convenience events)
+                        if event.type not in ANTHROPIC_STANDARD_EVENT_TYPES:
+                            logger.debug(f"Filtered non-standard event: {event.type}")
+                            continue
                         event_data = event.model_dump()
                         event_json = json.dumps(event_data, ensure_ascii=False)
                         logger.debug(f"Stream event: {event.type} - {event_json}")

--- a/tests/ai/anthropic_messages/test_client.py
+++ b/tests/ai/anthropic_messages/test_client.py
@@ -491,3 +491,150 @@ class TestAnthropicMessagesClient:
                 error_data = json.loads(chunks[0].replace("data: ", "").strip())
                 assert "error" in error_data
                 assert error_data["status_code"] == 500
+
+    @pytest.mark.asyncio
+    async def test_streaming_standard_events_passthrough(
+        self, client: AnthropicMessagesClient
+    ) -> None:
+        """Test standard Anthropic events are passed through."""
+        from unittest.mock import MagicMock
+
+        # Create mock events for standard types
+        events = []
+        for event_type in ["message_start", "content_block_delta", "message_stop"]:
+            mock_event = MagicMock()
+            mock_event.type = event_type
+            mock_event.model_dump = MagicMock(return_value={"type": event_type, "data": "test"})
+            events.append(mock_event)
+
+        # Create async iterator helper
+        async def async_iter():
+            for event in events:
+                yield event
+
+        mock_stream = AsyncMock()
+        mock_stream.__aenter__ = AsyncMock(return_value=mock_stream)
+        mock_stream.__aexit__ = AsyncMock(return_value=None)
+        mock_stream.__aiter__ = MagicMock(return_value=async_iter())
+
+        with patch("psi_agent.ai.anthropic_messages.client.AsyncAnthropic") as mock_anthropic:
+            mock_instance = AsyncMock()
+            mock_instance.messages.stream = MagicMock(return_value=mock_stream)
+            mock_instance.close = AsyncMock()
+            mock_anthropic.return_value = mock_instance
+
+            async with client:
+                result = await client.messages(
+                    {"messages": [{"role": "user", "content": "Hello"}], "max_tokens": 1024},
+                    stream=True,
+                )
+
+                chunks = []
+                async for chunk in result:
+                    chunks.append(chunk)
+
+                # Should have chunks for message_start, content_block_delta, message_stop
+                # Plus the final message_stop from the generator
+                assert len(chunks) >= 3
+
+    @pytest.mark.asyncio
+    async def test_streaming_text_event_filtered(self, client: AnthropicMessagesClient) -> None:
+        """Test 'text' convenience events are filtered out."""
+        from unittest.mock import MagicMock
+
+        # Create standard event and non-standard 'text' event
+        standard_event = MagicMock()
+        standard_event.type = "content_block_delta"
+        standard_event.model_dump = MagicMock(
+            return_value={"type": "content_block_delta", "delta": {"text": "Hello"}}
+        )
+
+        text_event = MagicMock()
+        text_event.type = "text"
+        text_event.model_dump = MagicMock(
+            return_value={"type": "text", "text": "Hello", "snapshot": "Hello"}
+        )
+
+        events = [standard_event, text_event, standard_event]
+
+        # Create async iterator helper
+        async def async_iter():
+            for event in events:
+                yield event
+
+        mock_stream = AsyncMock()
+        mock_stream.__aenter__ = AsyncMock(return_value=mock_stream)
+        mock_stream.__aexit__ = AsyncMock(return_value=None)
+        mock_stream.__aiter__ = MagicMock(return_value=async_iter())
+
+        with patch("psi_agent.ai.anthropic_messages.client.AsyncAnthropic") as mock_anthropic:
+            mock_instance = AsyncMock()
+            mock_instance.messages.stream = MagicMock(return_value=mock_stream)
+            mock_instance.close = AsyncMock()
+            mock_anthropic.return_value = mock_instance
+
+            async with client:
+                result = await client.messages(
+                    {"messages": [{"role": "user", "content": "Hello"}], "max_tokens": 1024},
+                    stream=True,
+                )
+
+                chunks = []
+                async for chunk in result:
+                    chunks.append(chunk)
+
+                # Should only have chunks for standard events (content_block_delta twice)
+                # The 'text' event should be filtered out
+                for chunk in chunks:
+                    if chunk.startswith("event:"):
+                        assert "event: text" not in chunk
+
+    @pytest.mark.asyncio
+    async def test_streaming_unknown_event_filtered(self, client: AnthropicMessagesClient) -> None:
+        """Test unknown event types are filtered out."""
+        from unittest.mock import MagicMock
+
+        standard_event = MagicMock()
+        standard_event.type = "content_block_delta"
+        standard_event.model_dump = MagicMock(
+            return_value={"type": "content_block_delta", "delta": {"text": "Hello"}}
+        )
+
+        unknown_event = MagicMock()
+        unknown_event.type = "unknown_event_type"
+        unknown_event.model_dump = MagicMock(
+            return_value={"type": "unknown_event_type", "data": "test"}
+        )
+
+        events = [standard_event, unknown_event]
+
+        # Create async iterator helper
+        async def async_iter():
+            for event in events:
+                yield event
+
+        mock_stream = AsyncMock()
+        mock_stream.__aenter__ = AsyncMock(return_value=mock_stream)
+        mock_stream.__aexit__ = AsyncMock(return_value=None)
+        mock_stream.__aiter__ = MagicMock(return_value=async_iter())
+
+        with patch("psi_agent.ai.anthropic_messages.client.AsyncAnthropic") as mock_anthropic:
+            mock_instance = AsyncMock()
+            mock_instance.messages.stream = MagicMock(return_value=mock_stream)
+            mock_instance.close = AsyncMock()
+            mock_anthropic.return_value = mock_instance
+
+            async with client:
+                result = await client.messages(
+                    {"messages": [{"role": "user", "content": "Hello"}], "max_tokens": 1024},
+                    stream=True,
+                )
+
+                chunks = []
+                async for chunk in result:
+                    chunks.append(chunk)
+
+                # Should only have chunks for standard events
+                for chunk in chunks:
+                    if chunk.startswith("event:"):
+                        assert "event: unknown_event_type" not in chunk

--- a/tests/ai/anthropic_messages/test_client.py
+++ b/tests/ai/anthropic_messages/test_client.py
@@ -529,6 +529,9 @@ class TestAnthropicMessagesClient:
                     stream=True,
                 )
 
+                # Type narrowing: streaming returns AsyncGenerator
+                assert isinstance(result, AsyncGenerator)
+
                 chunks = []
                 async for chunk in result:
                     chunks.append(chunk)
@@ -578,6 +581,9 @@ class TestAnthropicMessagesClient:
                     {"messages": [{"role": "user", "content": "Hello"}], "max_tokens": 1024},
                     stream=True,
                 )
+
+                # Type narrowing: streaming returns AsyncGenerator
+                assert isinstance(result, AsyncGenerator)
 
                 chunks = []
                 async for chunk in result:
@@ -629,6 +635,9 @@ class TestAnthropicMessagesClient:
                     {"messages": [{"role": "user", "content": "Hello"}], "max_tokens": 1024},
                     stream=True,
                 )
+
+                # Type narrowing: streaming returns AsyncGenerator
+                assert isinstance(result, AsyncGenerator)
 
                 chunks = []
                 async for chunk in result:


### PR DESCRIPTION
## Summary
- Fix content duplication in Anthropic Messages streaming by filtering non-standard SDK events
- Add whitelist of standard Anthropic event types (`message_start`, `content_block_delta`, etc.)
- Filter out convenience events like `text` that caused duplicate content
- Add DEBUG logging for filtered events

## Problem
When using certain Anthropic-compatible providers (e.g., astron-code-latest), the SDK emits both:
1. Standard protocol events (`content_block_delta`) - incremental text
2. Convenience events (`text`) - with snapshot field

This caused content to be streamed twice to the client.

## Solution
Filter events at the source in `client.py` before yielding to the translator. Only standard Anthropic Messages API event types are passed through.

## Test plan
- [x] Unit test for standard event passthrough
- [x] Unit test for `text` event filtering
- [x] Unit test for unknown event filtering
- [x] All existing tests pass
- [x] `ruff check` and `ruff format` pass
- [x] `ty check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)