### PR TITLE
Add Git workflow compliance requirements to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -706,7 +706,27 @@ uv run psi-agent channel repl \
   --session-socket ./channel.sock
 ```
 
-## Git 提交规范
+## Git 工作流规范
+
+### 分支管理
+
+> **⚠️ 禁止直接在 main 分支上工作**
+>
+> 所有变更必须在 feature 分支上进行，通过 Pull Request 合并到 main。
+>
+> **正确流程：**
+> 1. 从 main 创建 feature 分支：`git checkout -b <feature-name>`
+> 2. 在 feature 分支上进行开发和提交
+> 3. 推送 feature 分支：`git push -u origin <feature-name>`
+> 4. 创建 Pull Request
+> 5. 等待 CI 通过后合并
+>
+> **禁止事项：**
+> - 禁止直接在 main 分支上提交
+> - 禁止直接 push 到 main 分支
+> - 禁止绕过 PR 流程
+
+### OpenSpec 归档
 
 > **⚠️ 重要：OpenSpec 归档目录必须提交到 Git**
 >
@@ -718,3 +738,5 @@ uv run psi-agent channel repl \
 > 3. 确保新的 `openspec/specs/` 目录（如有）已添加到暂存区
 >
 > **禁止遗漏归档目录的提交。**
+
+### Git 提交格式

--- a/openspec/changes/archive/2026-05-01-emphasize-git-workflow/.openspec.yaml
+++ b/openspec/changes/archive/2026-05-01-emphasize-git-workflow/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-01

--- a/openspec/changes/archive/2026-05-01-emphasize-git-workflow/design.md
+++ b/openspec/changes/archive/2026-05-01-emphasize-git-workflow/design.md
@@ -1,0 +1,39 @@
+## Context
+
+在 ai-module-documentation 变更过程中，发生了以下工作流违规：
+1. 直接在 main 分支上创建归档提交
+2. 直接 push 到 main 分支，绕过了 PR 流程
+
+这暴露了 CLAUDE.md 中缺乏明确的 Git 工作流规范。虽然项目使用了 OpenSpec 工作流，但没有在 CLAUDE.md 中明确强调：
+- OpenSpec 变更必须纳入 Git 管理
+- 所有变更必须通过 PR 流程
+- 禁止直接在 main 分支上工作
+
+## Goals / Non-Goals
+
+**Goals:**
+- 在 CLAUDE.md 中添加明确的 Git 工作流规范
+- 防止未来再次发生直接 push main 的情况
+- 确保 OpenSpec 归档目录始终纳入 Git 管理
+
+**Non-Goals:**
+- 不修改现有的 Git 分支保护设置
+- 不修改 OpenSpec 工作流本身
+
+## Decisions
+
+### 1. 在 CLAUDE.md 中添加 Git 工作流章节
+
+在现有"开发工作流"章节后添加新的"Git 工作流规范"章节，包含：
+- 分支管理规范
+- PR 流程规范
+- OpenSpec 归档规范
+
+### 2. 强调 OpenSpec 归档必须提交
+
+明确说明 OpenSpec 归档目录（`openspec/changes/archive/`）必须与代码变更一起提交到 Git。
+
+## Risks / Trade-offs
+
+- **风险**: 开发者可能忽略文档中的规范 → 通过 code review 流程检查
+- **权衡**: 文档长度增加 → 保持简洁，只添加必要的规范

--- a/openspec/changes/archive/2026-05-01-emphasize-git-workflow/proposal.md
+++ b/openspec/changes/archive/2026-05-01-emphasize-git-workflow/proposal.md
@@ -1,0 +1,25 @@
+## Why
+
+在 ai-module-documentation 变更过程中，我错误地直接在 main 分支上工作并直接 push 到 main，这违反了项目的工作流规范。为了防止未来再次发生类似错误，需要在主 CLAUDE.md 中明确强调 Git 工作流规范。
+
+## What Changes
+
+- 在 `CLAUDE.md` 中添加 Git 工作流规范章节
+- 强调 OpenSpec 变更必须纳入 Git 管理
+- 强调禁止直接在 main 分支上工作
+- 强调禁止直接 push 到 main 分支
+
+## Capabilities
+
+### New Capabilities
+
+- `git-workflow-compliance`: Git 工作流规范，确保所有变更通过 PR 流程
+
+### Modified Capabilities
+
+None
+
+## Impact
+
+- `CLAUDE.md` — 添加 Git 工作流规范章节
+- 所有开发者 — 需要遵循新的工作流规范

--- a/openspec/changes/archive/2026-05-01-emphasize-git-workflow/specs/git-workflow-compliance/spec.md
+++ b/openspec/changes/archive/2026-05-01-emphasize-git-workflow/specs/git-workflow-compliance/spec.md
@@ -1,0 +1,34 @@
+## ADDED Requirements
+
+### Requirement: OpenSpec changes must be committed to Git
+All OpenSpec change directories (including archive) SHALL be committed to Git as part of the project history.
+
+#### Scenario: Archive directory committed
+- **WHEN** an OpenSpec change is archived
+- **THEN** the archive directory `openspec/changes/archive/YYYY-MM-DD-<name>/` SHALL be committed to Git
+
+#### Scenario: Archive directory not ignored
+- **WHEN** checking `.gitignore`
+- **THEN** `openspec/changes/archive/` SHALL NOT be in the ignore list
+
+### Requirement: No direct commits to main branch
+All changes SHALL be made on a feature branch and merged via pull request.
+
+#### Scenario: Feature branch created
+- **WHEN** starting work on a change
+- **THEN** a new branch SHALL be created from main
+
+#### Scenario: Changes merged via PR
+- **WHEN** work on a feature branch is complete
+- **THEN** changes SHALL be merged via a pull request, NOT by direct push to main
+
+### Requirement: No direct push to main branch
+Direct push to main branch SHALL be prohibited for all developers.
+
+#### Scenario: Push to main rejected
+- **WHEN** a developer attempts to push directly to main
+- **THEN** the push SHALL be rejected by branch protection rules
+
+#### Scenario: PR required for merge
+- **WHEN** changes need to be merged to main
+- **THEN** a pull request SHALL be created and approved before merge

--- a/openspec/changes/archive/2026-05-01-emphasize-git-workflow/tasks.md
+++ b/openspec/changes/archive/2026-05-01-emphasize-git-workflow/tasks.md
@@ -1,0 +1,3 @@
+## 1. Update CLAUDE.md
+
+- [x] 1.1 Add "Git 工作流规范" section to CLAUDE.md with OpenSpec archive and branch protection rules

--- a/openspec/specs/git-workflow-compliance/spec.md
+++ b/openspec/specs/git-workflow-compliance/spec.md
@@ -1,0 +1,36 @@
+# Git Workflow Compliance
+
+## Requirements
+
+### Requirement: OpenSpec changes must be committed to Git
+All OpenSpec change directories (including archive) SHALL be committed to Git as part of the project history.
+
+#### Scenario: Archive directory committed
+- **WHEN** an OpenSpec change is archived
+- **THEN** the archive directory `openspec/changes/archive/YYYY-MM-DD-<name>/` SHALL be committed to Git
+
+#### Scenario: Archive directory not ignored
+- **WHEN** checking `.gitignore`
+- **THEN** `openspec/changes/archive/` SHALL NOT be in the ignore list
+
+### Requirement: No direct commits to main branch
+All changes SHALL be made on a feature branch and merged via pull request.
+
+#### Scenario: Feature branch created
+- **WHEN** starting work on a change
+- **THEN** a new branch SHALL be created from main
+
+#### Scenario: Changes merged via PR
+- **WHEN** work on a feature branch is complete
+- **THEN** changes SHALL be merged via a pull request, NOT by direct push to main
+
+### Requirement: No direct push to main branch
+Direct push to main branch SHALL be prohibited for all developers.
+
+#### Scenario: Push to main rejected
+- **WHEN** a developer attempts to push directly to main
+- **THEN** the push SHALL be rejected by branch protection rules
+
+#### Scenario: PR required for merge
+- **WHEN** changes need to be merged to main
+- **THEN** a pull request SHALL be created and approved before merge


### PR DESCRIPTION
## Summary

- Add "Git 工作流规范" section to CLAUDE.md with branch management rules
- Emphasize no direct commits/pushes to main branch
- Emphasize OpenSpec archives must be committed to Git
- Create `git-workflow-compliance` spec with 3 requirements

## Context

在之前的 ai-module-documentation 变更过程中，我错误地直接在 main 分支上工作并直接 push 到 main。为了防止未来再次发生类似错误，添加了明确的 Git 工作流规范。

## Test plan

- [x] Verify CLAUDE.md has new "Git 工作流规范" section
- [x] Verify git-workflow-compliance spec exists
- [x] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)