### PR TITLE
Fix AI modules: logging, tool_calls translation, error handling

### DIFF
--- a/openspec/changes/archive/2026-05-02-ai-modules-coverage/.openspec.yaml
+++ b/openspec/changes/archive/2026-05-02-ai-modules-coverage/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-02

--- a/openspec/changes/archive/2026-05-02-ai-modules-coverage/design.md
+++ b/openspec/changes/archive/2026-05-02-ai-modules-coverage/design.md
@@ -1,0 +1,31 @@
+## Context
+
+PR #113 added new code paths that need test coverage:
+
+1. **Session runner error handling** (`runner.py:177-181`): New code to detect and raise RuntimeError when streaming response contains an error chunk. This code path is not exercised by existing tests.
+
+2. **Translator tool_use extraction** (`translator.py:210-223`): New code to extract tool_use content blocks and convert to tool_calls. Tests were added but we need to verify coverage.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Achieve 100% coverage for new code added in PR #113
+- Specifically cover the error chunk handling in `_parse_streaming_response`
+
+**Non-Goals:**
+- Improving coverage for unrelated code
+- Changing any production code
+
+## Decisions
+
+### Test error chunk handling
+
+**Decision**: Add a test that mocks a streaming response containing an error chunk and verifies that RuntimeError is raised.
+
+**Rationale**: The new error handling code raises RuntimeError when it detects `{"error": ...}` in a streaming chunk. We need to test this behavior.
+
+**Implementation**: Use `aiohttp` mock response with error chunk data.
+
+## Risks / Trade-offs
+
+**Minimal risk**: Only adding tests, no production code changes.

--- a/openspec/changes/archive/2026-05-02-ai-modules-coverage/proposal.md
+++ b/openspec/changes/archive/2026-05-02-ai-modules-coverage/proposal.md
@@ -1,0 +1,26 @@
+## Why
+
+Codecov reports insufficient test coverage for the newly added code in PR #113 (ai-modules-review). The changes introduced new code paths that need test coverage:
+
+1. **Session error handling**: New error chunk detection in `_parse_streaming_response` (lines 177-181) is not tested
+2. **Translator tool_calls extraction**: New tool_use content block handling in `translate_anthropic_to_openai` needs coverage verification
+
+## What Changes
+
+- Add test for error chunk handling in session's `_parse_streaming_response`
+- Verify coverage for new translator code (already has tests, may need edge cases)
+
+## Capabilities
+
+### New Capabilities
+
+None - this is test coverage improvement for existing code.
+
+### Modified Capabilities
+
+None - no spec-level behavior changes.
+
+## Impact
+
+- `tests/session/test_runner.py` — Add test for streaming error chunk handling
+- `tests/ai/anthropic_messages/test_translator.py` — Verify coverage for tool_use extraction (already added)

