### PR TITLE
Fix Telegram proxy configuration for updater polling

### DIFF
--- a/openspec/changes/archive/2026-04-30-fix-telegram-proxy-polling/.openspec.yaml
+++ b/openspec/changes/archive/2026-04-30-fix-telegram-proxy-polling/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-30

--- a/openspec/changes/archive/2026-04-30-fix-telegram-proxy-polling/design.md
+++ b/openspec/changes/archive/2026-04-30-fix-telegram-proxy-polling/design.md
@@ -1,0 +1,166 @@
+# Design: Telegram Channel Proxy Configuration Fix
+
+## Architecture Context
+
+The Telegram channel component uses python-telegram-bot's `Application` class, which has two separate HTTP clients:
+
+1. **Bot API Client**: Used for all bot API calls (sendMessage, editMessageText, getMe, etc.)
+2. **Updater Client**: Used specifically for `getUpdates` long-polling
+
+Each client has its own proxy configuration, which must be set separately.
+
+## Component Diagram
+
+```
+┌─────────────────────────────────────────────────────────┐
+│                    TelegramBot                          │
+│                                                         │
+│  ┌─────────────────┐     ┌─────────────────────────┐   │
+│  │   Application   │────▶│      Bot API Client     │   │
+│  │    (Builder)    │     │  (proxy() configured)   │   │
+│  │                 │     │                         │   │
+│  │                 │     └─────────────────────────┘   │
+│  │                 │                                    │
+│  │                 │     ┌─────────────────────────┐   │
+│  │                 │────▶│     Updater Client      │   │
+│  │                 │     │ (get_updates_proxy()    │   │
+│  │                 │     │     configured)         │   │
+│  └─────────────────┘     └─────────────────────────┘   │
+│                                                         │
+└─────────────────────────────────────────────────────────┘
+                          │
+                          ▼
+              ┌───────────────────────┐
+              │    Telegram API       │
+              │  (via Proxy Server)   │
+              └───────────────────────┘
+```
+
+## Implementation Design
+
+### Modified Code: bot.py
+
+**Current Implementation:**
+```python
+if self.config.proxy:
+    builder = builder.proxy(self.config.proxy)
+```
+
+**New Implementation:**
+```python
+if self.config.proxy:
+    builder = builder.proxy(self.config.proxy)
+    builder = builder.get_updates_proxy(self.config.proxy)
+    # Log proxy without credentials (show host only)
+    proxy_display = self._mask_proxy_credentials(self.config.proxy)
+    logger.info(f"Using proxy: {proxy_display}")
+```
+
+### Method: `get_updates_proxy()`
+
+This method was introduced in python-telegram-bot v20.7 alongside `proxy()`. Both methods accept the same proxy URL format:
+- String URL: `"http://proxy.example.com:8080"`
+- httpx.Proxy object
+- httpx.URL object
+
+Both use the same underlying HTTPXRequest class, so the proxy URL format is identical.
+
+## Error Handling Design
+
+### Error Flow
+
+```
+Application.builder()
+    .proxy(url)
+    .get_updates_proxy(url)
+    .build()
+    │
+    ├─▶ ImportError (socksio) ──▶ RuntimeError (installation instructions)
+    │
+    ├─▶ RuntimeError (Socks5) ──▶ RuntimeError (installation instructions)
+    │
+    └─▶ Success
+```
+
+### Error Handling Code
+
+The existing error handling is correct and will catch errors from both proxy configurations:
+
+```python
+try:
+    self._app = builder.build()
+except ImportError as e:
+    if "socksio" in str(e).lower():
+        msg = (
+            "SOCKS5 proxy support requires the 'socksio' package.\n"
+            "Install it with one of:\n"
+            "  pip install 'python-telegram-bot[socks]'\n"
+            "  uv sync --extra socks"
+        )
+        raise RuntimeError(msg) from e
+    raise
+except RuntimeError as e:
+    if "Socks5" in str(e):
+        msg = (
+            "SOCKS5 proxy support requires the 'socksio' package.\n"
+            "Install it with one of:\n"
+            "  pip install 'python-telegram-bot[socks]'\n"
+            "  uv sync --extra socks"
+        )
+        raise RuntimeError(msg) from e
+    raise
+```
+
+## Test Design
+
+### Test Cases
+
+1. **`test_bot_with_both_proxy_methods_called`**
+   - Mock Application.builder()
+   - Verify both `proxy()` and `get_updates_proxy()` are called with same URL
+
+2. **`test_http_proxy_with_both_methods`**
+   - Use HTTP proxy URL
+   - Verify builder methods are called correctly
+   - Verify app builds successfully
+
+3. **`test_socks5_proxy_missing_dependency_both_methods`**
+   - Verify error is caught regardless of which method triggers it
+
+### Test Implementation Strategy
+
+Update existing tests in `TestProxyValidation` class to verify both methods are called:
+
+```python
+@pytest.mark.asyncio
+async def test_http_proxy_no_extra_dependency(self):
+    """Test HTTP proxy works without extra dependencies."""
+    config = TelegramConfig(
+        token="test-token",
+        session_socket="/tmp/test.sock",
+        proxy="http://localhost:8080",
+    )
+    bot = TelegramBot(config)
+
+    mock_builder = MagicMock()
+    mock_builder.token.return_value = mock_builder
+    mock_builder.proxy.return_value = mock_builder
+    mock_builder.get_updates_proxy.return_value = mock_builder  # NEW
+    mock_builder.build.return_value = mock_app
+
+    with patch("psi_agent.channel.telegram.bot.Application.builder", return_value=mock_builder):
+        await bot.start()
+
+    # Verify both methods are called
+    mock_builder.proxy.assert_called_once_with("http://localhost:8080")
+    mock_builder.get_updates_proxy.assert_called_once_with("http://localhost:8080")
+```
+
+## Security Considerations
+
+The existing `_mask_proxy_credentials()` method correctly handles credential masking for logging. No changes needed.
+
+## Compatibility
+
+- python-telegram-bot v20.7+: Required (already using v22.7)
+- socksio v1.0.0+: Optional for SOCKS5 (already defined in optional dependencies)

