### PR TITLE
Fix tag detection in auto-alpha-tag workflow

### DIFF
--- a/.github/workflows/auto-alpha-tag.yml
+++ b/.github/workflows/auto-alpha-tag.yml
@@ -50,9 +50,9 @@ jobs:
           echo "Found last successful CI commit: $COMMIT_SHA"
 
           # Step 2: Check if commit already has a tag
-          if git describe --exact-match "$COMMIT_SHA" 2>/dev/null; then
-            EXISTING_TAG=$(git describe --exact-match "$COMMIT_SHA")
-            echo "::notice::Commit $COMMIT_SHA already has tag: $EXISTING_TAG, skipping"
+          EXISTING_TAGS=$(git tag --list --points-at "$COMMIT_SHA")
+          if [ -n "$EXISTING_TAGS" ]; then
+            echo "::notice::Commit $COMMIT_SHA already has tag(s): $(echo "$EXISTING_TAGS" | tr '\n' ','), skipping"
             exit 0
           fi
 

--- a/openspec/changes/archive/2026-05-07-fix-alpha-tag-detection/.openspec.yaml
+++ b/openspec/changes/archive/2026-05-07-fix-alpha-tag-detection/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-06

--- a/openspec/changes/archive/2026-05-07-fix-alpha-tag-detection/design.md
+++ b/openspec/changes/archive/2026-05-07-fix-alpha-tag-detection/design.md
@@ -1,0 +1,30 @@
+## Context
+
+The `auto-alpha-tag.yml` workflow creates lightweight tags (`git tag "$NEW_TAG"`) on commits that pass CI. Before creating a tag, it checks whether the commit already has one using `git describe --exact-match "$COMMIT_SHA"`. However, `git describe` only considers **annotated tags** by default — it ignores lightweight tags. Since the workflow itself creates lightweight tags, the check always fails, and the workflow will attempt to re-tag already-tagged commits on every scheduled run.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Fix tag detection to correctly identify both lightweight and annotated tags on a commit
+- Ensure the "skip already-tagged commits" behavior works reliably
+
+**Non-Goals:**
+- Changing the tag creation method from lightweight to annotated (that would be a separate concern)
+- Modifying the tag naming scheme or version derivation logic
+
+## Decisions
+
+**Decision: Use `git tag --list --points-at` instead of `git describe --exact-match`**
+
+`git tag --list --points-at "$COMMIT_SHA"` lists all tags (both lightweight and annotated) pointing at a given commit. This is the simplest and most reliable fix.
+
+Alternatives considered:
+- `git describe --exact-match --tags "$COMMIT_SHA"` — adds `--tags` flag to include lightweight tags. This works but `git describe` is designed for version derivation, not tag existence checks. It also has edge cases with `--match` patterns that could interfere.
+- `git for-each-ref --points-at` — more powerful but overkill for a simple existence check.
+
+`git tag --list --points-at` is the most direct and readable approach for "does this commit have any tags?"
+
+## Risks / Trade-offs
+
+- [Risk: `git tag --list --points-at` output could be empty string vs no output] → Check with `[ -n "$(git tag --list --points-at ...)" ]` which handles both cases.
+- [Risk: A commit could have non-alpha tags that should not block alpha tagging] → The current spec says "skip if the commit has *any* tag", so this is consistent with existing behavior. If finer-grained control is needed later, that's a separate change.