--- a/openspec/changes/archive/2026-05-02-ai-modules-coverage/specs/ai-modules-coverage/spec.md
+++ b/openspec/changes/archive/2026-05-02-ai-modules-coverage/specs/ai-modules-coverage/spec.md
@@ -1,0 +1,7 @@
+## ADDED Requirements
+
+None - this is a test coverage improvement with no spec-level behavior changes.
+
+The tests will verify existing behavior:
+- Error chunk handling in streaming responses (added in PR #113)
+- Tool_use content block extraction (added in PR #113)

--- a/openspec/changes/archive/2026-05-02-ai-modules-coverage/tasks.md
+++ b/openspec/changes/archive/2026-05-02-ai-modules-coverage/tasks.md
@@ -1,0 +1,7 @@
+## 1. Add tests for session error handling
+
+- [x] 1.1 Add test for `_parse_streaming_response` error chunk handling - verify RuntimeError is raised when error chunk is received
+
+## 2. Verify translator coverage
+
+- [x] 2.1 Run coverage report to verify translator tool_use extraction is covered

--- a/openspec/changes/archive/2026-05-02-ai-modules-review/.openspec.yaml
+++ b/openspec/changes/archive/2026-05-02-ai-modules-review/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-02

--- a/openspec/changes/archive/2026-05-02-ai-modules-review/design.md
+++ b/openspec/changes/archive/2026-05-02-ai-modules-review/design.md
@@ -1,0 +1,99 @@
+## Context
+
+The psi-ai-* modules (openai_completions and anthropic_messages) are LLM provider adapters that follow a consistent design pattern. After reviewing all files in both modules, several inconsistencies were identified:
+
+1. **Streaming request logging gap**: `_non_stream_request` logs the full request body at DEBUG level, but `_stream_request` does not. This makes debugging streaming issues harder.
+
+2. **Streaming completion logging gap**: The session module's server logs "SSE stream completed successfully" at DEBUG level before the INFO log, but the AI module servers only log at INFO level.
+
+3. **Redundant assertions**: Both server modules have `assert self.client is not None` immediately after assignment in `start()`, which is unnecessary.
+
+4. **Non-streaming tool_calls translation bug**: `translate_anthropic_to_openai()` does not extract `tool_use` content blocks from Anthropic responses. When `stop_reason == "tool_use"`, the `finish_reason` is correctly set to `"tool_calls"`, but the `message.tool_calls` field is missing. This breaks the OpenAI format contract.
+
+5. **Streaming error handling gap**: When AI modules yield an error chunk during streaming (`{"error": "...", "status_code": ...}`), the session module's `_parse_streaming_response` silently ignores it.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Achieve logging consistency between streaming and non-streaming code paths
+- Achieve logging consistency with session module patterns
+- Remove unnecessary code
+- Fix protocol translation bug to ensure consistent interface
+- Improve error handling robustness
+
+**Non-Goals:**
+- Adding new features
+- Major refactoring
+- Changing any external behavior (except fixing the bug)
+
+## Decisions
+
+### Add DEBUG log for streaming request body
+
+**Decision**: Add `logger.debug(f"Request body: {json.dumps(body, ensure_ascii=False, indent=2)}")` at the start of `_stream_request` in both client modules.
+
+**Rationale**: Parity with `_non_stream_request` which already has this log. This helps debug streaming issues.
+
+**Alternative considered**: Log only a summary. Rejected because the full body is needed for debugging.
+
+### Add DEBUG log for streaming completion
+
+**Decision**: Add `logger.debug("SSE stream completed successfully")` before the INFO log in `_handle_streaming` of both server modules.
+
+**Rationale**: Parity with session module's server which has this pattern. Provides consistent DEBUG-level traceability.
+
+### Remove redundant assertions
+
+**Decision**: Remove `assert self.client is not None` after assignment in `start()` method of both server modules.
+
+**Rationale**: The assertion immediately follows `self.client = ...` assignment, so it can never fail. The None check in `_handle_chat_completions` is sufficient.
+
+### Fix non-streaming tool_calls translation
+
+**Decision**: Modify `translate_anthropic_to_openai()` to extract `tool_use` content blocks and populate `message.tool_calls` field.
+
+**Rationale**: The current implementation only extracts `text` content blocks, completely ignoring `tool_use` blocks. This breaks the OpenAI format contract when Anthropic returns tool calls.
+
+**Implementation**:
+1. Iterate through `content_blocks` to find `type == "tool_use"` blocks
+2. Convert each `tool_use` block to OpenAI `tool_calls` format
+3. Add `tool_calls` to the `message` dict when present
+
+**Impact**: Session always uses streaming internally, so this bug doesn't affect normal operation. However, it's a protocol compliance issue that could affect other clients.
+
+### Handle streaming error chunks in session
+
+**Decision**: Add error detection in `_parse_streaming_response` to check for `error` field in chunks.
+
+**Rationale**: When streaming fails mid-stream, the error is silently ignored, leading to empty responses. Users should see the error message.
+
+**Implementation**: Check if chunk contains `error` field, log the error, and raise an exception or yield an error indicator.
+
+## Risks / Trade-offs
+
+**Minimal change risk**: The changes are small and focused.
+→ Mitigation: Run all existing tests to verify no regressions.
+
+**Protocol fix risk**: The tool_calls fix changes behavior, but only for non-streaming responses which are not used by session.
+→ Mitigation: Add tests to verify the fix works correctly.
+
+## Protocol Translation Consistency Analysis
+
+### Verified Consistent ✓
+
+| Aspect | OpenAI | Anthropic | Status |
+|--------|--------|-----------|--------|
+| [DONE] marker | `data: [DONE]\n\n` | `data: [DONE]\n\n` (via translator) | ✓ |
+| Error chunk format | `{"error": str, "status_code": int}` | Same | ✓ |
+| Streaming tool_calls | Via SDK | Via translator `StreamingTranslator` | ✓ |
+| finish_reason mapping | Via SDK | `end_turn→stop, tool_use→tool_calls, max_tokens→length` | ✓ |
+
+### Fixed by this change
+
+| Aspect | Issue | Fix |
+|--------|-------|-----|
+| Non-streaming tool_calls | `translate_anthropic_to_openai` ignores `tool_use` blocks | Extract and convert to `message.tool_calls` |
+
+### Robustness Patterns
+
+Both modules use defensive `.get()` access consistently. The translator has proper null checks throughout.

--- a/openspec/changes/archive/2026-05-02-ai-modules-review/proposal.md
+++ b/openspec/changes/archive/2026-05-02-ai-modules-review/proposal.md
@@ -1,0 +1,39 @@
+## Why
+
+The psi-ai-* modules (openai_completions and anthropic_messages) have inconsistent logging patterns, a protocol translation bug, and error handling gaps that affect maintainability, correctness, and debugging.
+
+### Issues Found
+
+1. **Logging inconsistencies**: Streaming request handling lacks DEBUG logs for request bodies, streaming response completion logging is inconsistent with session module patterns, and there are redundant assertions in server startup code.
+
+2. **Protocol translation bug**: `translate_anthropic_to_openai()` does not extract `tool_use` content blocks from Anthropic non-streaming responses. When the model makes a tool call, the response has `finish_reason: "tool_calls"` but no `message.tool_calls` field, breaking the OpenAI format contract.
+
+3. **Error handling gap**: When AI modules yield an error chunk during streaming, the session module silently ignores it, leading to empty responses instead of error messages.
+
+## What Changes
+
+- Add DEBUG log for request body in `_stream_request` method of both client modules (parity with `_non_stream_request`)
+- Add DEBUG log for streaming response completion in `_handle_streaming` method of both server modules (parity with session module)
+- Remove redundant `assert self.client is not None` statements after assignment in both server modules
+- Fix `translate_anthropic_to_openai()` to extract `tool_use` content blocks and populate `message.tool_calls`
+- Handle error chunks in session's `_parse_streaming_response` instead of silently ignoring them
+
+## Capabilities
+
+### New Capabilities
+
+None - this is a bug fix and code quality improvement.
+
+### Modified Capabilities
+
+**Fixed**: Non-streaming Anthropic responses now correctly include `tool_calls` in the message when the model makes tool calls. This ensures protocol parity with OpenAI responses.
+
+## Impact
+
+- `src/psi_agent/ai/openai_completions/client.py` — Add DEBUG log for streaming request body
+- `src/psi_agent/ai/openai_completions/server.py` — Add DEBUG log for streaming completion, remove redundant assert
+- `src/psi_agent/ai/anthropic_messages/client.py` — Add DEBUG log for streaming request body
+- `src/psi_agent/ai/anthropic_messages/server.py` — Add DEBUG log for streaming completion, remove redundant assert
+- `src/psi_agent/ai/anthropic_messages/translator.py` — Fix tool_use extraction in `translate_anthropic_to_openai`
+- `src/psi_agent/session/runner.py` — Handle error chunks in streaming response parsing
+- `tests/ai/anthropic_messages/test_translator.py` — Add tests for tool_calls translation

--- a/openspec/changes/archive/2026-05-02-ai-modules-review/specs/ai-modules-review/spec.md
+++ b/openspec/changes/archive/2026-05-02-ai-modules-review/specs/ai-modules-review/spec.md
@@ -1,0 +1,29 @@
+## ADDED Requirements
+
+### Protocol Translation Correctness
+
+**REQ-1**: Non-streaming Anthropic responses must include `tool_calls` in the message when `stop_reason` is `"tool_use"`.
+
+When Anthropic returns a response with `tool_use` content blocks:
+- The `finish_reason` must be `"tool_calls"`
+- The `message.tool_calls` field must be populated with the tool calls
+- Each tool call must have `id`, `type: "function"`, and `function.name` and `function.arguments`
+
+**Rationale**: This ensures parity with OpenAI responses and the streaming Anthropic translation which already handles this correctly.
+
+### Error Handling
+
+**REQ-2**: Streaming error chunks must be handled visibly, not silently ignored.
+
+When an AI module yields `{"error": "...", "status_code": ...}` during streaming:
+- The error must be logged at ERROR level
+- The session must not silently continue with empty content
+- The user must receive an error indication
+
+## REMOVED Requirements
+
+None - this is a bug fix and improvement with no removed functionality.
+
+## MODIFIED Requirements
+
+None - existing behavior is preserved except for the bug fix.

--- a/openspec/changes/archive/2026-05-02-ai-modules-review/tasks.md
+++ b/openspec/changes/archive/2026-05-02-ai-modules-review/tasks.md
@@ -1,0 +1,21 @@
+## 1. Update openai_completions module
+
+- [x] 1.1 Add DEBUG log for request body in `_stream_request` method of client.py
+- [x] 1.2 Add DEBUG log for streaming completion in `_handle_streaming` method of server.py
+- [x] 1.3 Remove redundant assert in `start` method of server.py
+
+## 2. Update anthropic_messages module
+
+- [x] 2.1 Add DEBUG log for request body in `_stream_request` method of client.py
+- [x] 2.2 Add DEBUG log for streaming completion in `_handle_streaming` method of server.py
+- [x] 2.3 Remove redundant assert in `start` method of server.py
+- [x] 2.4 Fix `translate_anthropic_to_openai` to extract tool_use content blocks and populate `message.tool_calls`
+
+## 3. Update session module for streaming error handling
+
+- [x] 3.1 Handle error chunks in `_parse_streaming_response` method of runner.py - detect `{"error": ...}` format and raise exception or log appropriately instead of silently ignoring
+
+## 4. Add tests for tool_calls translation fix
+
+- [x] 4.1 Add test for `translate_anthropic_to_openai` with tool_use content blocks
+- [x] 4.2 Add test for `translate_anthropic_to_openai` with mixed text and tool_use blocks

--- a/src/psi_agent/ai/anthropic_messages/client.py
+++ b/src/psi_agent/ai/anthropic_messages/client.py
@@ -134,6 +134,7 @@ class AnthropicMessagesClient:
         assert self._client is not None
         client = self._client  # Capture for closure
 
+        logger.debug(f"Request body: {json.dumps(body, ensure_ascii=False, indent=2)}")
         # Remove 'stream' key - messages.stream() doesn't accept this parameter
         body = {k: v for k, v in body.items() if k != "stream"}
 

--- a/src/psi_agent/ai/anthropic_messages/server.py
+++ b/src/psi_agent/ai/anthropic_messages/server.py
@@ -143,6 +143,7 @@ class AnthropicMessagesServer:
         async for chunk in stream_gen:
             await response.write(chunk.encode())
 
+        logger.debug("SSE stream completed successfully")
         logger.info("Streaming response completed")
         return response
 
@@ -169,7 +170,6 @@ class AnthropicMessagesServer:
 
         # Initialize client
         self.client = AnthropicMessagesClient(self.config)
-        assert self.client is not None
         await self.client.__aenter__()
 
         # Start server

--- a/src/psi_agent/ai/anthropic_messages/translator.py
+++ b/src/psi_agent/ai/anthropic_messages/translator.py
@@ -202,12 +202,27 @@ def translate_anthropic_to_openai(anthropic_response: dict[str, Any]) -> dict[st
     Returns:
         OpenAI chat completions response format.
     """
-    # Extract text from content blocks
+    # Extract content blocks
     content_blocks = anthropic_response.get("content", [])
     text_content = ""
+    tool_calls: list[dict[str, Any]] = []
+
     for block in content_blocks:
-        if block.get("type") == "text":
+        block_type = block.get("type", "")
+        if block_type == "text":
             text_content += block.get("text", "")
+        elif block_type == "tool_use":
+            # Convert tool_use block to OpenAI tool_calls format
+            tool_calls.append(
+                {
+                    "id": block.get("id", ""),
+                    "type": "function",
+                    "function": {
+                        "name": block.get("name", ""),
+                        "arguments": json.dumps(block.get("input", {})),
+                    },
+                }
+            )
 
     # Determine finish reason
     stop_reason = anthropic_response.get("stop_reason", "end_turn")
@@ -227,6 +242,11 @@ def translate_anthropic_to_openai(anthropic_response: dict[str, Any]) -> dict[st
         "total_tokens": usage.get("input_tokens", 0) + usage.get("output_tokens", 0),
     }
 
+    # Construct message
+    message: dict[str, Any] = {"role": "assistant", "content": text_content or None}
+    if tool_calls:
+        message["tool_calls"] = tool_calls
+
     # Construct OpenAI response
     return {
         "id": anthropic_response.get("id", ""),
@@ -236,7 +256,7 @@ def translate_anthropic_to_openai(anthropic_response: dict[str, Any]) -> dict[st
         "choices": [
             {
                 "index": 0,
-                "message": {"role": "assistant", "content": text_content},
+                "message": message,
                 "finish_reason": finish_reason,
             }
         ],

--- a/src/psi_agent/ai/openai_completions/client.py
+++ b/src/psi_agent/ai/openai_completions/client.py
@@ -167,6 +167,7 @@ class OpenAICompletionsClient:
         """
         assert self._client is not None
 
+        logger.debug(f"Request body: {json.dumps(body, ensure_ascii=False, indent=2)}")
         body["stream"] = True
         sdk_params, extra_params = self._split_params(body)
 

--- a/src/psi_agent/ai/openai_completions/server.py
+++ b/src/psi_agent/ai/openai_completions/server.py
@@ -139,6 +139,7 @@ class OpenAICompletionsServer:
         async for chunk in stream_gen:
             await response.write(chunk.encode())
 
+        logger.debug("SSE stream completed successfully")
         logger.info("Streaming response completed")
         return response
 
@@ -165,7 +166,6 @@ class OpenAICompletionsServer:
 
         # Initialize client
         self.client = OpenAICompletionsClient(self.config)
-        assert self.client is not None
         await self.client.__aenter__()
 
         # Start server

--- a/src/psi_agent/session/runner.py
+++ b/src/psi_agent/session/runner.py
@@ -161,6 +161,9 @@ class SessionRunner:
 
         Yields:
             Tuple of (content, reasoning, tool_calls) from each delta.
+
+        Raises:
+            RuntimeError: If an error chunk is received from the AI component.
         """
         async for line in response.content:
             line_str = line.decode().strip()
@@ -169,6 +172,14 @@ class SessionRunner:
             if line_str.startswith("data: "):
                 try:
                     chunk = json.loads(line_str[6:])
+
+                    # Check for error response
+                    if "error" in chunk:
+                        error_msg = chunk.get("error", "Unknown error")
+                        status_code = chunk.get("status_code", 500)
+                        logger.error(f"AI component error: {error_msg} (status: {status_code})")
+                        raise RuntimeError(f"AI component error: {error_msg}")
+
                     choices = chunk.get("choices", [])
                     if not choices:
                         yield None, None, None

--- a/tests/ai/anthropic_messages/test_translator.py
+++ b/tests/ai/anthropic_messages/test_translator.py
@@ -382,6 +382,56 @@ class TestTranslateAnthropicToOpenAI:
 
         assert result["choices"][0]["message"]["content"] == "Hello world!"
 
+    def test_tool_use_content_block(self) -> None:
+        """Test tool_use content block is converted to tool_calls."""
+        anthropic_response = {
+            "id": "msg_123",
+            "model": "claude-3",
+            "content": [
+                {"type": "tool_use", "id": "toolu_123", "name": "bash", "input": {"cmd": "ls"}}
+            ],
+            "stop_reason": "tool_use",
+            "usage": {"input_tokens": 10, "output_tokens": 5},
+        }
+
+        result = translate_anthropic_to_openai(anthropic_response)
+
+        assert result["id"] == "msg_123"
+        assert result["choices"][0]["finish_reason"] == "tool_calls"
+        message = result["choices"][0]["message"]
+        assert "tool_calls" in message
+        assert len(message["tool_calls"]) == 1
+        tool_call = message["tool_calls"][0]
+        assert tool_call["id"] == "toolu_123"
+        assert tool_call["type"] == "function"
+        assert tool_call["function"]["name"] == "bash"
+        assert tool_call["function"]["arguments"] == '{"cmd": "ls"}'
+
+    def test_mixed_text_and_tool_use_blocks(self) -> None:
+        """Test response with both text and tool_use content blocks."""
+        anthropic_response = {
+            "id": "msg_456",
+            "model": "claude-3",
+            "content": [
+                {"type": "text", "text": "Let me help you with that."},
+                {
+                    "type": "tool_use",
+                    "id": "toolu_456",
+                    "name": "read",
+                    "input": {"file": "test.py"},
+                },
+            ],
+            "stop_reason": "tool_use",
+        }
+
+        result = translate_anthropic_to_openai(anthropic_response)
+
+        message = result["choices"][0]["message"]
+        assert message["content"] == "Let me help you with that."
+        assert "tool_calls" in message
+        assert len(message["tool_calls"]) == 1
+        assert message["tool_calls"][0]["function"]["name"] == "read"
+
 
 class TestStreamingTranslator:
     """Tests for streaming event translation."""

--- a/tests/session/test_runner.py
+++ b/tests/session/test_runner.py
@@ -1279,3 +1279,24 @@ class TestParseStreamingResponse:
         assert results[0][0] is None
         assert results[1][0] is None
         assert results[2][0] == "Hello"
+
+    @pytest.mark.asyncio
+    async def test_parse_streaming_raises_on_error_chunk(self, config):
+        """Test _parse_streaming_response raises RuntimeError on error chunk."""
+        runner = SessionRunner(config)
+
+        sse_lines = [
+            b'data: {"error": "Authentication failed", "status_code": 401}\n',
+        ]
+
+        async def async_iter():
+            for line in sse_lines:
+                yield line
+
+        mock_response = AsyncMock()
+        mock_response.status = 200
+        mock_response.content = async_iter()
+
+        with pytest.raises(RuntimeError, match="AI component error: Authentication failed"):
+            async for _ in runner._parse_streaming_response(mock_response):
+                pass


### PR DESCRIPTION
## Summary

- **Logging consistency**: Add DEBUG logs for streaming request body and streaming completion in both `openai_completions` and `anthropic_messages` modules
- **Protocol translation bug fix**: Fix `translate_anthropic_to_openai` to extract `tool_use` content blocks and populate `message.tool_calls` in non-streaming responses
- **Error handling**: Handle error chunks in session's `_parse_streaming_response` instead of silently ignoring them
- **Code quality**: Remove redundant assertions after client assignment in both server modules

## Changes

### Logging Improvements
- `openai_completions/client.py`: Add DEBUG log for request body in `_stream_request`
- `openai_completions/server.py`: Add DEBUG log for streaming completion, remove redundant assert
- `anthropic_messages/client.py`: Add DEBUG log for request body in `_stream_request`
- `anthropic_messages/server.py`: Add DEBUG log for streaming completion, remove redundant assert

### Bug Fix
- `anthropic_messages/translator.py`: Fix `translate_anthropic_to_openai` to extract `tool_use` content blocks and convert to `message.tool_calls`. Previously, non-streaming Anthropic responses with tool calls would have `finish_reason: "tool_calls"` but no `tool_calls` field in the message.

### Error Handling
- `session/runner.py`: Detect `{"error": ...}` chunks in streaming responses and raise `RuntimeError` instead of silently yielding empty content.

### Tests
- `tests/ai/anthropic_messages/test_translator.py`: Add tests for tool_use translation and mixed text/tool_use blocks

## Test plan

- [x] All 671 tests pass
- [x] All lint checks pass
- [x] New tests for tool_calls translation added and passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)