--- a/openspec/changes/archive/2026-04-30-fix-telegram-proxy-polling/proposal.md
+++ b/openspec/changes/archive/2026-04-30-fix-telegram-proxy-polling/proposal.md
@@ -1,0 +1,72 @@
+# Proposal: Fix Telegram Channel Proxy Configuration
+
+## Summary
+
+Fix the proxy configuration for the Telegram channel so that users can successfully connect to Telegram through HTTP/SOCKS5 proxies.
+
+## Motivation
+
+Users have reported that configuring a proxy for the Telegram channel does not work. This prevents users in regions with restricted access to Telegram from using the bot functionality.
+
+## Problem Analysis
+
+### Current Implementation
+
+The current implementation in `src/psi_agent/channel/telegram/bot.py` uses:
+
+```python
+if self.config.proxy:
+    builder = builder.proxy(self.config.proxy)
+```
+
+### Investigation Findings
+
+1. **API Version Compatibility**: The `proxy()` method was added in python-telegram-bot v20.7. Current version is 22.7, so this is not the issue.
+
+2. **SOCKS5 Dependency**: For SOCKS5 proxies, the `socksio` package is required. This is already defined as an optional dependency (`pip install "psi-agent[socks]"`).
+
+3. **Missing `get_updates_proxy`**: The `proxy()` method sets the proxy for bot API calls (like `sendMessage`, `getMe`), but the updater's `start_polling()` uses a **separate** HTTP connection for `getUpdates`. This connection needs `get_updates_proxy()` to be set separately.
+
+   According to the python-telegram-bot documentation:
+   - `proxy()`: Sets proxy for general bot API requests
+   - `get_updates_proxy()`: Sets proxy specifically for the `getUpdates` long-polling connection
+
+   **This is the root cause**: Without `get_updates_proxy()`, the updater cannot connect to Telegram through the proxy when polling for updates.
+
+4. **Error Handling**: The current error handling catches `ImportError` and `RuntimeError` for socksio-related issues, which is correct.
+
+### Root Cause
+
+The proxy is only being set for general API requests, not for the `getUpdates` polling connection. The updater's long-polling mechanism uses a separate HTTP client that needs its own proxy configuration.
+
+## Proposed Solution
+
+### 1. Set Both Proxy Methods
+
+Update the `start()` method in `bot.py` to set both `proxy()` and `get_updates_proxy()`:
+
+```python
+if self.config.proxy:
+    builder = builder.proxy(self.config.proxy)
+    builder = builder.get_updates_proxy(self.config.proxy)
+```
+
+### 2. Improve Error Messages
+
+Enhance error handling to provide clearer guidance when proxy configuration fails.
+
+### 3. Add Tests
+
+Add tests that verify both proxy methods are called on the builder.
+
+## Impact
+
+- **Users with HTTP/HTTPS proxies**: Will now work correctly for both API calls and polling
+- **Users with SOCKS5 proxies**: Will work after installing the `socks` extra dependency
+- **Users without proxy**: No change in behavior
+
+## Implementation Plan
+
+1. Modify `src/psi_agent/channel/telegram/bot.py` to set `get_updates_proxy()`
+2. Update tests in `tests/channel/telegram/test_bot_streaming.py` to verify both proxy methods are called
+3. Run all quality checks (ruff, ty, pytest)

