### PR TITLE
Update session CLAUDE.md to reflect streaming parsing architecture

### DIFF
--- a/openspec/changes/archive/2026-05-01-session-docs-update/.openspec.yaml
+++ b/openspec/changes/archive/2026-05-01-session-docs-update/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-01

--- a/openspec/changes/archive/2026-05-01-session-docs-update/design.md
+++ b/openspec/changes/archive/2026-05-01-session-docs-update/design.md
@@ -1,0 +1,47 @@
+## Context
+
+The session module's CLAUDE.md provides comprehensive documentation for developers working on psi-session. After the recent code quality improvements (extracting `_parse_streaming_response` helper method), the documentation should be updated to reflect the current architecture.
+
+The current documentation covers:
+- Architecture overview
+- Module structure and responsibilities
+- Core data structures
+- Message processing flows
+- Tool system
+- Workspace hot-reload
+- Schedule system
+- History persistence
+- System interface
+- HTTP interface
+- CLI usage
+
+## Goals / Non-Goals
+
+**Goals:**
+- Update runner.py module description to mention the streaming parsing helper
+- Ensure documentation reflects current architecture accurately
+- Maintain consistent level of detail across all sections
+
+**Non-Goals:**
+- Rewriting or restructuring the entire document
+- Adding new sections that don't relate to recent changes
+- Changing any code behavior
+
+## Decisions
+
+### Update runner.py module description
+
+**Decision**: Add a brief mention of the `_parse_streaming_response` helper method in the module responsibilities table.
+
+**Rationale**: The helper method is a key architectural improvement that centralizes SSE parsing logic. Developers should know it exists when reading the module overview.
+
+### Keep documentation at consistent detail level
+
+**Decision**: Only add minimal updates to maintain consistency with existing documentation style.
+
+**Rationale**: The existing documentation provides good overview-level information. Adding too much detail about internal methods would create inconsistency with other modules' documentation.
+
+## Risks / Trade-offs
+
+**Documentation becoming outdated again**: Future code changes may not update docs.
+→ Mitigation: Keep updates minimal and focused on architectural decisions that are unlikely to change frequently.

--- a/openspec/changes/archive/2026-05-01-session-docs-update/proposal.md
+++ b/openspec/changes/archive/2026-05-01-session-docs-update/proposal.md
@@ -1,0 +1,23 @@
+## Why
+
+The session module's CLAUDE.md documentation was created before the recent code quality improvements. After extracting `_parse_streaming_response` as a shared helper method and adding consistent DEBUG logging, the documentation should reflect these architectural changes to help future developers understand the streaming parsing design.
+
+## What Changes
+
+- **Update runner.py module description**: Add mention of `_parse_streaming_response` helper method for centralized SSE parsing
+- **Update streaming processing section**: Clarify that both `_run_conversation` and `_stream_conversation` use the shared parsing helper
+- **Add internal methods section**: Document key private methods in SessionRunner that are important for understanding the architecture
+
+## Capabilities
+
+### New Capabilities
+
+None - this is a documentation update only.
+
+### Modified Capabilities
+
+None - no spec-level behavior changes, only documentation improvements.
+
+## Impact
+
+- `src/psi_agent/session/CLAUDE.md` — Documentation updates to reflect current architecture

--- a/openspec/changes/archive/2026-05-01-session-docs-update/specs/session-docs-update/spec.md
+++ b/openspec/changes/archive/2026-05-01-session-docs-update/specs/session-docs-update/spec.md
@@ -1,0 +1,5 @@
+## ADDED Requirements
+
+None - this is a documentation update only. No spec-level behavior changes.
+
+The session module's CLAUDE.md documentation will be updated to reflect the current architecture after the code quality improvements (extraction of `_parse_streaming_response` helper method).

--- a/openspec/changes/archive/2026-05-01-session-docs-update/tasks.md
+++ b/openspec/changes/archive/2026-05-01-session-docs-update/tasks.md
@@ -1,0 +1,4 @@
+## 1. Update CLAUDE.md documentation
+
+- [x] 1.1 Update runner.py module description in "模块职责" section to mention `_parse_streaming_response` helper method
+- [x] 1.2 Verify documentation consistency with other module descriptions

--- a/src/psi_agent/session/CLAUDE.md
+++ b/src/psi_agent/session/CLAUDE.md
@@ -66,7 +66,7 @@ src/psi_agent/session/
 | `config.py` | 配置 dataclass，包含 channel_socket、ai_socket、workspace、history_file |
 | `types.py` | 核心数据结构定义 |
 | `server.py` | HTTP server，监听 Unix socket，路由 `/v1/chat/completions` |
-| `runner.py` | 核心运行循环：消息处理、tool call 循环、流式/非流式响应 |
+| `runner.py` | 核心运行循环：消息处理、tool call 循环、流式/非流式响应；含 `_parse_streaming_response` 统一解析 SSE |
 | `tool_loader.py` | 扫描 tools 目录，动态导入，解析 docstring，生成 OpenAI schema |
 | `tool_executor.py` | 执行工具函数，支持并行执行多个 tool calls |
 | `workspace_watcher.py` | MD5 哈希检测文件变更，生成 ChangeSummary |


### PR DESCRIPTION
## Summary
- Update runner.py module description in CLAUDE.md to mention `_parse_streaming_response` helper method
- Document the centralized SSE parsing architecture introduced in the recent code quality improvements

## Changes
- `src/psi_agent/session/CLAUDE.md`: Updated runner.py module description to include `_parse_streaming_response` helper method for unified SSE parsing

## Test plan
- [x] Documentation update only, no code changes
- [x] Verified consistency with other module descriptions

🤖 Generated with [Claude Code](https://claude.com/claude-code)