### PR TITLE
Add skills directory location to system prompt

### DIFF
--- a/examples/a-simple-bash-only-workspace/systems/system.py
+++ b/examples/a-simple-bash-only-workspace/systems/system.py
@@ -99,11 +99,13 @@ class System:
                             skill_descriptions.append(f"- {skill_path.name}: {description}")
 
         workspace_resolved = await self._workspace_dir.resolve()
+        skills_dir = workspace_resolved / "skills"
         system_prompt = f"""You are a helpful assistant with access to tools and skills.
 
 ## Workspace
 
 Your workspace directory is: {workspace_resolved}
+All skills are located in: {skills_dir}
 
 ## Available Skills
 

--- a/openspec/changes/archive/2026-05-01-update-simple-workspace-system-prompt/.openspec.yaml
+++ b/openspec/changes/archive/2026-05-01-update-simple-workspace-system-prompt/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-01

--- a/openspec/changes/archive/2026-05-01-update-simple-workspace-system-prompt/design.md
+++ b/openspec/changes/archive/2026-05-01-update-simple-workspace-system-prompt/design.md
@@ -1,0 +1,23 @@
+## Context
+
+The simple workspace example (`examples/a-simple-bash-only-workspace/`) has a `build_system_prompt()` function that generates the system prompt for the agent. Currently, it shows the workspace directory path but doesn't explicitly mention where skills are located.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Add explicit guidance about the skills directory location in the system prompt
+- Make it clear to the agent that all skills are stored in `workspace/skills/`
+
+**Non-Goals:**
+- Changing the workspace structure
+- Modifying any other workspace examples
+- Adding new features beyond the informational message
+
+## Decisions
+
+- **Placement**: Add the skills directory information in the "Workspace" section of the system prompt, right after the workspace directory path. This keeps related information together.
+- **Format**: Use a simple sentence format that clearly states the location and purpose of the skills directory.
+
+## Risks / Trade-offs
+
+No significant risks. This is a minor informational change that improves clarity without affecting behavior.

--- a/openspec/changes/archive/2026-05-01-update-simple-workspace-system-prompt/proposal.md
+++ b/openspec/changes/archive/2026-05-01-update-simple-workspace-system-prompt/proposal.md
@@ -1,0 +1,24 @@
+## Why
+
+The current system prompt in the simple workspace example tells the agent about the workspace directory but doesn't explicitly inform the agent where skills are located. This makes it unclear to the agent that all skills are stored in the `skills/` subdirectory within the workspace, which could lead to confusion when the agent tries to read skill details.
+
+## What Changes
+
+- Add a sentence in the system prompt that explicitly states the skills directory location
+- Inform the agent that all skills are stored in the `skills/` directory within the workspace
+
+## Capabilities
+
+### New Capabilities
+
+- `skill-directory-guidance`: Provides explicit guidance to the agent about where skills are located in the workspace structure
+
+### Modified Capabilities
+
+None - this is a new informational addition, not a behavior change.
+
+## Impact
+
+- `examples/a-simple-bash-only-workspace/systems/system.py` - modification to `build_system_prompt()` function
+- No API changes
+- No breaking changes

--- a/openspec/changes/archive/2026-05-01-update-simple-workspace-system-prompt/specs/skill-directory-guidance/spec.md
+++ b/openspec/changes/archive/2026-05-01-update-simple-workspace-system-prompt/specs/skill-directory-guidance/spec.md
@@ -1,0 +1,12 @@
+## ADDED Requirements
+
+### Requirement: System prompt includes skills directory location
+The system prompt SHALL include explicit information about where skills are located in the workspace directory structure.
+
+#### Scenario: Skills directory mentioned in system prompt
+- **WHEN** the system prompt is built by `build_system_prompt()`
+- **THEN** the prompt includes a statement indicating that all skills are located in the `skills/` directory within the workspace
+
+#### Scenario: Skills directory path is clear
+- **WHEN** the agent reads the system prompt
+- **THEN** the agent can determine the exact location of the skills directory relative to the workspace directory

--- a/openspec/changes/archive/2026-05-01-update-simple-workspace-system-prompt/tasks.md
+++ b/openspec/changes/archive/2026-05-01-update-simple-workspace-system-prompt/tasks.md
@@ -1,0 +1,9 @@
+## 1. Code Changes
+
+- [x] 1.1 Create a new branch for the change
+- [x] 1.2 Modify `build_system_prompt()` in `examples/a-simple-bash-only-workspace/systems/system.py` to add skills directory information
+
+## 2. Verification
+
+- [x] 2.1 Verify the system prompt includes the skills directory location
+- [x] 2.2 Run quality checks (format, lint, typing)

--- a/openspec/specs/skill-directory-guidance/spec.md
+++ b/openspec/specs/skill-directory-guidance/spec.md
@@ -1,0 +1,14 @@
+# skill-directory-guidance
+
+## Requirements
+
+### Requirement: System prompt includes skills directory location
+The system prompt SHALL include explicit information about where skills are located in the workspace directory structure.
+
+#### Scenario: Skills directory mentioned in system prompt
+- **WHEN** the system prompt is built by `build_system_prompt()`
+- **THEN** the prompt includes a statement indicating that all skills are located in the `skills/` directory within the workspace
+
+#### Scenario: Skills directory path is clear
+- **WHEN** the agent reads the system prompt
+- **THEN** the agent can determine the exact location of the skills directory relative to the workspace directory


### PR DESCRIPTION
## Summary
- Update the simple workspace example to explicitly inform the agent where skills are located
- Add `All skills are located in: <skills_dir>` to the system prompt's Workspace section
- Create new `skill-directory-guidance` spec documenting this requirement

## Test plan
- [ ] Verify system prompt includes skills directory path
- [ ] Run quality checks (format, lint, typing) - all passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)