--- a/openspec/changes/archive/2026-04-30-fix-telegram-proxy-polling/specs.md
+++ b/openspec/changes/archive/2026-04-30-fix-telegram-proxy-polling/specs.md
@@ -1,0 +1,100 @@
+# Spec: Telegram Channel Proxy Configuration
+
+## Overview
+
+The Telegram channel component allows users to run a Telegram bot that communicates with psi-session. For users in regions with restricted access to Telegram, proxy support is essential.
+
+## Requirements
+
+### Functional Requirements
+
+1. **FR-1**: The Telegram channel MUST support HTTP, HTTPS, and SOCKS5 proxy configurations
+2. **FR-2**: The proxy configuration MUST apply to both:
+   - Bot API requests (sendMessage, getMe, etc.)
+   - Updater polling (getUpdates long-polling)
+3. **FR-3**: The system MUST provide clear error messages when SOCKS5 proxy is used without the required `socksio` dependency
+
+### Non-Functional Requirements
+
+1. **NFR-1**: Proxy credentials MUST be masked in logs for security
+2. **NFR-2**: Error messages MUST include installation instructions for SOCKS5 support
+
+## Interface Specification
+
+### Configuration Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `proxy` | `str \| None` | No | Proxy URL for Telegram API. Supports `http://`, `https://`, `socks5://` formats |
+| `stream` | `bool` | No | Enable streaming mode (default: True) |
+| `stream_interval` | `float` | No | Minimum interval between message edits (default: 1.0) |
+
+### Proxy URL Format
+
+```
+<protocol>://[<username>:<password>@]<host>[:<port>]
+```
+
+Examples:
+- `http://proxy.example.com:8080`
+- `socks5://user:pass@proxy.example.com:1080`
+- `https://proxy.example.com:443`
+
+## Behavior Specification
+
+### Startup Sequence
+
+1. Create Application builder with token
+2. If proxy is configured:
+   a. Call `builder.proxy(proxy_url)` for API requests
+   b. Call `builder.get_updates_proxy(proxy_url)` for polling
+   c. Log proxy configuration (with masked credentials)
+3. Build application
+4. Handle potential errors:
+   - `ImportError` with "socksio" → Show installation instructions
+   - `RuntimeError` with "Socks5" → Show installation instructions
+   - Other errors → Re-raise
+
+### Error Messages
+
+**SOCKS5 Missing Dependency:**
+```
+SOCKS5 proxy support requires the 'socksio' package.
+Install it with one of:
+  pip install 'python-telegram-bot[socks]'
+  uv sync --extra socks
+```
+
+## Test Specification
+
+### Unit Tests
+
+1. **Test: HTTP proxy configuration**
+   - Given: Config with HTTP proxy
+   - When: Bot starts
+   - Then: Both `proxy()` and `get_updates_proxy()` are called with proxy URL
+
+2. **Test: SOCKS5 proxy with missing socksio**
+   - Given: Config with SOCKS5 proxy, socksio not installed
+   - When: Bot starts
+   - Then: RuntimeError with installation instructions is raised
+
+3. **Test: Proxy without credentials**
+   - Given: Config with proxy URL without credentials
+   - When: Bot starts
+   - Then: Proxy is configured correctly
+
+4. **Test: Proxy credential masking**
+   - Given: Proxy URL with username:password
+   - When: Logging proxy configuration
+   - Then: Credentials are masked as `***`
+
+## Dependencies
+
+### Required Dependencies
+
+- `python-telegram-bot>=22.0` - Provides `proxy()` and `get_updates_proxy()` methods
+
+### Optional Dependencies
+
+- `socksio>=1.0.0` - Required for SOCKS5 proxy support (optional extra: `[socks]`)