--- a/openspec/changes/archive/2026-05-07-fix-alpha-tag-detection/proposal.md
+++ b/openspec/changes/archive/2026-05-07-fix-alpha-tag-detection/proposal.md
@@ -1,0 +1,23 @@
+## Why
+
+`auto-alpha-tag.yml` uses `git describe --exact-match` to check if a commit already has a tag, but this command only considers **annotated tags** by default. Since the workflow creates **lightweight tags** (`git tag "$NEW_TAG"` without `-a`), the detection always fails — the workflow never recognizes its own tags, causing it to attempt re-tagging already-tagged commits on every run.
+
+## What Changes
+
+- Fix the tag detection in `auto-alpha-tag.yml` to correctly detect both lightweight and annotated tags on a commit
+- Update the existing spec for `auto-alpha-tag` to clarify that detection must cover all tag types
+
+## Capabilities
+
+### New Capabilities
+
+(none)
+
+### Modified Capabilities
+
+- `auto-alpha-tag`: The "skip already-tagged commits" requirement must explicitly cover both lightweight and annotated tags
+
+## Impact
+
+- `.github/workflows/auto-alpha-tag.yml` — tag detection logic (line 53)
+- `openspec/specs/auto-alpha-tag/spec.md` — requirement clarification

--- a/openspec/changes/archive/2026-05-07-fix-alpha-tag-detection/specs/auto-alpha-tag/spec.md
+++ b/openspec/changes/archive/2026-05-07-fix-alpha-tag-detection/specs/auto-alpha-tag/spec.md
@@ -1,0 +1,16 @@
+## MODIFIED Requirements
+
+### Requirement: Skip already-tagged commits
+The workflow SHALL NOT create a tag if the target commit already has any tag (including both lightweight and annotated tags).
+
+#### Scenario: Commit has existing lightweight tag
+- **WHEN** the identified commit already has a lightweight tag
+- **THEN** the workflow exits without creating a new tag
+
+#### Scenario: Commit has existing annotated tag
+- **WHEN** the identified commit already has an annotated tag
+- **THEN** the workflow exits without creating a new tag
+
+#### Scenario: Commit has no tag
+- **WHEN** the identified commit has no existing tag
+- **THEN** the workflow proceeds to create a new alpha tag

--- a/openspec/changes/archive/2026-05-07-fix-alpha-tag-detection/tasks.md
+++ b/openspec/changes/archive/2026-05-07-fix-alpha-tag-detection/tasks.md
@@ -1,0 +1,7 @@
+## 1. Fix tag detection logic
+
+- [x] 1.1 Replace `git describe --exact-match "$COMMIT_SHA"` with `git tag --list --points-at "$COMMIT_SHA"` in `.github/workflows/auto-alpha-tag.yml` line 53, and update the surrounding conditional to check for non-empty output instead of exit code
+
+## 2. Update spec
+
+- [x] 2.1 Update `openspec/specs/auto-alpha-tag/spec.md` to clarify that tag detection covers both lightweight and annotated tags

--- a/openspec/specs/auto-alpha-tag/spec.md
+++ b/openspec/specs/auto-alpha-tag/spec.md
@@ -19,10 +19,14 @@ The workflow SHALL identify the most recent commit on main branch that has passe
 - **THEN** the workflow exits gracefully without creating a tag
 
 ### Requirement: Skip already-tagged commits
-The workflow SHALL NOT create a tag if the target commit already has any tag.
+The workflow SHALL NOT create a tag if the target commit already has any tag (including both lightweight and annotated tags).
 
-#### Scenario: Commit has existing tag
-- **WHEN** the identified commit already has a tag
+#### Scenario: Commit has existing lightweight tag
+- **WHEN** the identified commit already has a lightweight tag
+- **THEN** the workflow exits without creating a new tag
+
+#### Scenario: Commit has existing annotated tag
+- **WHEN** the identified commit already has an annotated tag
 - **THEN** the workflow exits without creating a new tag
 
 #### Scenario: Commit has no tag


### PR DESCRIPTION
## Summary
- `git describe --exact-match` only matches annotated tags, but the workflow creates lightweight tags — causing it to never detect existing tags
- Replace with `git tag --list --points-at` which correctly detects both lightweight and annotated tags
- Update spec to explicitly cover both tag types

## Test plan
- [ ] Verify the workflow YAML logic is correct (check `[ -n "$EXISTING_TAGS" ]` handles empty output when no tags exist)
- [ ] Manually trigger the workflow on a commit that already has a lightweight tag and confirm it skips

🤖 Generated with [Claude Code](https://claude.com/claude-code)