--- a/openspec/changes/archive/2026-04-30-fix-telegram-proxy-polling/tasks.md
+++ b/openspec/changes/archive/2026-04-30-fix-telegram-proxy-polling/tasks.md
@@ -1,0 +1,78 @@
+# Tasks: Fix Telegram Channel Proxy Configuration
+
+## Overview
+
+This change adds `get_updates_proxy()` to the Telegram bot's Application builder to ensure proxy configuration applies to both API requests and updater polling.
+
+## Tasks
+
+### 1. Update bot.py to set get_updates_proxy
+
+**File**: `src/psi_agent/channel/telegram/bot.py`
+
+**Changes**:
+- In `start()` method, add call to `builder.get_updates_proxy()` alongside existing `builder.proxy()` call
+- Both calls should use the same proxy URL from `self.config.proxy`
+
+**Implementation**:
+```python
+if self.config.proxy:
+    builder = builder.proxy(self.config.proxy)
+    builder = builder.get_updates_proxy(self.config.proxy)  # ADD THIS LINE
+    # Log proxy without credentials (show host only)
+    proxy_display = self._mask_proxy_credentials(self.config.proxy)
+    logger.info(f"Using proxy: {proxy_display}")
+```
+
+---
+
+### 2. Update tests to verify both proxy methods are called
+
+**File**: `tests/channel/telegram/test_bot_streaming.py`
+
+**Changes**:
+- Update `test_http_proxy_no_extra_dependency` to verify `get_updates_proxy` is called
+- Update `test_socks5_proxy_missing_dependency_error` to mock both methods
+- Update `test_socks5_proxy_runtime_error` to mock both methods
+- Update `test_import_error_non_socksio` to mock both methods
+- Update `test_runtime_error_non_socks5` to mock both methods
+
+**Implementation**:
+Add `mock_builder.get_updates_proxy.return_value = mock_builder` to each test and add assertion:
+```python
+mock_builder.get_updates_proxy.assert_called_once_with(<proxy_url>)
+```
+
+---
+
+### 3. Run quality checks
+
+**Commands**:
+```bash
+uv run ruff check src/psi_agent/channel/telegram/bot.py
+uv run ruff format src/psi_agent/channel/telegram/bot.py
+uv run ty check src/psi_agent/channel/telegram/
+uv run pytest tests/channel/telegram/ -v
+```
+
+---
+
+### 4. Commit changes
+
+**Commit message**:
+```
+Fix Telegram proxy configuration for updater polling
+
+The proxy was only being set for bot API requests, not for the
+getUpdates long-polling connection. This fix adds get_updates_proxy()
+to ensure both connections use the configured proxy.
+
+Fixes #92
+```
+
+## Verification
+
+1. Run tests: `uv run pytest tests/channel/telegram/ -v`
+2. All tests pass
+3. Code passes ruff check and format
+4. Code passes ty check

--- a/src/psi_agent/channel/telegram/bot.py
+++ b/src/psi_agent/channel/telegram/bot.py
@@ -73,9 +73,10 @@ class TelegramBot:
         """Start the Telegram bot."""
         builder = Application.builder().token(self.config.token)
 
-        # Configure proxy if provided
+        # Configure proxy if provided (for both API requests and updater polling)
         if self.config.proxy:
             builder = builder.proxy(self.config.proxy)
+            builder = builder.get_updates_proxy(self.config.proxy)
             # Log proxy without credentials (show host only)
             proxy_display = self._mask_proxy_credentials(self.config.proxy)
             logger.info(f"Using proxy: {proxy_display}")

--- a/tests/channel/telegram/test_bot_streaming.py
+++ b/tests/channel/telegram/test_bot_streaming.py
@@ -603,6 +603,7 @@ class TestProxyValidation:
         mock_builder = MagicMock()
         mock_builder.token.return_value = mock_builder
         mock_builder.proxy.return_value = mock_builder
+        mock_builder.get_updates_proxy.return_value = mock_builder
         mock_builder.build.side_effect = ImportError(
             "Using SOCKS proxy, but the 'socksio' package is not installed"
         )
@@ -618,6 +619,10 @@ class TestProxyValidation:
         assert "socksio" in error_msg.lower()
         assert "pip install" in error_msg or "uv sync" in error_msg
 
+        # Verify both proxy methods were called
+        mock_builder.proxy.assert_called_once_with("socks5://localhost:1080")
+        mock_builder.get_updates_proxy.assert_called_once_with("socks5://localhost:1080")
+
     @pytest.mark.asyncio
     async def test_socks5_proxy_runtime_error(self):
         """Test SOCKS5 proxy raises clear error when python-telegram-bot raises RuntimeError."""
@@ -632,6 +637,7 @@ class TestProxyValidation:
         mock_builder = MagicMock()
         mock_builder.token.return_value = mock_builder
         mock_builder.proxy.return_value = mock_builder
+        mock_builder.get_updates_proxy.return_value = mock_builder
         mock_builder.build.side_effect = RuntimeError(
             "To use Socks5 proxies, PTB must be installed via pip install"
         )
@@ -646,6 +652,10 @@ class TestProxyValidation:
         error_msg = str(exc_info.value)
         assert "socksio" in error_msg.lower()
         assert "pip install" in error_msg or "uv sync" in error_msg
+
+        # Verify both proxy methods were called
+        mock_builder.proxy.assert_called_once_with("socks5://localhost:1080")
+        mock_builder.get_updates_proxy.assert_called_once_with("socks5://localhost:1080")
 
     @pytest.mark.asyncio
     async def test_http_proxy_no_extra_dependency(self):
@@ -671,6 +681,7 @@ class TestProxyValidation:
         mock_builder = MagicMock()
         mock_builder.token.return_value = mock_builder
         mock_builder.proxy.return_value = mock_builder
+        mock_builder.get_updates_proxy.return_value = mock_builder
         mock_builder.build.return_value = mock_app
 
         # Set stop_event so start() doesn't hang waiting forever
@@ -679,6 +690,10 @@ class TestProxyValidation:
         with patch("psi_agent.channel.telegram.bot.Application.builder", return_value=mock_builder):
             # This should not raise any error about socksio
             await bot.start()
+
+        # Verify both proxy methods were called
+        mock_builder.proxy.assert_called_once_with("http://localhost:8080")
+        mock_builder.get_updates_proxy.assert_called_once_with("http://localhost:8080")
 
     @pytest.mark.asyncio
     async def test_import_error_non_socksio(self):
@@ -694,6 +709,7 @@ class TestProxyValidation:
         mock_builder = MagicMock()
         mock_builder.token.return_value = mock_builder
         mock_builder.proxy.return_value = mock_builder
+        mock_builder.get_updates_proxy.return_value = mock_builder
         mock_builder.build.side_effect = ImportError("Some other import error")
 
         with (
@@ -703,6 +719,10 @@ class TestProxyValidation:
             await bot.start()
 
         assert "Some other import error" in str(exc_info.value)
+
+        # Verify both proxy methods were called
+        mock_builder.proxy.assert_called_once_with("socks5://localhost:1080")
+        mock_builder.get_updates_proxy.assert_called_once_with("socks5://localhost:1080")
 
     @pytest.mark.asyncio
     async def test_runtime_error_non_socks5(self):
@@ -718,6 +738,7 @@ class TestProxyValidation:
         mock_builder = MagicMock()
         mock_builder.token.return_value = mock_builder
         mock_builder.proxy.return_value = mock_builder
+        mock_builder.get_updates_proxy.return_value = mock_builder
         mock_builder.build.side_effect = RuntimeError("Some other runtime error")
 
         with (
@@ -727,6 +748,10 @@ class TestProxyValidation:
             await bot.start()
 
         assert "Some other runtime error" in str(exc_info.value)
+
+        # Verify both proxy methods were called
+        mock_builder.proxy.assert_called_once_with("socks5://localhost:1080")
+        mock_builder.get_updates_proxy.assert_called_once_with("socks5://localhost:1080")
 
 
 class TestProxyCredentialMasking:


### PR DESCRIPTION
## Summary
- Fix proxy configuration not working for Telegram channel by adding `get_updates_proxy()` call alongside existing `proxy()` call
- The proxy was only being set for bot API requests, but the updater's `getUpdates` long-polling connection uses a separate HTTP client that needs its own proxy configuration

## Root Cause
The python-telegram-bot library uses two separate HTTP clients:
1. Bot API client (for `sendMessage`, `getMe`, etc.) - configured via `proxy()`
2. Updater client (for `getUpdates` polling) - configured via `get_updates_proxy()`

Without setting both, the updater could not connect through the proxy when polling for updates.

## Changes
- `src/psi_agent/channel/telegram/bot.py`: Added `builder.get_updates_proxy(self.config.proxy)` call
- `tests/channel/telegram/test_bot_streaming.py`: Updated tests to verify both proxy methods are called

## Test plan
- [x] All 571 tests pass
- [x] 89% code coverage maintained
- [x] ruff check passes
- [x] ruff format passes
- [x] ty check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)