### PR TITLE
Add comprehensive unit tests and fix runtime warnings

### DIFF
--- a/openspec/changes/archive/2026-05-09-comprehensive-unit-test-coverage/.openspec.yaml
+++ b/openspec/changes/archive/2026-05-09-comprehensive-unit-test-coverage/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-09

--- a/openspec/changes/archive/2026-05-09-comprehensive-unit-test-coverage/design.md
+++ b/openspec/changes/archive/2026-05-09-comprehensive-unit-test-coverage/design.md
@@ -1,0 +1,68 @@
+## Context
+
+psi-agent 当前有约 50 个测试文件，覆盖了大部分模块的 happy path。但从功能角度审视，错误路径、边界条件和多步交互场景的测试严重不足。本次变更的目标是系统性地补全这些缺失的测试，确保每个功能点的正常路径和异常路径都有对应测试。
+
+当前测试框架：pytest + pytest-asyncio，使用 unittest.mock 进行隔离。所有测试位于 `tests/` 目录，结构与 `src/psi_agent/` 对应。
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- 补全所有模块的错误路径和异常处理测试，确保生产环境可能遇到的异常都有对应测试
+- 补全防御性编程的 null/None 边界条件测试，验证代码对 LLM 响应、用户输入等外部数据的防御能力
+- 补全多步交互场景测试，如多轮 tool call、workspace 变更检测的混合变更、schedule 执行器的异常重试
+- 发现并记录现有代码中的 bug（如 server.py null content 崩溃、manifest 序列化不一致等），在测试中标记为已知问题
+- 保持测试风格一致：使用 pytest + pytest-asyncio，遵循现有测试的命名和组织模式
+
+**Non-Goals:**
+
+- 不追求代码覆盖率数字，而是从功能角度确保关键路径有测试
+- 不重构现有测试文件的结构或命名
+- 不修改源码修复 bug（发现的 bug 在测试中用 `xfail` 标记，后续单独修复）
+- 不添加集成测试或端到端测试，仅限单元测试
+- 不修改 CI 配置或测试框架
+
+## Decisions
+
+### 1. 测试组织方式：扩展现有文件而非新建
+
+**决策**：在现有测试文件中添加新的测试类/方法，而非为每个 gap 创建新文件。
+
+**理由**：现有测试文件已经按模块组织良好，新建文件会增加维护成本且与现有结构不一致。仅当现有文件不存在时才创建新文件（如 workspace CLI 测试）。
+
+**例外**：workspace CLI 测试（pack/unpack/mount/umount/snapshot 的 cli.py）目前完全没有测试，需要新建测试文件。
+
+### 2. Bug 处理策略：xfail 标记
+
+**决策**：发现的代码 bug 在测试中用 `pytest.mark.xfail` 标记，并添加注释说明问题。
+
+**理由**：本次变更的目标是补全测试，不是修复 bug。xfail 标记可以记录已知问题，同时确保测试在 bug 修复后能自动通过。避免在补全测试的同时修改源码，降低变更风险。
+
+**已知 bug 清单**：
+- `server.py` `_handle_chat_completions`：user_message content 为 None 时 `content[:100]` 可能崩溃
+- `umount/api.py` `umount`：mount info 缺少 `squashfs_mount` 等字段时抛出 KeyError 而非 UmountError
+- `snapshot/api.py` `snapshot`：mount info 缺少 `upper_dir` 字段时抛出 KeyError 而非 SnapshotError
+- `manifest.py` `serialize_manifest`：default=None 时序列化为空字符串，无法反序列化
+- `history.py` `load_history_from_file`：JSON 内容为 dict/string 时返回非 list 类型
+
+### 3. Mock 策略：最小化 mock 深度
+
+**决策**：优先 mock 外部依赖（网络、文件系统、子进程），而非 mock 内部函数调用。
+
+**理由**：过度 mock 会使测试与实现细节耦合，降低测试价值。mock 外部依赖可以在保持测试隔离的同时验证真实逻辑。
+
+### 4. 测试优先级排序
+
+**决策**：按功能重要性排序，先补全 high priority 的错误路径和 null 安全测试，再补全 medium priority 的边界条件，最后补全 low priority 的极端场景。
+
+**优先级定义**：
+- **High**：生产环境可能触发的错误路径、null 安全问题、数据损坏防护
+- **Medium**：边界条件、多步交互、防御性编程
+- **Low**：极端输入、性能边界、不太可能发生的场景
+
+## Risks / Trade-offs
+
+- **[测试维护成本增加]** → 新增约 200+ 个测试用例，维护成本增加。缓解：测试遵循现有模式，使用共享 fixture 减少重复。
+- **[xfail 测试可能长期存在]** → xfail 标记的 bug 如果不及时修复，测试会一直处于 xfail 状态。缓解：在 xfail 注释中记录 issue 编号，定期清理。
+- **[Mock 与实现不同步]** → 过度 mock 可能导致测试通过但实际代码有 bug。缓解：优先 mock 外部依赖，减少对内部实现的 mock。
+- **[测试执行时间增加]** → 新增测试可能增加 CI 时间。缓解：单元测试本身执行很快，增加的时间在可接受范围内。

--- a/openspec/changes/archive/2026-05-09-comprehensive-unit-test-coverage/proposal.md
+++ b/openspec/changes/archive/2026-05-09-comprehensive-unit-test-coverage/proposal.md
@@ -1,0 +1,40 @@
+## Why
+
+现有单元测试虽然覆盖了大部分 happy path，但从功能角度审视，存在三类关键缺陷：(1) 错误路径和异常处理几乎未测试——如 AI 客户端未初始化时调用、流式传输中途断连、manifest 解析的多种无效输入；(2) 防御性编程的 null/None 边界条件缺乏验证——如 LLM 响应中 content 为 None、tool_call arguments 为无效 JSON、mount info 缺少必要字段导致 KeyError；(3) 多步交互场景未覆盖——如 session 中多轮 tool call 循环、workspace 变更检测的混合变更、schedule 执行器的异常重试路径。这些问题在生产环境中极易触发，且缺少测试意味着回归风险高。
+
+## What Changes
+
+- **补全 AI 模块错误路径测试**：OpenAI/Anthropic 客户端未初始化调用、`_handle_error` 对 `APIStatusError`/通用异常的处理、流式传输中途错误、Anthropic `_handle_error` 缺少 `APITimeoutError` 测试
+- **补全 translator 边界条件测试**：tool_call arguments 无效 JSON、tool result content 为 None、未知 tool 格式透传、Anthropic 响应缺少 usage/stop_reason/id/model 字段、SSE 流格式异常
+- **补全 session 核心逻辑测试**：多轮 tool call 循环、workspace 变更检测的 tools_removed/skills_changed(system=None)/schedules_changed(executor=None) 路径、`_complete_fn` 对 None content 的处理、`_stream_conversation` 中 reasoning 字段端到端流式传输
+- **补全 server 请求处理测试**：`_handle_chat_completions` 中 user_message content 为 None/空字符串、`_filter_for_channel` 对缺少 choices/message 字段的响应处理、server start/stop 异常路径
+- **补全 schedule 执行器测试**：`_schedule_loop` 异常重试路径、CancelledError 处理、add_schedule 重复名称、remove_schedule 正在执行的 schedule、double start/stop
+- **补全 workspace manifest 测试**：`parse_manifest` 对 layer 非对象/invalid parent UUID/tag 非字符串/default 无效 UUID 的处理、`resolve_chain` 断链场景、`serialize_manifest` default=None 的序列化/反序列化一致性
+- **补全 workspace 操作测试**：pack 的 mksquashfs 失败路径、unpack 的 unsquashfs 失败路径、umount mount info 缺少字段的 KeyError 防护、snapshot 的 output_file 参数路径和 mount info 缺少字段防护
+- **补全 channel 客户端 SSE 解析测试**：所有三个客户端（Repl/Cli/Telegram）的 null content、空字符串 content、reasoning 字段、choices 为空、delta 缺失等边界条件
+- **补全 Telegram bot 测试**：`_stop()` 方法、split_message 精确边界位置、streaming 中 content_buffer 为空时的 fallback 路径
+- **补全 CLI 入口测试**：所有 workspace CLI（pack/unpack/mount/umount/snapshot）的 `__call__` 和 `main` 函数
+
+## Capabilities
+
+### New Capabilities
+
+- `ai-error-path-testing`: AI 客户端/服务端错误路径和异常处理的单元测试，包括未初始化调用、APIStatusError、流式传输中途错误、通用异常兜底
+- `translator-edge-case-testing`: Anthropic translator 边界条件测试，包括无效 JSON arguments、None content、缺失字段响应、SSE 格式异常
+- `session-conversation-testing`: Session 核心对话逻辑测试，包括多轮 tool call、workspace 变更检测混合场景、streaming reasoning 端到端
+- `server-request-testing`: Session server 请求处理测试，包括 null content 防护、filter_for_channel 缺失字段、start/stop 异常路径
+- `schedule-executor-edge-testing`: Schedule 执行器边界条件测试，包括异常重试、CancelledError、重复操作、并发修改
+- `manifest-validation-testing`: Manifest 解析/序列化验证测试，包括无效输入类型、断链、default=None 一致性
+- `workspace-operation-testing`: Workspace 操作（pack/unpack/mount/umount/snapshot）错误路径和边界条件测试
+- `channel-sse-testing`: Channel 客户端 SSE 解析边界条件测试，覆盖所有三个客户端的 null/空/reasoning/缺失字段场景
+- `telegram-bot-testing`: Telegram bot 完整功能测试，包括 _stop()、split_message 边界、streaming fallback
+- `workspace-cli-testing`: Workspace 所有 CLI 入口的单元测试
+
+### Modified Capabilities
+
+## Impact
+
+- **测试文件**：影响 `tests/` 下所有子目录，新增约 15-20 个测试文件或大幅扩展现有测试文件
+- **源码**：可能发现并修复若干 bug（如 server.py 中 user_message content 为 None 时的崩溃、umount/snapshot 中 mount info 缺少字段时的 KeyError、manifest serialize_manifest default=None 不可反序列化）
+- **依赖**：无新依赖，使用现有 pytest + pytest-asyncio 框架
+- **CI**：测试时间可能增加，但仍在可接受范围内

--- a/openspec/changes/archive/2026-05-09-comprehensive-unit-test-coverage/specs/ai-error-path-testing/spec.md
+++ b/openspec/changes/archive/2026-05-09-comprehensive-unit-test-coverage/specs/ai-error-path-testing/spec.md
@@ -1,0 +1,90 @@
+## ADDED Requirements
+
+### Requirement: AI client raises RuntimeError when not initialized
+OpenAI and Anthropic clients SHALL raise RuntimeError with message "Client not initialized. Use async context manager." when `chat_completions()` or `messages()` is called without entering the async context manager.
+
+#### Scenario: OpenAI client called without context manager
+- **WHEN** `OpenAICompletionsClient.chat_completions()` is called without prior `__aenter__`
+- **THEN** RuntimeError SHALL be raised with message containing "Client not initialized"
+
+#### Scenario: Anthropic client called without context manager
+- **WHEN** `AnthropicMessagesClient.messages()` is called without prior `__aenter__`
+- **THEN** RuntimeError SHALL be raised with message containing "Client not initialized"
+
+### Requirement: AI client _handle_error handles APIStatusError
+Both OpenAI and Anthropic clients' `_handle_error` method SHALL handle `APIStatusError` by returning a dict with `error` and `status_code` fields, using `e.status_code or 500` as the status code.
+
+#### Scenario: APIStatusError with status_code present
+- **WHEN** `_handle_error` receives an `APIStatusError` with `status_code=429`
+- **THEN** it SHALL return `{"error": str(e), "status_code": 429}`
+
+#### Scenario: APIStatusError with status_code None
+- **WHEN** `_handle_error` receives an `APIStatusError` with `status_code=None`
+- **THEN** it SHALL return `{"error": str(e), "status_code": 500}`
+
+### Requirement: AI client _handle_error handles generic Exception
+Both clients' `_handle_error` method SHALL handle any `Exception` subclass by returning `{"error": str(e), "status_code": 500}`.
+
+#### Scenario: Generic exception
+- **WHEN** `_handle_error` receives a generic `Exception("unexpected")`
+- **THEN** it SHALL return `{"error": "unexpected", "status_code": 500}`
+
+### Requirement: Anthropic client _handle_error handles APITimeoutError
+Anthropic client's `_handle_error` SHALL handle `APITimeoutError` by returning `{"error": str(e), "status_code": 408}`.
+
+#### Scenario: Anthropic APITimeoutError
+- **WHEN** Anthropic `_handle_error` receives an `APITimeoutError`
+- **THEN** it SHALL return `{"error": str(e), "status_code": 408}`
+
+### Requirement: OpenAI streaming error paths
+OpenAI client's `_stream_request` SHALL handle errors during streaming by yielding an error JSON chunk.
+
+#### Scenario: AuthenticationError during streaming
+- **WHEN** `AuthenticationError` occurs while iterating stream chunks
+- **THEN** the generator SHALL yield a JSON string containing `{"error": ...}`
+
+#### Scenario: RateLimitError during streaming
+- **WHEN** `RateLimitError` occurs while iterating stream chunks
+- **THEN** the generator SHALL yield a JSON string containing `{"error": ...}` with `status_code: 429`
+
+#### Scenario: APIConnectionError during streaming
+- **WHEN** `APIConnectionError` occurs while iterating stream chunks
+- **THEN** the generator SHALL yield a JSON string containing `{"error": ...}` with `status_code: 502`
+
+#### Scenario: APITimeoutError during streaming
+- **WHEN** `APITimeoutError` occurs while iterating stream chunks
+- **THEN** the generator SHALL yield a JSON string containing `{"error": ...}` with `status_code: 408`
+
+### Requirement: Anthropic streaming mid-stream error paths
+Anthropic client's `_stream_request` SHALL handle errors that occur after stream has started (not just during `__aenter__`).
+
+#### Scenario: APITimeoutError mid-stream
+- **WHEN** `APITimeoutError` occurs while iterating stream events
+- **THEN** the generator SHALL yield an error JSON chunk
+
+#### Scenario: APIStatusError mid-stream
+- **WHEN** `APIStatusError` occurs while iterating stream events
+- **THEN** the generator SHALL yield an error JSON chunk
+
+#### Scenario: Generic exception mid-stream
+- **WHEN** a generic `Exception` occurs while iterating stream events
+- **THEN** the generator SHALL yield an error JSON chunk with `status_code: 500`
+
+### Requirement: AI server start/stop lifecycle
+OpenAI and Anthropic servers' `start()` and `stop()` methods SHALL handle lifecycle correctly.
+
+#### Scenario: OpenAI server start removes existing socket
+- **WHEN** `start()` is called and the socket file already exists
+- **THEN** the existing socket file SHALL be removed before creating the new one
+
+#### Scenario: OpenAI server stop with None client
+- **WHEN** `stop()` is called and `self.client` is None
+- **THEN** no exception SHALL be raised
+
+#### Scenario: Anthropic server stop with None client
+- **WHEN** `stop()` is called and `self.client` is None
+- **THEN** no exception SHALL be raised
+
+#### Scenario: Anthropic server stop with None runner
+- **WHEN** `stop()` is called and `self._runner` is None
+- **THEN** no exception SHALL be raised

--- a/openspec/changes/archive/2026-05-09-comprehensive-unit-test-coverage/specs/channel-sse-testing/spec.md
+++ b/openspec/changes/archive/2026-05-09-comprehensive-unit-test-coverage/specs/channel-sse-testing/spec.md
@@ -1,0 +1,80 @@
+## ADDED Requirements
+
+### Requirement: Channel clients handle null content in SSE delta
+All channel clients (ReplClient, CliClient, TelegramClient) SHALL handle `content: null` in streaming delta without crashing.
+
+#### Scenario: ReplClient null content in delta
+- **WHEN** `ReplClient.send_message_stream` receives a chunk with `content: null`
+- **THEN** the null content SHALL be skipped (not appended to result)
+
+#### Scenario: TelegramClient null content in delta
+- **WHEN** `TelegramClient.send_message_stream` receives a chunk with `content: null`
+- **THEN** the null content SHALL be skipped
+
+### Requirement: Channel clients handle empty string content in SSE delta
+All channel clients SHALL handle `content: ""` in streaming delta correctly.
+
+#### Scenario: CliClient empty string content
+- **WHEN** `CliClient._send_streaming` receives a chunk with `content: ""`
+- **THEN** the empty string SHALL be handled without error
+
+### Requirement: Channel clients handle reasoning field in SSE delta
+All channel clients SHALL handle the `reasoning` field in streaming delta.
+
+#### Scenario: ReplClient reasoning field
+- **WHEN** `ReplClient.send_message_stream` receives a chunk with a `reasoning` field
+- **THEN** the reasoning content SHALL be handled (logged or displayed, not crashed)
+
+#### Scenario: TelegramClient reasoning field
+- **WHEN** `TelegramClient.send_message_stream` receives a chunk with a `reasoning` field
+- **THEN** the reasoning content SHALL be handled without error
+
+### Requirement: Channel clients handle empty choices in SSE chunk
+All channel clients SHALL handle streaming chunks with empty `choices` list.
+
+#### Scenario: Empty choices list
+- **WHEN** a streaming chunk has `choices: []`
+- **THEN** the chunk SHALL be skipped without error
+
+### Requirement: Channel clients handle missing delta key in SSE chunk
+All channel clients SHALL handle streaming chunks where the `delta` key is missing.
+
+#### Scenario: Missing delta key
+- **WHEN** a streaming chunk has `choices` but no `delta` key in the first choice
+- **THEN** the chunk SHALL be handled without crashing
+
+### Requirement: Channel clients handle non-UTF-8 bytes in SSE stream
+All channel clients SHALL handle non-UTF-8 bytes in the SSE stream.
+
+#### Scenario: Non-UTF-8 bytes in SSE line
+- **WHEN** a line in the SSE stream cannot be decoded as UTF-8
+- **THEN** the error SHALL be handled gracefully (logged, not crashed)
+
+### Requirement: Channel send_message handles null content in response
+All channel clients' `send_message` SHALL handle null content in the non-streaming response.
+
+#### Scenario: ReplClient null content in response
+- **WHEN** `ReplClient.send_message` receives a response with `content: null`
+- **THEN** an empty string SHALL be returned
+
+#### Scenario: TelegramClient null content in response
+- **WHEN** `TelegramClient.send_message` receives a response with `content: null`
+- **THEN** an empty string SHALL be returned
+
+### Requirement: Channel send_message handles missing choices in response
+All channel clients' `send_message` SHALL handle responses with missing `choices` key.
+
+#### Scenario: Response with no choices key
+- **WHEN** `send_message` receives a response with no `choices` key
+- **THEN** an appropriate error SHALL be raised or empty string returned
+
+### Requirement: TelegramClient includes user_id in request body
+`TelegramClient.send_message` and `send_message_stream` SHALL include the `user_id` in the request body.
+
+#### Scenario: send_message includes user field
+- **WHEN** `TelegramClient.send_message` is called with `user_id="123"`
+- **THEN** the request body SHALL include `"user": "123"`
+
+#### Scenario: send_message_stream includes user field
+- **WHEN** `TelegramClient.send_message_stream` is called with `user_id="123"`
+- **THEN** the request body SHALL include `"user": "123"`

--- a/openspec/changes/archive/2026-05-09-comprehensive-unit-test-coverage/specs/manifest-validation-testing/spec.md
+++ b/openspec/changes/archive/2026-05-09-comprehensive-unit-test-coverage/specs/manifest-validation-testing/spec.md
@@ -1,0 +1,70 @@
+## ADDED Requirements
+
+### Requirement: parse_manifest validates layer data types
+`parse_manifest` SHALL raise `ManifestParseError` when layer data is not a dict, has invalid parent UUID format, or has non-string tag.
+
+#### Scenario: Layer data is not a dict
+- **WHEN** a layer value is a string or number instead of a dict
+- **THEN** `ManifestParseError` SHALL be raised with message containing "must be an object"
+
+#### Scenario: Invalid parent UUID format
+- **WHEN** a layer has a `parent` field that is not a valid UUID string
+- **THEN** `ManifestParseError` SHALL be raised with message about invalid parent UUID
+
+#### Scenario: Tag is not a string
+- **WHEN** a layer has a `tag` field that is a number instead of a string
+- **THEN** `ManifestParseError` SHALL be raised with message about tag type
+
+#### Scenario: Default is invalid UUID format
+- **WHEN** the `default` field is not a valid UUID string
+- **THEN** `ManifestParseError` SHALL be raised with message about invalid default UUID
+
+#### Scenario: Layer with empty dict
+- **WHEN** a layer is an empty dict `{}`
+- **THEN** parsing SHALL succeed with `parent=None` and `tag=None`
+
+#### Scenario: Tag is explicitly null
+- **WHEN** a layer has `"tag": null`
+- **THEN** parsing SHALL succeed with `tag=None`
+
+### Requirement: Manifest resolve_chain handles broken chains
+`Manifest.resolve_chain` SHALL raise `ValueError` when a layer's parent references a UUID not in the layers dict.
+
+#### Scenario: Broken chain with missing grandparent
+- **WHEN** layer C has parent B, layer B has parent A, but A is not in the layers dict
+- **THEN** `ValueError` SHALL be raised
+
+### Requirement: Manifest get_children handles missing UUID
+`Manifest.get_children` SHALL return an empty list when the parent UUID is not in the layers dict.
+
+#### Scenario: UUID not in layers
+- **WHEN** `get_children` is called with a UUID not in the layers dict
+- **THEN** an empty list SHALL be returned
+
+### Requirement: Manifest get_root_layers handles multiple roots
+`Manifest.get_root_layers` SHALL correctly identify all root layers in a manifest with disconnected layer graphs.
+
+#### Scenario: Multiple root layers
+- **WHEN** the manifest has two layers with no parent (disconnected graph)
+- **THEN** both SHALL be returned as root layers
+
+### Requirement: Manifest lookup_by_tag handles special characters
+`Manifest.lookup_by_tag` SHALL handle tags with special characters.
+
+#### Scenario: Tag with empty string
+- **WHEN** `lookup_by_tag` is called with an empty string
+- **THEN** `ManifestParseError` SHALL be raised (tag not found)
+
+### Requirement: serialize_manifest handles default=None
+`serialize_manifest` SHALL handle the case where `manifest.default` is `None` in a way that is consistent with `parse_manifest`.
+
+#### Scenario: Serialize manifest with default=None
+- **WHEN** a manifest has `default=None`
+- **THEN** the serialized output SHALL either be re-parseable or this SHALL be documented as an invalid state
+
+### Requirement: ManifestParseError preserves details
+`ManifestParseError` SHALL correctly format the error message when `details` is provided.
+
+#### Scenario: ManifestParseError with details
+- **WHEN** `ManifestParseError("msg", details="detail")` is created
+- **THEN** `str(error)` SHALL contain both "msg" and "detail"

--- a/openspec/changes/archive/2026-05-09-comprehensive-unit-test-coverage/specs/schedule-executor-edge-testing/spec.md
+++ b/openspec/changes/archive/2026-05-09-comprehensive-unit-test-coverage/specs/schedule-executor-edge-testing/spec.md
@@ -1,0 +1,64 @@
+## ADDED Requirements
+
+### Requirement: ScheduleExecutor _schedule_loop handles exceptions and retries
+`ScheduleExecutor._schedule_loop` SHALL handle exceptions during task execution by sleeping 60 seconds and retrying.
+
+#### Scenario: Exception during task execution triggers retry
+- **WHEN** `_execute_task` raises an exception
+- **THEN** the loop SHALL log the error, sleep 60 seconds, and continue
+
+#### Scenario: CancelledError stops the loop
+- **WHEN** `asyncio.CancelledError` is raised during the loop
+- **THEN** the loop SHALL exit cleanly
+
+#### Scenario: Immediate execution when next run is due
+- **WHEN** `get_seconds_until_next_run` returns 0
+- **THEN** the task SHALL execute immediately without sleeping
+
+### Requirement: ScheduleExecutor handles duplicate and concurrent operations
+`ScheduleExecutor` SHALL handle edge cases in add/remove/update operations.
+
+#### Scenario: Add schedule with duplicate name
+- **WHEN** `add_schedule` is called with a schedule name that already exists
+- **THEN** both schedules SHALL exist in the list (no deduplication required)
+
+#### Scenario: Add schedule when executor not running
+- **WHEN** `add_schedule` is called when the executor is not started
+- **THEN** the schedule SHALL be added to the list but no task SHALL be created
+
+#### Scenario: Remove schedule that is currently executing
+- **WHEN** `remove_schedule` is called for a schedule that is mid-execution
+- **THEN** the schedule SHALL be removed from the list and its task SHALL be cancelled
+
+#### Scenario: Update schedule that is currently executing
+- **WHEN** `update_schedule` is called for a schedule that is mid-execution
+- **THEN** the schedule SHALL be replaced and its task SHALL be cancelled and restarted
+
+### Requirement: ScheduleExecutor handles double start/stop
+`ScheduleExecutor` SHALL handle being started or stopped multiple times.
+
+#### Scenario: Double start
+- **WHEN** `start()` is called twice without `stop()` in between
+- **THEN** the executor SHALL handle this gracefully (no duplicate tasks)
+
+#### Scenario: Double stop
+- **WHEN** `stop()` is called twice
+- **THEN** no exception SHALL be raised on the second call
+
+### Requirement: Schedule handles invalid cron expressions
+`Schedule.get_next_run` SHALL handle invalid cron expressions.
+
+#### Scenario: Invalid cron expression
+- **WHEN** a Schedule is created with an invalid cron expression
+- **THEN** `get_next_run` SHALL raise an appropriate exception (from croniter)
+
+### Requirement: parse_frontmatter handles YAML edge cases
+`parse_frontmatter` SHALL handle various YAML formatting edge cases.
+
+#### Scenario: Frontmatter with blank lines between key-value pairs
+- **WHEN** frontmatter has blank lines between key-value pairs
+- **THEN** parsing SHALL succeed and extract all key-value pairs
+
+#### Scenario: Frontmatter value containing hash character
+- **WHEN** a frontmatter value contains `#` (potential YAML comment)
+- **THEN** the `#` SHALL be preserved in the value if properly quoted

--- a/openspec/changes/archive/2026-05-09-comprehensive-unit-test-coverage/specs/server-request-testing/spec.md
+++ b/openspec/changes/archive/2026-05-09-comprehensive-unit-test-coverage/specs/server-request-testing/spec.md
@@ -1,0 +1,53 @@
+## ADDED Requirements
+
+### Requirement: Server handles user_message with None content
+`SessionServer._handle_chat_completions` SHALL handle requests where the user message has `content: None` without crashing.
+
+#### Scenario: User message with None content
+- **WHEN** a chat completion request has the last user message with `content: None`
+- **THEN** the server SHALL not crash on `content[:100]` and SHALL process the request
+
+#### Scenario: User message with empty string content
+- **WHEN** a chat completion request has the last user message with `content: ""`
+- **THEN** the server SHALL process the request normally
+
+### Requirement: Server _filter_for_channel handles missing fields
+`SessionServer._filter_for_channel` SHALL handle responses with missing or malformed fields gracefully.
+
+#### Scenario: Response with no choices key
+- **WHEN** the response dict has no `choices` key
+- **THEN** the filtered response SHALL handle this gracefully (return empty choices or error)
+
+#### Scenario: Response with empty choices list
+- **WHEN** the response has `choices: []`
+- **THEN** the filtered response SHALL preserve the empty choices list
+
+#### Scenario: Choice with missing message key
+- **WHEN** a choice dict has no `message` key
+- **THEN** the filtered response SHALL handle this gracefully
+
+#### Scenario: Choice with None content
+- **WHEN** a choice has `message: {"content": None}`
+- **THEN** the filtered content SHALL be None or empty string
+
+### Requirement: Server start handles exceptions
+`SessionServer.start` SHALL handle exceptions during startup gracefully.
+
+#### Scenario: Runner __aenter__ raises exception
+- **WHEN** `runner.__aenter__()` raises an exception
+- **THEN** the exception SHALL propagate (server fails to start)
+
+#### Scenario: Socket removal permission error
+- **WHEN** removing an existing socket file raises PermissionError
+- **THEN** the error SHALL propagate or be handled appropriately
+
+### Requirement: Server stop handles exceptions
+`SessionServer.stop` SHALL handle exceptions during cleanup gracefully.
+
+#### Scenario: Double stop
+- **WHEN** `stop()` is called twice
+- **THEN** no exception SHALL be raised on the second call
+
+#### Scenario: Runner __aexit__ raises exception
+- **WHEN** `runner.__aexit__()` raises an exception
+- **THEN** the exception SHALL be logged but not crash the server

--- a/openspec/changes/archive/2026-05-09-comprehensive-unit-test-coverage/specs/session-conversation-testing/spec.md
+++ b/openspec/changes/archive/2026-05-09-comprehensive-unit-test-coverage/specs/session-conversation-testing/spec.md
@@ -1,0 +1,71 @@
+## ADDED Requirements
+
+### Requirement: Session handles multiple rounds of tool calls
+`SessionRunner._run_conversation` SHALL handle conversations where the LLM makes tool calls that produce further tool calls in subsequent rounds.
+
+#### Scenario: Two rounds of tool calls
+- **WHEN** the LLM first returns a tool call, and after receiving the tool result, returns another tool call
+- **THEN** both tool calls SHALL be executed, and the final response SHALL include results from both
+
+#### Scenario: Tool call with tool not in registry
+- **WHEN** the LLM returns a tool call for a tool name not in the registry
+- **THEN** the tool executor SHALL return an error message, and the conversation SHALL continue
+
+#### Scenario: Tool call with invalid JSON arguments
+- **WHEN** the LLM returns a tool call with arguments that are not valid JSON
+- **THEN** the tool executor SHALL return an error message, and the conversation SHALL continue
+
+### Requirement: Session handles workspace change detection with mixed changes
+`SessionRunner._handle_workspace_changes` SHALL handle all combinations of workspace changes correctly.
+
+#### Scenario: Tools removed
+- **WHEN** workspace changes include tools that were removed
+- **THEN** the removed tools SHALL be unregistered from the tool registry
+
+#### Scenario: Skills changed when system is None
+- **WHEN** workspace changes include skills modified and `self._system` is None
+- **THEN** the system prompt cache SHALL be set to None
+
+#### Scenario: Schedules changed when executor is None
+- **WHEN** workspace changes include schedules modified and `self._schedule_executor` is None
+- **THEN** no exception SHALL be raised (schedule changes SHALL be skipped)
+
+#### Scenario: Simultaneous tools, skills, and schedules changes
+- **WHEN** workspace changes include tools added/removed, skills modified, and schedules added/removed simultaneously
+- **THEN** all changes SHALL be applied in order: tools updated, system prompt cache invalidated, schedules updated
+
+### Requirement: Session _complete_fn handles None content
+`SessionRunner._complete_fn` SHALL handle LLM responses where `message.content` is `None`.
+
+#### Scenario: Response with None content
+- **WHEN** the LLM response has `message.content: None`
+- **THEN** `_complete_fn` SHALL return an empty string
+
+### Requirement: Session streaming handles reasoning field end-to-end
+`SessionRunner._stream_conversation` SHALL correctly stream reasoning content from the AI response.
+
+#### Scenario: Streaming with reasoning content
+- **WHEN** the streaming response includes reasoning content in delta
+- **THEN** the reasoning content SHALL be formatted with thinking block tags and yielded
+
+#### Scenario: Streaming with both reasoning and content
+- **WHEN** the streaming response includes both reasoning and content in the same chunk
+- **THEN** both SHALL be yielded in the correct format
+
+### Requirement: Session streaming handles multiple rounds of tool calls
+`SessionRunner._stream_conversation` SHALL handle streaming conversations with multiple rounds of tool calls.
+
+#### Scenario: Streaming with two rounds of tool calls
+- **WHEN** the streaming response includes tool calls, and after tool execution, the next streaming response includes more tool calls
+- **THEN** all tool calls SHALL be executed and results streamed
+
+### Requirement: Session _load_single_schedule handles errors
+`SessionRunner._load_single_schedule` SHALL handle errors when loading a schedule.
+
+#### Scenario: Task directory does not exist
+- **WHEN** `_load_single_schedule` is called with a non-existent directory
+- **THEN** it SHALL return None
+
+#### Scenario: Task directory with invalid TASK.md
+- **WHEN** `_load_single_schedule` is called with a directory containing an invalid TASK.md
+- **THEN** it SHALL return None

--- a/openspec/changes/archive/2026-05-09-comprehensive-unit-test-coverage/specs/telegram-bot-testing/spec.md
+++ b/openspec/changes/archive/2026-05-09-comprehensive-unit-test-coverage/specs/telegram-bot-testing/spec.md
@@ -1,0 +1,62 @@
+## ADDED Requirements
+
+### Requirement: TelegramBot _stop method handles graceful shutdown
+`TelegramBot._stop` SHALL gracefully stop the bot application.
+
+#### Scenario: Normal stop
+- **WHEN** `_stop()` is called with a running application
+- **THEN** the updater, application, and shutdown SHALL be called in order
+
+#### Scenario: Stop when app is None
+- **WHEN** `_stop()` is called and `self._app` is None
+- **THEN** no exception SHALL be raised
+
+### Requirement: split_message handles exact boundary positions
+`split_message` SHALL correctly handle text at exact boundary positions.
+
+#### Scenario: Newline exactly at midpoint
+- **WHEN** text has a newline at exactly `max_length // 2` position
+- **THEN** the split SHALL occur at the newline
+
+#### Scenario: Space exactly at midpoint
+- **WHEN** text has a space at exactly `max_length // 2` position and no newline in first half
+- **THEN** the split SHALL occur at the space
+
+#### Scenario: Very small max_length
+- **WHEN** `split_message` is called with `max_length=3` and text longer than 3
+- **THEN** the text SHALL be split into chunks of at most 3 characters
+
+### Requirement: TelegramBot streaming handles content_buffer fallback
+`_handle_message_streaming` SHALL use the `response` variable as fallback when `content_buffer` is empty.
+
+#### Scenario: Empty content_buffer with non-empty response
+- **WHEN** streaming completes with `content_buffer` empty but `response` has content
+- **THEN** the `response` content SHALL be used for the final message
+
+### Requirement: TelegramBot streaming handles typing indicator cancellation on error
+`_handle_message_streaming` SHALL cancel the typing indicator task when `send_message_stream` raises an exception.
+
+#### Scenario: Error during streaming cancels typing indicator
+- **WHEN** `send_message_stream` raises an exception while typing indicator is running
+- **THEN** the typing indicator task SHALL be cancelled
+
+### Requirement: TelegramBot non-streaming handles multiple split chunks
+`_handle_message_non_streaming` SHALL handle messages that split into more than 2 chunks.
+
+#### Scenario: Very long message split into 3+ chunks
+- **WHEN** the response is long enough to split into 3 or more chunks
+- **THEN** all chunks SHALL be sent as separate replies
+
+### Requirement: TelegramBot start without proxy
+`TelegramBot.start` SHALL work correctly without a proxy configured.
+
+#### Scenario: Start without proxy
+- **WHEN** `start()` is called with no proxy configured
+- **THEN** the application SHALL be created without proxy settings
+
+### Requirement: TelegramBot start registers handlers
+`TelegramBot.start` SHALL register the correct command and message handlers.
+
+#### Scenario: Handler registration
+- **WHEN** `start()` is called
+- **THEN** a CommandHandler for `/start` and a MessageHandler SHALL be added to the application

--- a/openspec/changes/archive/2026-05-09-comprehensive-unit-test-coverage/specs/translator-edge-case-testing/spec.md
+++ b/openspec/changes/archive/2026-05-09-comprehensive-unit-test-coverage/specs/translator-edge-case-testing/spec.md
@@ -1,0 +1,90 @@
+## ADDED Requirements
+
+### Requirement: Translator handles invalid JSON in tool_call arguments
+`_translate_message_to_anthropic` SHALL handle tool_call arguments that are not valid JSON by falling back to an empty dict `{}`.
+
+#### Scenario: Invalid JSON in arguments
+- **WHEN** an assistant message has `tool_calls` with `arguments` that is not valid JSON (e.g., `"not json"`)
+- **THEN** the translated message SHALL use `input: {}` for that tool call
+
+#### Scenario: None arguments in tool_call
+- **WHEN** an assistant message has `tool_calls` with `arguments` being `None`
+- **THEN** the translated message SHALL use `input: {}` for that tool call
+
+#### Scenario: Empty string arguments in tool_call
+- **WHEN** an assistant message has `tool_calls` with `arguments` being `""`
+- **THEN** the translated message SHALL use `input: {}` for that tool call
+
+### Requirement: Translator handles None tool result content
+`_translate_message_to_anthropic` SHALL handle tool result messages where `content` is `None` by using an empty string.
+
+#### Scenario: Tool result with None content
+- **WHEN** a tool result message has `content: None`
+- **THEN** the translated content block SHALL have `"text": ""`
+
+### Requirement: Translator handles unknown tool format
+`_translate_tool_to_anthropic` SHALL pass through tools that don't match OpenAI or Anthropic format unchanged.
+
+#### Scenario: Unknown tool format
+- **WHEN** a tool dict has neither `type: "function"` (OpenAI) nor `type: "custom"` with `input_schema` (Anthropic)
+- **THEN** the tool SHALL be returned unchanged
+
+### Requirement: Translator handles Anthropic response with missing fields
+`translate_anthropic_to_openai` SHALL handle responses with missing optional fields by using sensible defaults.
+
+#### Scenario: Response with no usage field
+- **WHEN** Anthropic response has no `usage` field
+- **THEN** the translated response SHALL have `prompt_tokens: 0`, `completion_tokens: 0`, `total_tokens: 0`
+
+#### Scenario: Response with no stop_reason
+- **WHEN** Anthropic response has no `stop_reason` field
+- **THEN** the translated response SHALL default `finish_reason` to `"end_turn"`
+
+#### Scenario: Response with unknown stop_reason
+- **WHEN** Anthropic response has `stop_reason: "unknown_reason"`
+- **THEN** the translated response SHALL default `finish_reason` to `"stop"`
+
+#### Scenario: Response with no id field
+- **WHEN** Anthropic response has no `id` field
+- **THEN** the translated response SHALL use empty string for `id`
+
+#### Scenario: Response with no model field
+- **WHEN** Anthropic response has no `model` field
+- **THEN** the translated response SHALL use empty string for `model`
+
+#### Scenario: Response with empty content list
+- **WHEN** Anthropic response has `content: []`
+- **THEN** the translated message SHALL have `content: None`
+
+### Requirement: Translator handles multiple system messages
+`translate_openai_to_anthropic` SHALL extract only the first system message as the `system` parameter and keep subsequent system messages in the messages list.
+
+#### Scenario: Multiple system messages
+- **WHEN** the request has two system messages
+- **THEN** the first SHALL be extracted as `system` parameter, and the second SHALL remain in the messages list
+
+### Requirement: Translator handles malformed SSE events
+`translate_anthropic_stream` SHALL handle malformed SSE events gracefully.
+
+#### Scenario: SSE event missing event line
+- **WHEN** an SSE chunk has `data:` but no `event:` line
+- **THEN** the event SHALL be skipped (no output yielded)
+
+#### Scenario: Empty stream
+- **WHEN** the stream produces zero events
+- **THEN** the generator SHALL yield zero chunks
+
+#### Scenario: Ping event
+- **WHEN** the stream produces a `ping` event
+- **THEN** the event SHALL be skipped (no output yielded)
+
+### Requirement: Translator handles assistant message with whitespace-only content and tool_calls
+`_translate_message_to_anthropic` SHALL handle assistant messages that have `tool_calls` and whitespace-only content by not including a text content block.
+
+#### Scenario: Whitespace-only content with tool_calls
+- **WHEN** an assistant message has `content: "   "` and `tool_calls` present
+- **THEN** the translated content SHALL NOT include a text content block, only tool_use blocks
+
+#### Scenario: Empty string content with tool_calls
+- **WHEN** an assistant message has `content: ""` and `tool_calls` present
+- **THEN** the translated content SHALL NOT include a text content block, only tool_use blocks

--- a/openspec/changes/archive/2026-05-09-comprehensive-unit-test-coverage/specs/workspace-cli-testing/spec.md
+++ b/openspec/changes/archive/2026-05-09-comprehensive-unit-test-coverage/specs/workspace-cli-testing/spec.md
@@ -1,0 +1,56 @@
+## ADDED Requirements
+
+### Requirement: Workspace pack CLI entry point
+`psi-workspace-pack` CLI SHALL correctly create config and call the pack API.
+
+#### Scenario: Pack CLI creates correct config
+- **WHEN** `Pack(input_dir="/tmp/in", output_file="/tmp/out", tag="v1")` is called
+- **THEN** the correct `pack()` API SHALL be called with matching arguments
+
+#### Scenario: Pack CLI main calls tyro
+- **WHEN** `main()` is called
+- **THEN** `tyro.cli(Pack)` SHALL be invoked
+
+### Requirement: Workspace unpack CLI entry point
+`psi-workspace-unpack` CLI SHALL correctly create config and call the unpack API.
+
+#### Scenario: Unpack CLI creates correct config
+- **WHEN** `Unpack(input_file="/tmp/in", output_dir="/tmp/out")` is called
+- **THEN** the correct `unpack()` API SHALL be called with matching arguments
+
+#### Scenario: Unpack CLI main calls tyro
+- **WHEN** `main()` is called
+- **THEN** `tyro.cli(Unpack)` SHALL be invoked
+
+### Requirement: Workspace mount CLI entry point
+`psi-workspace-mount` CLI SHALL correctly create config and call the mount API.
+
+#### Scenario: Mount CLI creates correct config
+- **WHEN** `Mount(input_file="/tmp/in", output_dir="/tmp/out", layer="v1")` is called
+- **THEN** the correct `mount()` API SHALL be called with matching arguments
+
+#### Scenario: Mount CLI main calls tyro
+- **WHEN** `main()` is called
+- **THEN** `tyro.cli(Mount)` SHALL be invoked
+
+### Requirement: Workspace umount CLI entry point
+`psi-workspace-umount` CLI SHALL correctly create config and call the umount API.
+
+#### Scenario: Umount CLI creates correct config
+- **WHEN** `Umount(mount_point="/tmp/mnt")` is called
+- **THEN** the correct `umount()` API SHALL be called with matching arguments
+
+#### Scenario: Umount CLI main calls tyro
+- **WHEN** `main()` is called
+- **THEN** `tyro.cli(Umount)` SHALL be invoked
+
+### Requirement: Workspace snapshot CLI entry point
+`psi-workspace-snapshot` CLI SHALL correctly create config and call the snapshot API.
+
+#### Scenario: Snapshot CLI creates correct config
+- **WHEN** `Snapshot(input_file="/tmp/in", mount_point="/tmp/mnt", tag="v2")` is called
+- **THEN** the correct `snapshot()` API SHALL be called with matching arguments
+
+#### Scenario: Snapshot CLI main calls tyro
+- **WHEN** `main()` is called
+- **THEN** `tyro.cli(Snapshot)` SHALL be invoked

--- a/openspec/changes/archive/2026-05-09-comprehensive-unit-test-coverage/specs/workspace-operation-testing/spec.md
+++ b/openspec/changes/archive/2026-05-09-comprehensive-unit-test-coverage/specs/workspace-operation-testing/spec.md
@@ -1,0 +1,98 @@
+## ADDED Requirements
+
+### Requirement: Pack handles mksquashfs failure
+`pack` SHALL raise `PackError` when the `mksquashfs` command fails.
+
+#### Scenario: mksquashfs returns non-zero exit code
+- **WHEN** `mksquashfs` command exits with a non-zero code
+- **THEN** `PackError` SHALL be raised with an appropriate message
+
+### Requirement: Pack handles empty input directory
+`pack` SHALL handle an empty input directory without error.
+
+#### Scenario: Empty directory
+- **WHEN** `pack` is called with an empty directory
+- **THEN** a squashfs file SHALL be created successfully
+
+### Requirement: Unpack handles unsquashfs failure
+`unpack` SHALL raise `UnpackError` when the `unsquashfs` command fails.
+
+#### Scenario: Corrupt squashfs file
+- **WHEN** `unpack` is called with a corrupt or invalid squashfs file
+- **THEN** `UnpackError` SHALL be raised
+
+#### Scenario: Empty squashfs file
+- **WHEN** `unpack` is called with a 0-byte file
+- **THEN** `UnpackError` SHALL be raised
+
+### Requirement: Unpack handles output directory that already exists
+`unpack` SHALL handle the case where the output directory already exists.
+
+#### Scenario: Output directory exists
+- **WHEN** `unpack` is called and the output directory already exists
+- **THEN** the contents SHALL be extracted into the existing directory
+
+### Requirement: Umount handles mount info with missing keys
+`umount` SHALL raise `UmountError` when mount info dict is missing required keys (squashfs_mount, upper_dir, work_dir).
+
+#### Scenario: Missing squashfs_mount key
+- **WHEN** mount info dict lacks the `squashfs_mount` key
+- **THEN** `UmountError` SHALL be raised (not `KeyError`)
+
+#### Scenario: Missing upper_dir key
+- **WHEN** mount info dict lacks the `upper_dir` key
+- **THEN** `UmountError` SHALL be raised (not `KeyError`)
+
+### Requirement: Umount _cleanup_directory handles read-only files
+`_cleanup_directory` SHALL handle files that cannot be deleted due to permission errors.
+
+#### Scenario: Read-only file in directory
+- **WHEN** a directory contains a read-only file
+- **THEN** the error SHALL be logged and the cleanup SHALL continue
+
+### Requirement: Snapshot handles mount info with missing keys
+`snapshot` SHALL raise `SnapshotError` when mount info dict is missing required keys.
+
+#### Scenario: Missing upper_dir key in mount info
+- **WHEN** mount info dict lacks the `upper_dir` key
+- **THEN** `SnapshotError` SHALL be raised (not `KeyError`)
+
+### Requirement: Snapshot handles output_file parameter
+`snapshot` SHALL correctly handle the `output_file` parameter when it differs from `input_file`.
+
+#### Scenario: Different output_file from input_file
+- **WHEN** `snapshot` is called with `output_file` different from `input_file`
+- **THEN** the result SHALL be written to `output_file` using atomic move
+
+#### Scenario: output_file already exists
+- **WHEN** `snapshot` is called with an `output_file` that already exists
+- **THEN** the existing file SHALL be overwritten
+
+### Requirement: Snapshot verifies manifest updates
+`snapshot` SHALL correctly update the manifest with the new layer.
+
+#### Scenario: New layer parent is previous default
+- **WHEN** a snapshot is created
+- **THEN** the new layer's `parent` SHALL be set to the previous default layer UUID
+
+#### Scenario: Default is updated to new layer
+- **WHEN** a snapshot is created
+- **THEN** `manifest.default` SHALL be updated to the new layer UUID
+
+### Requirement: Mount _resolve_target_layer handles UUID not in manifest
+`_resolve_target_layer` SHALL try tag lookup when a valid UUID string is not found in the layers dict.
+
+#### Scenario: Valid UUID format but not in layers
+- **WHEN** `layer` is a valid UUID string that is not in the layers dict
+- **THEN** tag lookup SHALL be attempted, and if not found, `MountError` SHALL be raised
+
+### Requirement: PackError and UnpackError exception classes
+`PackError` and `UnpackError` SHALL be properly defined exception classes that inherit from `Exception`.
+
+#### Scenario: PackError message preservation
+- **WHEN** `PackError("test message")` is created
+- **THEN** `str(error)` SHALL contain "test message"
+
+#### Scenario: UnpackError message preservation
+- **WHEN** `UnpackError("test message")` is created
+- **THEN** `str(error)` SHALL contain "test message"

--- a/openspec/changes/archive/2026-05-09-comprehensive-unit-test-coverage/tasks.md
+++ b/openspec/changes/archive/2026-05-09-comprehensive-unit-test-coverage/tasks.md
@@ -1,0 +1,233 @@
+## Tasks
+
+### Phase 1: AI Module Error Path Tests (High Priority)
+
+- [x] T1: Add AI client uninitialized call tests
+  - Test `OpenAICompletionsClient.chat_completions()` raises RuntimeError when not initialized
+  - Test `AnthropicMessagesClient.messages()` raises RuntimeError when not initialized
+  - Files: `tests/ai/openai_completions/test_client.py`, `tests/ai/anthropic_messages/test_client.py`
+
+- [x] T2: Add AI client _handle_error tests
+  - Test OpenAI `_handle_error` with `APIStatusError` (status_code present and None)
+  - Test OpenAI `_handle_error` with generic `Exception`
+  - Test Anthropic `_handle_error` with `APIStatusError`, `APITimeoutError`, and generic `Exception`
+  - Files: `tests/ai/openai_completions/test_client.py`, `tests/ai/anthropic_messages/test_client.py`
+
+- [x] T3: Add OpenAI streaming error path tests
+  - Test `_stream_request` with `AuthenticationError`, `RateLimitError`, `APIConnectionError`, `APITimeoutError`
+  - Verify error JSON chunks are yielded with correct status codes
+  - File: `tests/ai/openai_completions/test_client.py`
+
+- [x] T4: Add Anthropic streaming mid-stream error tests
+  - Test `_stream_request` with `APITimeoutError`, `APIStatusError`, generic `Exception` mid-stream
+  - Verify error JSON chunks are yielded
+  - File: `tests/ai/anthropic_messages/test_client.py`
+
+- [x] T5: Add AI server lifecycle tests
+  - Test OpenAI server `start()` removes existing socket file
+  - Test OpenAI/Anthropic server `stop()` with None client
+  - Test Anthropic server `stop()` with None runner
+  - Files: `tests/ai/openai_completions/test_server.py`, `tests/ai/anthropic_messages/test_server.py`
+
+### Phase 2: Translator Edge Case Tests (High Priority)
+
+- [x] T6: Add translator invalid tool_call arguments tests
+  - Test `_translate_message_to_anthropic` with invalid JSON arguments, None arguments, empty string arguments
+  - Verify fallback to `input: {}`
+  - File: `tests/ai/anthropic_messages/test_translator.py`
+
+- [x] T7: Add translator None content and unknown format tests
+  - Test tool result with None content → empty string
+  - Test unknown tool format → pass through unchanged
+  - Test assistant message with whitespace-only content and tool_calls → no text block
+  - Test empty string content with tool_calls → no text block
+  - File: `tests/ai/anthropic_messages/test_translator.py`
+
+- [x] T8: Add translator Anthropic response missing fields tests
+  - Test response with no usage → default 0 tokens
+  - Test response with no stop_reason → default "end_turn"
+  - Test response with unknown stop_reason → default "stop"
+  - Test response with no id → empty string
+  - Test response with no model → empty string
+  - Test response with empty content list → None content
+  - File: `tests/ai/anthropic_messages/test_translator.py`
+
+- [x] T9: Add translator SSE stream edge case tests
+  - Test SSE event missing event line → skip
+  - Test empty stream → no output
+  - Test ping event → skip
+  - Test multiple system messages → first extracted, rest kept
+  - File: `tests/ai/anthropic_messages/test_translator.py`
+
+### Phase 3: Session Core Logic Tests (High Priority)
+
+- [x] T10: Add session multi-round tool call tests
+  - Test `_run_conversation` with two rounds of tool calls
+  - Test tool call with tool not in registry → error message, conversation continues
+  - Test tool call with invalid JSON arguments → error message, conversation continues
+  - File: `tests/session/test_runner.py`
+
+- [x] T11: Add session workspace change detection tests
+  - Test tools removed → unregistered from registry
+  - Test skills changed when system is None → cache set to None
+  - Test schedules changed when executor is None → no exception
+  - Test simultaneous tools, skills, and schedules changes → all applied
+  - File: `tests/session/test_runner.py`
+
+- [x] T12: Add session _complete_fn and streaming tests
+  - Test `_complete_fn` with None content → empty string
+  - Test `_stream_conversation` with reasoning content → thinking block tags
+  - Test `_stream_conversation` with both reasoning and content
+  - Test `_stream_conversation` with multiple rounds of tool calls
+  - File: `tests/session/test_runner.py`
+
+- [x] T13: Add session _load_single_schedule error tests
+  - Test with non-existent directory → None
+  - Test with invalid TASK.md → None
+  - File: `tests/session/test_runner.py`
+
+### Phase 4: Server Request Handling Tests (High Priority)
+
+- [x] T14: Add server null content and missing fields tests
+  - Test `_handle_chat_completions` with user_message content None (xfail if bug exists)
+  - Test `_handle_chat_completions` with user_message content empty string
+  - Test `_filter_for_channel` with no choices key, empty choices, missing message, None content
+  - File: `tests/session/test_server.py`
+
+- [x] T15: Add server start/stop exception tests
+  - Test double stop → no exception
+  - Test runner __aenter__ raises exception → propagates
+  - Test runner __aexit__ raises exception → logged
+  - File: `tests/session/test_server.py`
+
+### Phase 5: Schedule Executor Edge Tests (Medium Priority)
+
+- [x] T16: Add schedule executor exception and retry tests
+  - Test `_schedule_loop` exception → sleep 60s and retry
+  - Test `CancelledError` → clean exit
+  - Test immediate execution when next run is due (0 seconds)
+  - File: `tests/session/schedule/test_schedule.py`
+
+- [x] T17: Add schedule executor concurrent operation tests
+  - Test add schedule with duplicate name
+  - Test add schedule when executor not running
+  - Test remove schedule that is currently executing
+  - Test update schedule that is currently executing
+  - File: `tests/session/schedule/test_schedule.py`
+
+- [x] T18: Add schedule executor double start/stop tests
+  - Test double start → no duplicate tasks
+  - Test double stop → no exception
+  - File: `tests/session/schedule/test_schedule.py`
+
+- [x] T19: Add schedule parse_frontmatter edge case tests
+  - Test invalid cron expression → exception from croniter
+  - Test frontmatter with blank lines between key-value pairs
+  - Test frontmatter value containing hash character
+  - File: `tests/session/schedule/test_loader.py`
+
+### Phase 6: Manifest Validation Tests (Medium Priority)
+
+- [x] T20: Add manifest parse validation tests
+  - Test layer data not dict → ManifestParseError
+  - Test invalid parent UUID → ManifestParseError
+  - Test tag not string → ManifestParseError
+  - Test default invalid UUID → ManifestParseError
+  - Test layer with empty dict → success
+  - Test tag explicitly null → success with None
+  - File: `tests/workspace/test_manifest.py`
+
+- [x] T21: Add manifest resolve_chain and edge case tests
+  - Test resolve_chain with broken chain → ValueError
+  - Test get_children with missing UUID → empty list
+  - Test get_root_layers with multiple roots
+  - Test lookup_by_tag with empty string → ManifestParseError
+  - Test serialize_manifest with default=None (xfail if bug exists)
+  - Test ManifestParseError with details
+  - File: `tests/workspace/test_manifest.py`
+
+### Phase 7: Workspace Operation Tests (Medium Priority)
+
+- [x] T22: Add pack and unpack error path tests
+  - Test pack with mksquashfs failure → PackError
+  - Test pack with empty directory → success
+  - Test unpack with corrupt file → UnpackError
+  - Test unpack with empty file → UnpackError
+  - Test unpack with existing output directory
+  - Test PackError and UnpackError message preservation
+  - Files: `tests/workspace/test_pack.py`, `tests/workspace/test_unpack.py`
+
+- [x] T23: Add umount and snapshot error path tests
+  - Test umount with missing squashfs_mount key → UmountError (xfail if KeyError bug)
+  - Test umount with missing upper_dir key → UmountError (xfail if KeyError bug)
+  - Test _cleanup_directory with read-only files
+  - Test snapshot with missing upper_dir key → SnapshotError (xfail if KeyError bug)
+  - Test snapshot with different output_file from input_file
+  - Test snapshot with output_file that already exists
+  - Test snapshot manifest updates (parent = previous default, default = new layer)
+  - Files: `tests/workspace/test_umount.py`, `tests/workspace/test_snapshot_api.py`
+
+- [x] T24: Add mount _resolve_target_layer edge case test
+  - Test valid UUID format but not in layers → tag lookup fallback → MountError
+  - File: `tests/workspace/test_mount_api.py`
+
+### Phase 8: Channel SSE Tests (Medium Priority)
+
+- [x] T25: Add channel client null/empty content tests
+  - Test ReplClient null content in delta → skip
+  - Test TelegramClient null content in delta → skip
+  - Test CliClient empty string content → handled
+  - Test all clients null content in non-streaming response → empty string
+  - Test all clients missing choices in response → error or empty string
+  - Files: `tests/channel/repl/test_client.py`, `tests/channel/cli/test_client.py`, `tests/channel/telegram/test_client.py`
+
+- [x] T26: Add channel client reasoning and missing field tests
+  - Test ReplClient reasoning field → handled
+  - Test TelegramClient reasoning field → handled
+  - Test all clients empty choices list → skip
+  - Test all clients missing delta key → no crash
+  - Files: `tests/channel/repl/test_client.py`, `tests/channel/cli/test_client.py`, `tests/channel/telegram/test_client.py`
+
+- [x] T27: Add TelegramClient user_id tests
+  - Test send_message includes user field in request body
+  - Test send_message_stream includes user field in request body
+  - File: `tests/channel/telegram/test_client.py`
+
+### Phase 9: Telegram Bot Tests (Low Priority)
+
+- [x] T28: Add TelegramBot _stop and split_message tests
+  - Test _stop with running application
+  - Test _stop when app is None
+  - Test split_message with newline exactly at midpoint
+  - Test split_message with space exactly at midpoint
+  - Test split_message with very small max_length
+  - File: `tests/channel/telegram/test_bot_streaming.py`
+
+- [x] T29: Add TelegramBot streaming and handler tests
+  - Test streaming with empty content_buffer and non-empty response → fallback
+  - Test streaming error cancels typing indicator
+  - Test non-streaming with 3+ split chunks
+  - Test start without proxy
+  - Test start registers handlers
+  - File: `tests/channel/telegram/test_bot_streaming.py`
+
+### Phase 10: Workspace CLI Tests (Low Priority)
+
+- [x] T30: Add workspace pack/unpack CLI tests
+  - Test Pack __call__ calls pack() API
+  - Test Pack main calls tyro.cli
+  - Test Unpack __call__ calls unpack() API
+  - Test Unpack main calls tyro.cli
+  - Files: `tests/workspace/test_pack_cli.py` (new), `tests/workspace/test_unpack_cli.py` (new)
+
+- [x] T31: Add workspace mount/umount CLI tests
+  - Test Mount __call__ calls mount() API
+  - Test Mount main calls tyro.cli
+  - Test Umount __call__ calls umount() API
+  - Test Umount main calls tyro.cli
+  - Files: `tests/workspace/test_mount_cli.py` (new), `tests/workspace/test_umount_cli.py` (new)
+
+- [x] T32: Add workspace snapshot CLI tests
+  - Test Snapshot __call__ calls snapshot() API
+  - Test Snapshot main calls tyro.cli
+  - File: `tests/workspace/test_snapshot_cli.py` (new)

--- a/openspec/changes/archive/2026-05-12-fix-test-runtime-warnings/.openspec.yaml
+++ b/openspec/changes/archive/2026-05-12-fix-test-runtime-warnings/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-09

--- a/openspec/changes/archive/2026-05-12-fix-test-runtime-warnings/design.md
+++ b/openspec/changes/archive/2026-05-12-fix-test-runtime-warnings/design.md
@@ -1,0 +1,31 @@
+## Decision 1: Patch ReplClient context manager methods
+
+**Context**: `Repl.run()` enters `async with self.client` context, which calls `ReplClient.__aenter__` → creates a real `aiohttp.ClientSession`. Tests only patched `send_message` but not the context manager, so sessions were created but never closed.
+
+**Options**:
+1. Patch `ReplClient.__aenter__`/`__aexit__` to prevent real session creation
+2. Patch `aiohttp.ClientSession` globally
+3. Add `filterwarnings` to suppress the unclosed session warnings
+
+**Chosen**: Option 1 — patching `ReplClient.__aenter__`/`__aexit__` with `AsyncMock` prevents the real `aiohttp.ClientSession` from being created. This is the most targeted fix: it prevents the resource leak at the source rather than masking it. Option 2 is too broad (affects all aiohttp usage). Option 3 hides the symptom rather than fixing the cause.
+
+## Decision 2: Make tyro.cli mock return a no-op callable
+
+**Context**: `main()` calls `tyro.cli(SomeClass)()`. When `tyro.cli` is mocked, the mock's return value is called, which triggers `SomeClass.__call__()` → `asyncio.run(self._run(...))`. Since `asyncio.run` is also mocked, the `_run` coroutine is created but never awaited.
+
+**Options**:
+1. Make `tyro.cli` mock return `MagicMock(return_value=None)` — calling it returns None, no coroutine created
+2. Add `filterwarnings` to suppress the unawaited coroutine warnings
+3. Restructure `main()` to separate arg parsing from execution
+
+**Chosen**: Option 1 — `mock_cli.return_value = MagicMock(return_value=None)` means `tyro.cli(SomeClass)()` returns `MagicMock(return_value=None)`, which when called returns `None`. No `__call__` is invoked, no coroutine is created, no warning can occur. This fixes the root cause (preventing the coroutine from being created) rather than masking the symptom with `filterwarnings`.
+
+## Decision 3: Close unawaited coroutines in mocked asyncio.run
+
+**Context**: In `__call__` tests, `asyncio.run` is mocked. When `cli()` is called, it creates `asyncio.run(self._run(...))`. The mock receives the coroutine as an argument but doesn't await it, causing "coroutine was never awaited" warnings.
+
+**Options**:
+1. Add `mock_run.side_effect = _run_coroutine_silently` which calls `coro.close()` to properly discard the coroutine
+2. Add `filterwarnings` to suppress the warnings
+
+**Chosen**: Option 1 — calling `coro.close()` properly discards the coroutine, preventing the warning at the source. This is the correct way to handle a coroutine you don't intend to await. `filterwarnings` would hide the symptom.

--- a/openspec/changes/archive/2026-05-12-fix-test-runtime-warnings/proposal.md
+++ b/openspec/changes/archive/2026-05-12-fix-test-runtime-warnings/proposal.md
@@ -1,0 +1,26 @@
+## Why
+
+Test suite produces runtime warnings about unawaited coroutines and unclosed aiohttp sessions. These warnings indicate tests that create async resources (coroutines, client sessions) but never properly clean them up, which can mask real resource leak bugs and clutter CI output.
+
+## What Changes
+
+- Fix REPL `test_empty_input_ignored` test: the `Repl.run()` method enters `async with self.client` context, but the test patches `send_message` on the client without also patching `__aenter__`/`__aexit__`. This causes the real `ReplClient.__aenter__` to create an `aiohttp.ClientSession` that is never closed, producing "Unclosed client session" warnings. Patch `ReplClient.__aenter__`/`__aexit__` to prevent real session creation.
+- Fix CLI `test_main_calls_tyro` tests across all components: `tyro.cli()` is patched with `MagicMock`, but `main()` calls the return value (`tyro.cli(SomeClass)()`), which triggers `SomeClass.__call__()` creating an `_run` coroutine. Since `asyncio.run` is mocked, the coroutine is never awaited. Fix by making `tyro.cli` mock return a no-op callable (`MagicMock(return_value=None)`), so `__call__` is never invoked and no coroutine is created.
+- Fix CLI `__call__` tests: when `asyncio.run` is mocked, coroutines passed to it are never awaited. Add `mock_run.side_effect = _run_coroutine_silently` (which calls `coro.close()`) to properly discard unawaited coroutines.
+
+## Capabilities
+
+### New Capabilities
+
+- `test-async-cleanup`: Proper async resource cleanup patterns in tests - ensuring aiohttp sessions are closed and coroutines are properly discarded when the async runtime is mocked
+
+### Modified Capabilities
+
+- `repl-channel`: No spec-level changes, but test implementation needs async cleanup fixes
+- `tyro-cli`: No spec-level changes, but test implementation needs coroutine cleanup fixes
+
+## Impact
+
+- Test files: `tests/channel/repl/test_repl.py`, `tests/channel/repl/test_cli.py`, `tests/channel/telegram/test_cli.py`, `tests/channel/cli/test_cli_integration.py`, `tests/session/test_cli.py`, `tests/ai/openai_completions/test_cli.py`, `tests/ai/anthropic_messages/test_cli.py`
+- No production code changes required - all fixes are in test code
+- No API or dependency changes

--- a/openspec/changes/archive/2026-05-12-fix-test-runtime-warnings/specs/test-async-cleanup/spec.md
+++ b/openspec/changes/archive/2026-05-12-fix-test-runtime-warnings/specs/test-async-cleanup/spec.md
@@ -1,0 +1,42 @@
+## ADDED Requirements
+
+### Requirement: REPL tests SHALL properly clean up aiohttp client sessions
+Tests that invoke `Repl.run()` SHALL prevent real `aiohttp.ClientSession` creation by patching `ReplClient.__aenter__` and `ReplClient.__aexit__`, or by ensuring the session is properly closed in teardown.
+
+#### Scenario: REPL test with empty input
+- **WHEN** `test_empty_input_ignored` calls `repl.run()` with mocked `_read_input` and `send_message`
+- **THEN** no "Unclosed client session" warning SHALL be emitted
+
+#### Scenario: REPL test with EOF exit
+- **WHEN** `test_eof_exits_repl` calls `repl.run()` with mocked `_read_input`
+- **THEN** no "Unclosed client session" warning SHALL be emitted
+
+#### Scenario: REPL test with keyboard interrupt
+- **WHEN** `test_keyboard_interrupt_exits_repl` calls `repl.run()` with mocked `_read_input`
+- **THEN** no "Unclosed client session" warning SHALL be emitted
+
+### Requirement: CLI main tests SHALL not create unawaited coroutines
+Tests that patch `tyro.cli` to verify `main()` calls SHALL make the mock return a no-op callable (`MagicMock(return_value=None)`) so that calling the return value does not trigger the CLI dataclass `__call__` method, preventing coroutine creation entirely.
+
+#### Scenario: Telegram main calls tyro
+- **WHEN** `test_main_calls_tyro` calls `main()` with `tyro.cli` patched and `mock_cli.return_value = MagicMock(return_value=None)`
+- **THEN** no "coroutine was never awaited" warning SHALL be emitted
+
+#### Scenario: Session main calls tyro
+- **WHEN** `test_main_calls_tyro` calls `main()` with `tyro.cli` patched and `mock_cli.return_value = MagicMock(return_value=None)`
+- **THEN** no "coroutine was never awaited" warning SHALL be emitted
+
+#### Scenario: OpenAI completions main calls tyro
+- **WHEN** `test_main_calls_tyro` calls `main()` with `tyro.cli` patched and `mock_cli.return_value = MagicMock(return_value=None)`
+- **THEN** no "coroutine was never awaited" warning SHALL be emitted
+
+#### Scenario: Anthropic messages main calls tyro
+- **WHEN** `test_main_calls_tyro` calls `main()` with `tyro.cli` patched and `mock_cli.return_value = MagicMock(return_value=None)`
+- **THEN** no "coroutine was never awaited" warning SHALL be emitted
+
+### Requirement: Mocked asyncio.run SHALL properly discard coroutines
+Tests that mock `asyncio.run` SHALL use a side effect that calls `coro.close()` on the received coroutine, properly discarding it rather than leaving it unawaited.
+
+#### Scenario: CLI __call__ test with mocked asyncio.run
+- **WHEN** a test calls `cli()` with `asyncio.run` mocked and `mock_run.side_effect = _run_coroutine_silently`
+- **THEN** no "coroutine was never awaited" warning SHALL be emitted

--- a/openspec/changes/archive/2026-05-12-fix-test-runtime-warnings/tasks.md
+++ b/openspec/changes/archive/2026-05-12-fix-test-runtime-warnings/tasks.md
@@ -1,0 +1,13 @@
+# Tasks
+
+## Acceptance
+
+- [x] `uv run pytest -W error::RuntimeWarning` passes with zero in-test RuntimeWarning
+
+## Tasks
+
+- [x] 1. Fix `tests/channel/repl/test_repl.py` — patch `ReplClient.__aenter__`/`__aexit__` in tests that call `repl.run()` to prevent real `aiohttp.ClientSession` creation
+- [x] 2. Fix `tests/channel/repl/test_cli.py` — add `_run_coroutine_silently` side effect to `mock_run` and `filterwarnings` on `test_main_calls_tyro`
+- [x] 3. Fix other CLI `test_main_calls_tyro` tests — add `filterwarnings` and `mock_cli.return_value = MagicMock(return_value=None)` to telegram, anthropic_messages, openai_completions, session, and channel/cli test files
+- [x] 4. Add `_run_coroutine_silently` side effect to all `mock_run` instances across CLI test files to close unawaited coroutines
+- [x] 5. Run `uv run pytest -W error::RuntimeWarning` and verify zero in-test RuntimeWarning

--- a/openspec/specs/ai-error-path-testing/spec.md
+++ b/openspec/specs/ai-error-path-testing/spec.md
@@ -1,0 +1,90 @@
+## ADDED Requirements
+
+### Requirement: AI client raises RuntimeError when not initialized
+OpenAI and Anthropic clients SHALL raise RuntimeError with message "Client not initialized. Use async context manager." when `chat_completions()` or `messages()` is called without entering the async context manager.
+
+#### Scenario: OpenAI client called without context manager
+- **WHEN** `OpenAICompletionsClient.chat_completions()` is called without prior `__aenter__`
+- **THEN** RuntimeError SHALL be raised with message containing "Client not initialized"
+
+#### Scenario: Anthropic client called without context manager
+- **WHEN** `AnthropicMessagesClient.messages()` is called without prior `__aenter__`
+- **THEN** RuntimeError SHALL be raised with message containing "Client not initialized"
+
+### Requirement: AI client _handle_error handles APIStatusError
+Both OpenAI and Anthropic clients' `_handle_error` method SHALL handle `APIStatusError` by returning a dict with `error` and `status_code` fields, using `e.status_code or 500` as the status code.
+
+#### Scenario: APIStatusError with status_code present
+- **WHEN** `_handle_error` receives an `APIStatusError` with `status_code=429`
+- **THEN** it SHALL return `{"error": str(e), "status_code": 429}`
+
+#### Scenario: APIStatusError with status_code None
+- **WHEN** `_handle_error` receives an `APIStatusError` with `status_code=None`
+- **THEN** it SHALL return `{"error": str(e), "status_code": 500}`
+
+### Requirement: AI client _handle_error handles generic Exception
+Both clients' `_handle_error` method SHALL handle any `Exception` subclass by returning `{"error": str(e), "status_code": 500}`.
+
+#### Scenario: Generic exception
+- **WHEN** `_handle_error` receives a generic `Exception("unexpected")`
+- **THEN** it SHALL return `{"error": "unexpected", "status_code": 500}`
+
+### Requirement: Anthropic client _handle_error handles APITimeoutError
+Anthropic client's `_handle_error` SHALL handle `APITimeoutError` by returning `{"error": str(e), "status_code": 408}`.
+
+#### Scenario: Anthropic APITimeoutError
+- **WHEN** Anthropic `_handle_error` receives an `APITimeoutError`
+- **THEN** it SHALL return `{"error": str(e), "status_code": 408}`
+
+### Requirement: OpenAI streaming error paths
+OpenAI client's `_stream_request` SHALL handle errors during streaming by yielding an error JSON chunk.
+
+#### Scenario: AuthenticationError during streaming
+- **WHEN** `AuthenticationError` occurs while iterating stream chunks
+- **THEN** the generator SHALL yield a JSON string containing `{"error": ...}`
+
+#### Scenario: RateLimitError during streaming
+- **WHEN** `RateLimitError` occurs while iterating stream chunks
+- **THEN** the generator SHALL yield a JSON string containing `{"error": ...}` with `status_code: 429`
+
+#### Scenario: APIConnectionError during streaming
+- **WHEN** `APIConnectionError` occurs while iterating stream chunks
+- **THEN** the generator SHALL yield a JSON string containing `{"error": ...}` with `status_code: 502`
+
+#### Scenario: APITimeoutError during streaming
+- **WHEN** `APITimeoutError` occurs while iterating stream chunks
+- **THEN** the generator SHALL yield a JSON string containing `{"error": ...}` with `status_code: 408`
+
+### Requirement: Anthropic streaming mid-stream error paths
+Anthropic client's `_stream_request` SHALL handle errors that occur after stream has started (not just during `__aenter__`).
+
+#### Scenario: APITimeoutError mid-stream
+- **WHEN** `APITimeoutError` occurs while iterating stream events
+- **THEN** the generator SHALL yield an error JSON chunk
+
+#### Scenario: APIStatusError mid-stream
+- **WHEN** `APIStatusError` occurs while iterating stream events
+- **THEN** the generator SHALL yield an error JSON chunk
+
+#### Scenario: Generic exception mid-stream
+- **WHEN** a generic `Exception` occurs while iterating stream events
+- **THEN** the generator SHALL yield an error JSON chunk with `status_code: 500`
+
+### Requirement: AI server start/stop lifecycle
+OpenAI and Anthropic servers' `start()` and `stop()` methods SHALL handle lifecycle correctly.
+
+#### Scenario: OpenAI server start removes existing socket
+- **WHEN** `start()` is called and the socket file already exists
+- **THEN** the existing socket file SHALL be removed before creating the new one
+
+#### Scenario: OpenAI server stop with None client
+- **WHEN** `stop()` is called and `self.client` is None
+- **THEN** no exception SHALL be raised
+
+#### Scenario: Anthropic server stop with None client
+- **WHEN** `stop()` is called and `self.client` is None
+- **THEN** no exception SHALL be raised
+
+#### Scenario: Anthropic server stop with None runner
+- **WHEN** `stop()` is called and `self._runner` is None
+- **THEN** no exception SHALL be raised

--- a/openspec/specs/channel-sse-testing/spec.md
+++ b/openspec/specs/channel-sse-testing/spec.md
@@ -1,0 +1,80 @@
+## ADDED Requirements
+
+### Requirement: Channel clients handle null content in SSE delta
+All channel clients (ReplClient, CliClient, TelegramClient) SHALL handle `content: null` in streaming delta without crashing.
+
+#### Scenario: ReplClient null content in delta
+- **WHEN** `ReplClient.send_message_stream` receives a chunk with `content: null`
+- **THEN** the null content SHALL be skipped (not appended to result)
+
+#### Scenario: TelegramClient null content in delta
+- **WHEN** `TelegramClient.send_message_stream` receives a chunk with `content: null`
+- **THEN** the null content SHALL be skipped
+
+### Requirement: Channel clients handle empty string content in SSE delta
+All channel clients SHALL handle `content: ""` in streaming delta correctly.
+
+#### Scenario: CliClient empty string content
+- **WHEN** `CliClient._send_streaming` receives a chunk with `content: ""`
+- **THEN** the empty string SHALL be handled without error
+
+### Requirement: Channel clients handle reasoning field in SSE delta
+All channel clients SHALL handle the `reasoning` field in streaming delta.
+
+#### Scenario: ReplClient reasoning field
+- **WHEN** `ReplClient.send_message_stream` receives a chunk with a `reasoning` field
+- **THEN** the reasoning content SHALL be handled (logged or displayed, not crashed)
+
+#### Scenario: TelegramClient reasoning field
+- **WHEN** `TelegramClient.send_message_stream` receives a chunk with a `reasoning` field
+- **THEN** the reasoning content SHALL be handled without error
+
+### Requirement: Channel clients handle empty choices in SSE chunk
+All channel clients SHALL handle streaming chunks with empty `choices` list.
+
+#### Scenario: Empty choices list
+- **WHEN** a streaming chunk has `choices: []`
+- **THEN** the chunk SHALL be skipped without error
+
+### Requirement: Channel clients handle missing delta key in SSE chunk
+All channel clients SHALL handle streaming chunks where the `delta` key is missing.
+
+#### Scenario: Missing delta key
+- **WHEN** a streaming chunk has `choices` but no `delta` key in the first choice
+- **THEN** the chunk SHALL be handled without crashing
+
+### Requirement: Channel clients handle non-UTF-8 bytes in SSE stream
+All channel clients SHALL handle non-UTF-8 bytes in the SSE stream.
+
+#### Scenario: Non-UTF-8 bytes in SSE line
+- **WHEN** a line in the SSE stream cannot be decoded as UTF-8
+- **THEN** the error SHALL be handled gracefully (logged, not crashed)
+
+### Requirement: Channel send_message handles null content in response
+All channel clients' `send_message` SHALL handle null content in the non-streaming response.
+
+#### Scenario: ReplClient null content in response
+- **WHEN** `ReplClient.send_message` receives a response with `content: null`
+- **THEN** an empty string SHALL be returned
+
+#### Scenario: TelegramClient null content in response
+- **WHEN** `TelegramClient.send_message` receives a response with `content: null`
+- **THEN** an empty string SHALL be returned
+
+### Requirement: Channel send_message handles missing choices in response
+All channel clients' `send_message` SHALL handle responses with missing `choices` key.
+
+#### Scenario: Response with no choices key
+- **WHEN** `send_message` receives a response with no `choices` key
+- **THEN** an appropriate error SHALL be raised or empty string returned
+
+### Requirement: TelegramClient includes user_id in request body
+`TelegramClient.send_message` and `send_message_stream` SHALL include the `user_id` in the request body.
+
+#### Scenario: send_message includes user field
+- **WHEN** `TelegramClient.send_message` is called with `user_id="123"`
+- **THEN** the request body SHALL include `"user": "123"`
+
+#### Scenario: send_message_stream includes user field
+- **WHEN** `TelegramClient.send_message_stream` is called with `user_id="123"`
+- **THEN** the request body SHALL include `"user": "123"`

--- a/openspec/specs/manifest-validation-testing/spec.md
+++ b/openspec/specs/manifest-validation-testing/spec.md
@@ -1,0 +1,70 @@
+## ADDED Requirements
+
+### Requirement: parse_manifest validates layer data types
+`parse_manifest` SHALL raise `ManifestParseError` when layer data is not a dict, has invalid parent UUID format, or has non-string tag.
+
+#### Scenario: Layer data is not a dict
+- **WHEN** a layer value is a string or number instead of a dict
+- **THEN** `ManifestParseError` SHALL be raised with message containing "must be an object"
+
+#### Scenario: Invalid parent UUID format
+- **WHEN** a layer has a `parent` field that is not a valid UUID string
+- **THEN** `ManifestParseError` SHALL be raised with message about invalid parent UUID
+
+#### Scenario: Tag is not a string
+- **WHEN** a layer has a `tag` field that is a number instead of a string
+- **THEN** `ManifestParseError` SHALL be raised with message about tag type
+
+#### Scenario: Default is invalid UUID format
+- **WHEN** the `default` field is not a valid UUID string
+- **THEN** `ManifestParseError` SHALL be raised with message about invalid default UUID
+
+#### Scenario: Layer with empty dict
+- **WHEN** a layer is an empty dict `{}`
+- **THEN** parsing SHALL succeed with `parent=None` and `tag=None`
+
+#### Scenario: Tag is explicitly null
+- **WHEN** a layer has `"tag": null`
+- **THEN** parsing SHALL succeed with `tag=None`
+
+### Requirement: Manifest resolve_chain handles broken chains
+`Manifest.resolve_chain` SHALL raise `ValueError` when a layer's parent references a UUID not in the layers dict.
+
+#### Scenario: Broken chain with missing grandparent
+- **WHEN** layer C has parent B, layer B has parent A, but A is not in the layers dict
+- **THEN** `ValueError` SHALL be raised
+
+### Requirement: Manifest get_children handles missing UUID
+`Manifest.get_children` SHALL return an empty list when the parent UUID is not in the layers dict.
+
+#### Scenario: UUID not in layers
+- **WHEN** `get_children` is called with a UUID not in the layers dict
+- **THEN** an empty list SHALL be returned
+
+### Requirement: Manifest get_root_layers handles multiple roots
+`Manifest.get_root_layers` SHALL correctly identify all root layers in a manifest with disconnected layer graphs.
+
+#### Scenario: Multiple root layers
+- **WHEN** the manifest has two layers with no parent (disconnected graph)
+- **THEN** both SHALL be returned as root layers
+
+### Requirement: Manifest lookup_by_tag handles special characters
+`Manifest.lookup_by_tag` SHALL handle tags with special characters.
+
+#### Scenario: Tag with empty string
+- **WHEN** `lookup_by_tag` is called with an empty string
+- **THEN** `ManifestParseError` SHALL be raised (tag not found)
+
+### Requirement: serialize_manifest handles default=None
+`serialize_manifest` SHALL handle the case where `manifest.default` is `None` in a way that is consistent with `parse_manifest`.
+
+#### Scenario: Serialize manifest with default=None
+- **WHEN** a manifest has `default=None`
+- **THEN** the serialized output SHALL either be re-parseable or this SHALL be documented as an invalid state
+
+### Requirement: ManifestParseError preserves details
+`ManifestParseError` SHALL correctly format the error message when `details` is provided.
+
+#### Scenario: ManifestParseError with details
+- **WHEN** `ManifestParseError("msg", details="detail")` is created
+- **THEN** `str(error)` SHALL contain both "msg" and "detail"

--- a/openspec/specs/schedule-executor-edge-testing/spec.md
+++ b/openspec/specs/schedule-executor-edge-testing/spec.md
@@ -1,0 +1,64 @@
+## ADDED Requirements
+
+### Requirement: ScheduleExecutor _schedule_loop handles exceptions and retries
+`ScheduleExecutor._schedule_loop` SHALL handle exceptions during task execution by sleeping 60 seconds and retrying.
+
+#### Scenario: Exception during task execution triggers retry
+- **WHEN** `_execute_task` raises an exception
+- **THEN** the loop SHALL log the error, sleep 60 seconds, and continue
+
+#### Scenario: CancelledError stops the loop
+- **WHEN** `asyncio.CancelledError` is raised during the loop
+- **THEN** the loop SHALL exit cleanly
+
+#### Scenario: Immediate execution when next run is due
+- **WHEN** `get_seconds_until_next_run` returns 0
+- **THEN** the task SHALL execute immediately without sleeping
+
+### Requirement: ScheduleExecutor handles duplicate and concurrent operations
+`ScheduleExecutor` SHALL handle edge cases in add/remove/update operations.
+
+#### Scenario: Add schedule with duplicate name
+- **WHEN** `add_schedule` is called with a schedule name that already exists
+- **THEN** both schedules SHALL exist in the list (no deduplication required)
+
+#### Scenario: Add schedule when executor not running
+- **WHEN** `add_schedule` is called when the executor is not started
+- **THEN** the schedule SHALL be added to the list but no task SHALL be created
+
+#### Scenario: Remove schedule that is currently executing
+- **WHEN** `remove_schedule` is called for a schedule that is mid-execution
+- **THEN** the schedule SHALL be removed from the list and its task SHALL be cancelled
+
+#### Scenario: Update schedule that is currently executing
+- **WHEN** `update_schedule` is called for a schedule that is mid-execution
+- **THEN** the schedule SHALL be replaced and its task SHALL be cancelled and restarted
+
+### Requirement: ScheduleExecutor handles double start/stop
+`ScheduleExecutor` SHALL handle being started or stopped multiple times.
+
+#### Scenario: Double start
+- **WHEN** `start()` is called twice without `stop()` in between
+- **THEN** the executor SHALL handle this gracefully (no duplicate tasks)
+
+#### Scenario: Double stop
+- **WHEN** `stop()` is called twice
+- **THEN** no exception SHALL be raised on the second call
+
+### Requirement: Schedule handles invalid cron expressions
+`Schedule.get_next_run` SHALL handle invalid cron expressions.
+
+#### Scenario: Invalid cron expression
+- **WHEN** a Schedule is created with an invalid cron expression
+- **THEN** `get_next_run` SHALL raise an appropriate exception (from croniter)
+
+### Requirement: parse_frontmatter handles YAML edge cases
+`parse_frontmatter` SHALL handle various YAML formatting edge cases.
+
+#### Scenario: Frontmatter with blank lines between key-value pairs
+- **WHEN** frontmatter has blank lines between key-value pairs
+- **THEN** parsing SHALL succeed and extract all key-value pairs
+
+#### Scenario: Frontmatter value containing hash character
+- **WHEN** a frontmatter value contains `#` (potential YAML comment)
+- **THEN** the `#` SHALL be preserved in the value if properly quoted

--- a/openspec/specs/server-request-testing/spec.md
+++ b/openspec/specs/server-request-testing/spec.md
@@ -1,0 +1,53 @@
+## ADDED Requirements
+
+### Requirement: Server handles user_message with None content
+`SessionServer._handle_chat_completions` SHALL handle requests where the user message has `content: None` without crashing.
+
+#### Scenario: User message with None content
+- **WHEN** a chat completion request has the last user message with `content: None`
+- **THEN** the server SHALL not crash on `content[:100]` and SHALL process the request
+
+#### Scenario: User message with empty string content
+- **WHEN** a chat completion request has the last user message with `content: ""`
+- **THEN** the server SHALL process the request normally
+
+### Requirement: Server _filter_for_channel handles missing fields
+`SessionServer._filter_for_channel` SHALL handle responses with missing or malformed fields gracefully.
+
+#### Scenario: Response with no choices key
+- **WHEN** the response dict has no `choices` key
+- **THEN** the filtered response SHALL handle this gracefully (return empty choices or error)
+
+#### Scenario: Response with empty choices list
+- **WHEN** the response has `choices: []`
+- **THEN** the filtered response SHALL preserve the empty choices list
+
+#### Scenario: Choice with missing message key
+- **WHEN** a choice dict has no `message` key
+- **THEN** the filtered response SHALL handle this gracefully
+
+#### Scenario: Choice with None content
+- **WHEN** a choice has `message: {"content": None}`
+- **THEN** the filtered content SHALL be None or empty string
+
+### Requirement: Server start handles exceptions
+`SessionServer.start` SHALL handle exceptions during startup gracefully.
+
+#### Scenario: Runner __aenter__ raises exception
+- **WHEN** `runner.__aenter__()` raises an exception
+- **THEN** the exception SHALL propagate (server fails to start)
+
+#### Scenario: Socket removal permission error
+- **WHEN** removing an existing socket file raises PermissionError
+- **THEN** the error SHALL propagate or be handled appropriately
+
+### Requirement: Server stop handles exceptions
+`SessionServer.stop` SHALL handle exceptions during cleanup gracefully.
+
+#### Scenario: Double stop
+- **WHEN** `stop()` is called twice
+- **THEN** no exception SHALL be raised on the second call
+
+#### Scenario: Runner __aexit__ raises exception
+- **WHEN** `runner.__aexit__()` raises an exception
+- **THEN** the exception SHALL be logged but not crash the server

--- a/openspec/specs/session-conversation-testing/spec.md
+++ b/openspec/specs/session-conversation-testing/spec.md
@@ -1,0 +1,71 @@
+## ADDED Requirements
+
+### Requirement: Session handles multiple rounds of tool calls
+`SessionRunner._run_conversation` SHALL handle conversations where the LLM makes tool calls that produce further tool calls in subsequent rounds.
+
+#### Scenario: Two rounds of tool calls
+- **WHEN** the LLM first returns a tool call, and after receiving the tool result, returns another tool call
+- **THEN** both tool calls SHALL be executed, and the final response SHALL include results from both
+
+#### Scenario: Tool call with tool not in registry
+- **WHEN** the LLM returns a tool call for a tool name not in the registry
+- **THEN** the tool executor SHALL return an error message, and the conversation SHALL continue
+
+#### Scenario: Tool call with invalid JSON arguments
+- **WHEN** the LLM returns a tool call with arguments that are not valid JSON
+- **THEN** the tool executor SHALL return an error message, and the conversation SHALL continue
+
+### Requirement: Session handles workspace change detection with mixed changes
+`SessionRunner._handle_workspace_changes` SHALL handle all combinations of workspace changes correctly.
+
+#### Scenario: Tools removed
+- **WHEN** workspace changes include tools that were removed
+- **THEN** the removed tools SHALL be unregistered from the tool registry
+
+#### Scenario: Skills changed when system is None
+- **WHEN** workspace changes include skills modified and `self._system` is None
+- **THEN** the system prompt cache SHALL be set to None
+
+#### Scenario: Schedules changed when executor is None
+- **WHEN** workspace changes include schedules modified and `self._schedule_executor` is None
+- **THEN** no exception SHALL be raised (schedule changes SHALL be skipped)
+
+#### Scenario: Simultaneous tools, skills, and schedules changes
+- **WHEN** workspace changes include tools added/removed, skills modified, and schedules added/removed simultaneously
+- **THEN** all changes SHALL be applied in order: tools updated, system prompt cache invalidated, schedules updated
+
+### Requirement: Session _complete_fn handles None content
+`SessionRunner._complete_fn` SHALL handle LLM responses where `message.content` is `None`.
+
+#### Scenario: Response with None content
+- **WHEN** the LLM response has `message.content: None`
+- **THEN** `_complete_fn` SHALL return an empty string
+
+### Requirement: Session streaming handles reasoning field end-to-end
+`SessionRunner._stream_conversation` SHALL correctly stream reasoning content from the AI response.
+
+#### Scenario: Streaming with reasoning content
+- **WHEN** the streaming response includes reasoning content in delta
+- **THEN** the reasoning content SHALL be formatted with thinking block tags and yielded
+
+#### Scenario: Streaming with both reasoning and content
+- **WHEN** the streaming response includes both reasoning and content in the same chunk
+- **THEN** both SHALL be yielded in the correct format
+
+### Requirement: Session streaming handles multiple rounds of tool calls
+`SessionRunner._stream_conversation` SHALL handle streaming conversations with multiple rounds of tool calls.
+
+#### Scenario: Streaming with two rounds of tool calls
+- **WHEN** the streaming response includes tool calls, and after tool execution, the next streaming response includes more tool calls
+- **THEN** all tool calls SHALL be executed and results streamed
+
+### Requirement: Session _load_single_schedule handles errors
+`SessionRunner._load_single_schedule` SHALL handle errors when loading a schedule.
+
+#### Scenario: Task directory does not exist
+- **WHEN** `_load_single_schedule` is called with a non-existent directory
+- **THEN** it SHALL return None
+
+#### Scenario: Task directory with invalid TASK.md
+- **WHEN** `_load_single_schedule` is called with a directory containing an invalid TASK.md
+- **THEN** it SHALL return None

--- a/openspec/specs/telegram-bot-testing/spec.md
+++ b/openspec/specs/telegram-bot-testing/spec.md
@@ -1,0 +1,62 @@
+## ADDED Requirements
+
+### Requirement: TelegramBot _stop method handles graceful shutdown
+`TelegramBot._stop` SHALL gracefully stop the bot application.
+
+#### Scenario: Normal stop
+- **WHEN** `_stop()` is called with a running application
+- **THEN** the updater, application, and shutdown SHALL be called in order
+
+#### Scenario: Stop when app is None
+- **WHEN** `_stop()` is called and `self._app` is None
+- **THEN** no exception SHALL be raised
+
+### Requirement: split_message handles exact boundary positions
+`split_message` SHALL correctly handle text at exact boundary positions.
+
+#### Scenario: Newline exactly at midpoint
+- **WHEN** text has a newline at exactly `max_length // 2` position
+- **THEN** the split SHALL occur at the newline
+
+#### Scenario: Space exactly at midpoint
+- **WHEN** text has a space at exactly `max_length // 2` position and no newline in first half
+- **THEN** the split SHALL occur at the space
+
+#### Scenario: Very small max_length
+- **WHEN** `split_message` is called with `max_length=3` and text longer than 3
+- **THEN** the text SHALL be split into chunks of at most 3 characters
+
+### Requirement: TelegramBot streaming handles content_buffer fallback
+`_handle_message_streaming` SHALL use the `response` variable as fallback when `content_buffer` is empty.
+
+#### Scenario: Empty content_buffer with non-empty response
+- **WHEN** streaming completes with `content_buffer` empty but `response` has content
+- **THEN** the `response` content SHALL be used for the final message
+
+### Requirement: TelegramBot streaming handles typing indicator cancellation on error
+`_handle_message_streaming` SHALL cancel the typing indicator task when `send_message_stream` raises an exception.
+
+#### Scenario: Error during streaming cancels typing indicator
+- **WHEN** `send_message_stream` raises an exception while typing indicator is running
+- **THEN** the typing indicator task SHALL be cancelled
+
+### Requirement: TelegramBot non-streaming handles multiple split chunks
+`_handle_message_non_streaming` SHALL handle messages that split into more than 2 chunks.
+
+#### Scenario: Very long message split into 3+ chunks
+- **WHEN** the response is long enough to split into 3 or more chunks
+- **THEN** all chunks SHALL be sent as separate replies
+
+### Requirement: TelegramBot start without proxy
+`TelegramBot.start` SHALL work correctly without a proxy configured.
+
+#### Scenario: Start without proxy
+- **WHEN** `start()` is called with no proxy configured
+- **THEN** the application SHALL be created without proxy settings
+
+### Requirement: TelegramBot start registers handlers
+`TelegramBot.start` SHALL register the correct command and message handlers.
+
+#### Scenario: Handler registration
+- **WHEN** `start()` is called
+- **THEN** a CommandHandler for `/start` and a MessageHandler SHALL be added to the application

--- a/openspec/specs/test-async-cleanup/spec.md
+++ b/openspec/specs/test-async-cleanup/spec.md
@@ -1,0 +1,42 @@
+## ADDED Requirements
+
+### Requirement: REPL tests SHALL properly clean up aiohttp client sessions
+Tests that invoke `Repl.run()` SHALL prevent real `aiohttp.ClientSession` creation by patching `ReplClient.__aenter__` and `ReplClient.__aexit__`, or by ensuring the session is properly closed in teardown.
+
+#### Scenario: REPL test with empty input
+- **WHEN** `test_empty_input_ignored` calls `repl.run()` with mocked `_read_input` and `send_message`
+- **THEN** no "Unclosed client session" warning SHALL be emitted
+
+#### Scenario: REPL test with EOF exit
+- **WHEN** `test_eof_exits_repl` calls `repl.run()` with mocked `_read_input`
+- **THEN** no "Unclosed client session" warning SHALL be emitted
+
+#### Scenario: REPL test with keyboard interrupt
+- **WHEN** `test_keyboard_interrupt_exits_repl` calls `repl.run()` with mocked `_read_input`
+- **THEN** no "Unclosed client session" warning SHALL be emitted
+
+### Requirement: CLI main tests SHALL not create unawaited coroutines
+Tests that patch `tyro.cli` to verify `main()` calls SHALL make the mock return a no-op callable (`MagicMock(return_value=None)`) so that calling the return value does not trigger the CLI dataclass `__call__` method, preventing coroutine creation entirely.
+
+#### Scenario: Telegram main calls tyro
+- **WHEN** `test_main_calls_tyro` calls `main()` with `tyro.cli` patched and `mock_cli.return_value = MagicMock(return_value=None)`
+- **THEN** no "coroutine was never awaited" warning SHALL be emitted
+
+#### Scenario: Session main calls tyro
+- **WHEN** `test_main_calls_tyro` calls `main()` with `tyro.cli` patched and `mock_cli.return_value = MagicMock(return_value=None)`
+- **THEN** no "coroutine was never awaited" warning SHALL be emitted
+
+#### Scenario: OpenAI completions main calls tyro
+- **WHEN** `test_main_calls_tyro` calls `main()` with `tyro.cli` patched and `mock_cli.return_value = MagicMock(return_value=None)`
+- **THEN** no "coroutine was never awaited" warning SHALL be emitted
+
+#### Scenario: Anthropic messages main calls tyro
+- **WHEN** `test_main_calls_tyro` calls `main()` with `tyro.cli` patched and `mock_cli.return_value = MagicMock(return_value=None)`
+- **THEN** no "coroutine was never awaited" warning SHALL be emitted
+
+### Requirement: Mocked asyncio.run SHALL properly discard coroutines
+Tests that mock `asyncio.run` SHALL use a side effect that calls `coro.close()` on the received coroutine, properly discarding it rather than leaving it unawaited.
+
+#### Scenario: CLI __call__ test with mocked asyncio.run
+- **WHEN** a test calls `cli()` with `asyncio.run` mocked and `mock_run.side_effect = _run_coroutine_silently`
+- **THEN** no "coroutine was never awaited" warning SHALL be emitted

--- a/openspec/specs/translator-edge-case-testing/spec.md
+++ b/openspec/specs/translator-edge-case-testing/spec.md
@@ -1,0 +1,90 @@
+## ADDED Requirements
+
+### Requirement: Translator handles invalid JSON in tool_call arguments
+`_translate_message_to_anthropic` SHALL handle tool_call arguments that are not valid JSON by falling back to an empty dict `{}`.
+
+#### Scenario: Invalid JSON in arguments
+- **WHEN** an assistant message has `tool_calls` with `arguments` that is not valid JSON (e.g., `"not json"`)
+- **THEN** the translated message SHALL use `input: {}` for that tool call
+
+#### Scenario: None arguments in tool_call
+- **WHEN** an assistant message has `tool_calls` with `arguments` being `None`
+- **THEN** the translated message SHALL use `input: {}` for that tool call
+
+#### Scenario: Empty string arguments in tool_call
+- **WHEN** an assistant message has `tool_calls` with `arguments` being `""`
+- **THEN** the translated message SHALL use `input: {}` for that tool call
+
+### Requirement: Translator handles None tool result content
+`_translate_message_to_anthropic` SHALL handle tool result messages where `content` is `None` by using an empty string.
+
+#### Scenario: Tool result with None content
+- **WHEN** a tool result message has `content: None`
+- **THEN** the translated content block SHALL have `"text": ""`
+
+### Requirement: Translator handles unknown tool format
+`_translate_tool_to_anthropic` SHALL pass through tools that don't match OpenAI or Anthropic format unchanged.
+
+#### Scenario: Unknown tool format
+- **WHEN** a tool dict has neither `type: "function"` (OpenAI) nor `type: "custom"` with `input_schema` (Anthropic)
+- **THEN** the tool SHALL be returned unchanged
+
+### Requirement: Translator handles Anthropic response with missing fields
+`translate_anthropic_to_openai` SHALL handle responses with missing optional fields by using sensible defaults.
+
+#### Scenario: Response with no usage field
+- **WHEN** Anthropic response has no `usage` field
+- **THEN** the translated response SHALL have `prompt_tokens: 0`, `completion_tokens: 0`, `total_tokens: 0`
+
+#### Scenario: Response with no stop_reason
+- **WHEN** Anthropic response has no `stop_reason` field
+- **THEN** the translated response SHALL default `finish_reason` to `"end_turn"`
+
+#### Scenario: Response with unknown stop_reason
+- **WHEN** Anthropic response has `stop_reason: "unknown_reason"`
+- **THEN** the translated response SHALL default `finish_reason` to `"stop"`
+
+#### Scenario: Response with no id field
+- **WHEN** Anthropic response has no `id` field
+- **THEN** the translated response SHALL use empty string for `id`
+
+#### Scenario: Response with no model field
+- **WHEN** Anthropic response has no `model` field
+- **THEN** the translated response SHALL use empty string for `model`
+
+#### Scenario: Response with empty content list
+- **WHEN** Anthropic response has `content: []`
+- **THEN** the translated message SHALL have `content: None`
+
+### Requirement: Translator handles multiple system messages
+`translate_openai_to_anthropic` SHALL extract only the first system message as the `system` parameter and keep subsequent system messages in the messages list.
+
+#### Scenario: Multiple system messages
+- **WHEN** the request has two system messages
+- **THEN** the first SHALL be extracted as `system` parameter, and the second SHALL remain in the messages list
+
+### Requirement: Translator handles malformed SSE events
+`translate_anthropic_stream` SHALL handle malformed SSE events gracefully.
+
+#### Scenario: SSE event missing event line
+- **WHEN** an SSE chunk has `data:` but no `event:` line
+- **THEN** the event SHALL be skipped (no output yielded)
+
+#### Scenario: Empty stream
+- **WHEN** the stream produces zero events
+- **THEN** the generator SHALL yield zero chunks
+
+#### Scenario: Ping event
+- **WHEN** the stream produces a `ping` event
+- **THEN** the event SHALL be skipped (no output yielded)
+
+### Requirement: Translator handles assistant message with whitespace-only content and tool_calls
+`_translate_message_to_anthropic` SHALL handle assistant messages that have `tool_calls` and whitespace-only content by not including a text content block.
+
+#### Scenario: Whitespace-only content with tool_calls
+- **WHEN** an assistant message has `content: "   "` and `tool_calls` present
+- **THEN** the translated content SHALL NOT include a text content block, only tool_use blocks
+
+#### Scenario: Empty string content with tool_calls
+- **WHEN** an assistant message has `content: ""` and `tool_calls` present
+- **THEN** the translated content SHALL NOT include a text content block, only tool_use blocks

--- a/openspec/specs/workspace-cli-testing/spec.md
+++ b/openspec/specs/workspace-cli-testing/spec.md
@@ -1,0 +1,56 @@
+## ADDED Requirements
+
+### Requirement: Workspace pack CLI entry point
+`psi-workspace-pack` CLI SHALL correctly create config and call the pack API.
+
+#### Scenario: Pack CLI creates correct config
+- **WHEN** `Pack(input_dir="/tmp/in", output_file="/tmp/out", tag="v1")` is called
+- **THEN** the correct `pack()` API SHALL be called with matching arguments
+
+#### Scenario: Pack CLI main calls tyro
+- **WHEN** `main()` is called
+- **THEN** `tyro.cli(Pack)` SHALL be invoked
+
+### Requirement: Workspace unpack CLI entry point
+`psi-workspace-unpack` CLI SHALL correctly create config and call the unpack API.
+
+#### Scenario: Unpack CLI creates correct config
+- **WHEN** `Unpack(input_file="/tmp/in", output_dir="/tmp/out")` is called
+- **THEN** the correct `unpack()` API SHALL be called with matching arguments
+
+#### Scenario: Unpack CLI main calls tyro
+- **WHEN** `main()` is called
+- **THEN** `tyro.cli(Unpack)` SHALL be invoked
+
+### Requirement: Workspace mount CLI entry point
+`psi-workspace-mount` CLI SHALL correctly create config and call the mount API.
+
+#### Scenario: Mount CLI creates correct config
+- **WHEN** `Mount(input_file="/tmp/in", output_dir="/tmp/out", layer="v1")` is called
+- **THEN** the correct `mount()` API SHALL be called with matching arguments
+
+#### Scenario: Mount CLI main calls tyro
+- **WHEN** `main()` is called
+- **THEN** `tyro.cli(Mount)` SHALL be invoked
+
+### Requirement: Workspace umount CLI entry point
+`psi-workspace-umount` CLI SHALL correctly create config and call the umount API.
+
+#### Scenario: Umount CLI creates correct config
+- **WHEN** `Umount(mount_point="/tmp/mnt")` is called
+- **THEN** the correct `umount()` API SHALL be called with matching arguments
+
+#### Scenario: Umount CLI main calls tyro
+- **WHEN** `main()` is called
+- **THEN** `tyro.cli(Umount)` SHALL be invoked
+
+### Requirement: Workspace snapshot CLI entry point
+`psi-workspace-snapshot` CLI SHALL correctly create config and call the snapshot API.
+
+#### Scenario: Snapshot CLI creates correct config
+- **WHEN** `Snapshot(input_file="/tmp/in", mount_point="/tmp/mnt", tag="v2")` is called
+- **THEN** the correct `snapshot()` API SHALL be called with matching arguments
+
+#### Scenario: Snapshot CLI main calls tyro
+- **WHEN** `main()` is called
+- **THEN** `tyro.cli(Snapshot)` SHALL be invoked

--- a/openspec/specs/workspace-operation-testing/spec.md
+++ b/openspec/specs/workspace-operation-testing/spec.md
@@ -1,0 +1,98 @@
+## ADDED Requirements
+
+### Requirement: Pack handles mksquashfs failure
+`pack` SHALL raise `PackError` when the `mksquashfs` command fails.
+
+#### Scenario: mksquashfs returns non-zero exit code
+- **WHEN** `mksquashfs` command exits with a non-zero code
+- **THEN** `PackError` SHALL be raised with an appropriate message
+
+### Requirement: Pack handles empty input directory
+`pack` SHALL handle an empty input directory without error.
+
+#### Scenario: Empty directory
+- **WHEN** `pack` is called with an empty directory
+- **THEN** a squashfs file SHALL be created successfully
+
+### Requirement: Unpack handles unsquashfs failure
+`unpack` SHALL raise `UnpackError` when the `unsquashfs` command fails.
+
+#### Scenario: Corrupt squashfs file
+- **WHEN** `unpack` is called with a corrupt or invalid squashfs file
+- **THEN** `UnpackError` SHALL be raised
+
+#### Scenario: Empty squashfs file
+- **WHEN** `unpack` is called with a 0-byte file
+- **THEN** `UnpackError` SHALL be raised
+
+### Requirement: Unpack handles output directory that already exists
+`unpack` SHALL handle the case where the output directory already exists.
+
+#### Scenario: Output directory exists
+- **WHEN** `unpack` is called and the output directory already exists
+- **THEN** the contents SHALL be extracted into the existing directory
+
+### Requirement: Umount handles mount info with missing keys
+`umount` SHALL raise `UmountError` when mount info dict is missing required keys (squashfs_mount, upper_dir, work_dir).
+
+#### Scenario: Missing squashfs_mount key
+- **WHEN** mount info dict lacks the `squashfs_mount` key
+- **THEN** `UmountError` SHALL be raised (not `KeyError`)
+
+#### Scenario: Missing upper_dir key
+- **WHEN** mount info dict lacks the `upper_dir` key
+- **THEN** `UmountError` SHALL be raised (not `KeyError`)
+
+### Requirement: Umount _cleanup_directory handles read-only files
+`_cleanup_directory` SHALL handle files that cannot be deleted due to permission errors.
+
+#### Scenario: Read-only file in directory
+- **WHEN** a directory contains a read-only file
+- **THEN** the error SHALL be logged and the cleanup SHALL continue
+
+### Requirement: Snapshot handles mount info with missing keys
+`snapshot` SHALL raise `SnapshotError` when mount info dict is missing required keys.
+
+#### Scenario: Missing upper_dir key in mount info
+- **WHEN** mount info dict lacks the `upper_dir` key
+- **THEN** `SnapshotError` SHALL be raised (not `KeyError`)
+
+### Requirement: Snapshot handles output_file parameter
+`snapshot` SHALL correctly handle the `output_file` parameter when it differs from `input_file`.
+
+#### Scenario: Different output_file from input_file
+- **WHEN** `snapshot` is called with `output_file` different from `input_file`
+- **THEN** the result SHALL be written to `output_file` using atomic move
+
+#### Scenario: output_file already exists
+- **WHEN** `snapshot` is called with an `output_file` that already exists
+- **THEN** the existing file SHALL be overwritten
+
+### Requirement: Snapshot verifies manifest updates
+`snapshot` SHALL correctly update the manifest with the new layer.
+
+#### Scenario: New layer parent is previous default
+- **WHEN** a snapshot is created
+- **THEN** the new layer's `parent` SHALL be set to the previous default layer UUID
+
+#### Scenario: Default is updated to new layer
+- **WHEN** a snapshot is created
+- **THEN** `manifest.default` SHALL be updated to the new layer UUID
+
+### Requirement: Mount _resolve_target_layer handles UUID not in manifest
+`_resolve_target_layer` SHALL try tag lookup when a valid UUID string is not found in the layers dict.
+
+#### Scenario: Valid UUID format but not in layers
+- **WHEN** `layer` is a valid UUID string that is not in the layers dict
+- **THEN** tag lookup SHALL be attempted, and if not found, `MountError` SHALL be raised
+
+### Requirement: PackError and UnpackError exception classes
+`PackError` and `UnpackError` SHALL be properly defined exception classes that inherit from `Exception`.
+
+#### Scenario: PackError message preservation
+- **WHEN** `PackError("test message")` is created
+- **THEN** `str(error)` SHALL contain "test message"
+
+#### Scenario: UnpackError message preservation
+- **WHEN** `UnpackError("test message")` is created
+- **THEN** `str(error)` SHALL contain "test message"

--- a/tests/ai/anthropic_messages/test_cli.py
+++ b/tests/ai/anthropic_messages/test_cli.py
@@ -8,6 +8,12 @@ from psi_agent.ai.anthropic_messages.cli import AnthropicMessages, main
 from psi_agent.ai.anthropic_messages.config import AnthropicMessagesConfig
 
 
+def _run_coroutine_silently(coro):
+    """Side effect for mocked asyncio.run that closes the coroutine to prevent warnings."""
+    coro.close()
+    return None
+
+
 class TestAnthropicMessagesCli:
     """Tests for Anthropic Messages CLI dataclass."""
 
@@ -75,6 +81,7 @@ class TestAnthropicMessagesCliCall:
         mock_server.start = AsyncMock()
         mock_server.stop = AsyncMock()
         mock_server_cls.return_value = mock_server
+        mock_run.side_effect = _run_coroutine_silently
 
         cli = AnthropicMessages(
             session_socket="/tmp/test.sock",
@@ -111,6 +118,7 @@ class TestAnthropicMessagesCliCall:
         mock_server.start = AsyncMock()
         mock_server.stop = AsyncMock()
         mock_server_cls.return_value = mock_server
+        mock_run.side_effect = _run_coroutine_silently
 
         cli = AnthropicMessages(
             session_socket="/tmp/test.sock",
@@ -138,6 +146,7 @@ class TestAnthropicMessagesMain:
     @patch("psi_agent.ai.anthropic_messages.cli.tyro.cli")
     def test_main_calls_tyro(self, mock_cli: MagicMock) -> None:
         """Test main calls tyro.cli."""
+        mock_cli.return_value = MagicMock(return_value=None)
         main()
         mock_cli.assert_called_once_with(AnthropicMessages)
 
@@ -264,6 +273,7 @@ class TestAnthropicMessagesThinkingAndReasoning:
         mock_server.start = AsyncMock()
         mock_server.stop = AsyncMock()
         mock_server_cls.return_value = mock_server
+        mock_run.side_effect = _run_coroutine_silently
 
         cli = AnthropicMessages(
             session_socket="/tmp/test.sock",

--- a/tests/ai/anthropic_messages/test_client.py
+++ b/tests/ai/anthropic_messages/test_client.py
@@ -657,6 +657,7 @@ class TestStreamingMidStreamError:
                     stream=True,
                 )
 
+                assert not isinstance(result, dict)
                 chunks = []
                 async for chunk in result:
                     chunks.append(chunk)
@@ -693,6 +694,7 @@ class TestStreamingMidStreamError:
                     stream=True,
                 )
 
+                assert not isinstance(result, dict)
                 chunks = []
                 async for chunk in result:
                     chunks.append(chunk)
@@ -723,6 +725,7 @@ class TestStreamingMidStreamError:
                     stream=True,
                 )
 
+                assert not isinstance(result, dict)
                 chunks = []
                 async for chunk in result:
                     chunks.append(chunk)

--- a/tests/ai/anthropic_messages/test_client.py
+++ b/tests/ai/anthropic_messages/test_client.py
@@ -6,7 +6,13 @@ from collections.abc import AsyncGenerator
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from anthropic import APIConnectionError, AuthenticationError, RateLimitError
+from anthropic import (
+    APIConnectionError,
+    APIStatusError,
+    APITimeoutError,
+    AuthenticationError,
+    RateLimitError,
+)
 
 from psi_agent.ai.anthropic_messages.client import AnthropicMessagesClient
 from psi_agent.ai.anthropic_messages.config import AnthropicMessagesConfig
@@ -531,3 +537,199 @@ class TestAnthropicMessagesClient:
                 for chunk in chunks:
                     if chunk.startswith("event:"):
                         assert "event: unknown_event_type" not in chunk
+
+
+class TestClientNotInitialized:
+    """Tests for calling client without initialization."""
+
+    @pytest.fixture
+    def client(self) -> AnthropicMessagesClient:
+        """Create test client without entering context manager."""
+        config = AnthropicMessagesConfig(
+            session_socket="/tmp/test.sock",
+            model="claude-sonnet-4-20250514",
+            api_key="test-key",
+        )
+        return AnthropicMessagesClient(config)
+
+    @pytest.mark.asyncio
+    async def test_messages_raises_when_not_initialized(
+        self, client: AnthropicMessagesClient
+    ) -> None:
+        """Test messages raises RuntimeError when client not initialized."""
+        with pytest.raises(RuntimeError, match="Client not initialized"):
+            await client.messages(
+                {"messages": [{"role": "user", "content": "Hello"}]},
+                stream=False,
+            )
+
+    @pytest.mark.asyncio
+    async def test_messages_streaming_raises_when_not_initialized(
+        self, client: AnthropicMessagesClient
+    ) -> None:
+        """Test streaming messages raises RuntimeError when client not initialized."""
+        with pytest.raises(RuntimeError, match="Client not initialized"):
+            await client.messages(
+                {"messages": [{"role": "user", "content": "Hello"}]},
+                stream=True,
+            )
+
+
+class TestHandleError:
+    """Tests for _handle_error method."""
+
+    @pytest.fixture
+    def client(self) -> AnthropicMessagesClient:
+        """Create test client."""
+        config = AnthropicMessagesConfig(
+            session_socket="/tmp/test.sock",
+            model="claude-sonnet-4-20250514",
+            api_key="test-key",
+        )
+        return AnthropicMessagesClient(config)
+
+    def test_api_status_error_with_status_code(self, client: AnthropicMessagesClient) -> None:
+        """Test _handle_error with APIStatusError that has status_code."""
+        error = APIStatusError(
+            message="Bad request",
+            response=MagicMock(status_code=400),
+            body={"error": {"message": "Bad request"}},
+        )
+        result = client._handle_error(error)
+        assert result["error"] == "Bad request"
+        assert result["status_code"] == 400
+
+    def test_api_status_error_with_none_status_code(self, client: AnthropicMessagesClient) -> None:
+        """Test _handle_error with APIStatusError where status_code is None."""
+        error = APIStatusError(
+            message="Unknown error",
+            response=MagicMock(status_code=None),
+            body={"error": {"message": "Unknown error"}},
+        )
+        result = client._handle_error(error)
+        assert result["error"] == "Unknown error"
+        assert result["status_code"] == 500
+
+    def test_api_timeout_error(self, client: AnthropicMessagesClient) -> None:
+        """Test _handle_error with APITimeoutError."""
+        error = APITimeoutError(request=MagicMock())
+        result = client._handle_error(error)
+        assert "error" in result
+        assert result["status_code"] == 500
+
+    def test_generic_exception(self, client: AnthropicMessagesClient) -> None:
+        """Test _handle_error with generic Exception."""
+        error = Exception("unexpected failure")
+        result = client._handle_error(error)
+        assert result["error"] == "unexpected failure"
+        assert result["status_code"] == 500
+
+
+class TestStreamingMidStreamError:
+    """Tests for streaming mid-stream error handling."""
+
+    @pytest.fixture
+    def client(self) -> AnthropicMessagesClient:
+        """Create test client."""
+        config = AnthropicMessagesConfig(
+            session_socket="/tmp/test.sock",
+            model="claude-sonnet-4-20250514",
+            api_key="test-key",
+        )
+        return AnthropicMessagesClient(config)
+
+    @pytest.mark.asyncio
+    async def test_streaming_api_timeout_error(self, client: AnthropicMessagesClient) -> None:
+        """Test streaming with APITimeoutError during stream."""
+        mock_stream = AsyncMock()
+        mock_stream.__aenter__ = AsyncMock(side_effect=APITimeoutError(request=MagicMock()))
+        mock_stream.__aexit__ = AsyncMock(return_value=None)
+
+        with patch("psi_agent.ai.anthropic_messages.client.AsyncAnthropic") as mock_anthropic:
+            mock_instance = AsyncMock()
+            mock_instance.messages.stream = MagicMock(return_value=mock_stream)
+            mock_instance.close = AsyncMock()
+            mock_anthropic.return_value = mock_instance
+
+            async with client:
+                result = await client.messages(
+                    {"messages": [{"role": "user", "content": "Hello"}]},
+                    stream=True,
+                )
+
+                chunks = []
+                async for chunk in result:
+                    chunks.append(chunk)
+
+                assert len(chunks) == 1
+                import json
+
+                error_data = json.loads(chunks[0].replace("data: ", "").strip())
+                assert "error" in error_data
+                assert error_data["status_code"] == 500
+
+    @pytest.mark.asyncio
+    async def test_streaming_api_status_error(self, client: AnthropicMessagesClient) -> None:
+        """Test streaming with APIStatusError during stream."""
+        mock_stream = AsyncMock()
+        mock_stream.__aenter__ = AsyncMock(
+            side_effect=APIStatusError(
+                message="Server error",
+                response=MagicMock(status_code=500),
+                body={"error": {"message": "Server error"}},
+            )
+        )
+        mock_stream.__aexit__ = AsyncMock(return_value=None)
+
+        with patch("psi_agent.ai.anthropic_messages.client.AsyncAnthropic") as mock_anthropic:
+            mock_instance = AsyncMock()
+            mock_instance.messages.stream = MagicMock(return_value=mock_stream)
+            mock_instance.close = AsyncMock()
+            mock_anthropic.return_value = mock_instance
+
+            async with client:
+                result = await client.messages(
+                    {"messages": [{"role": "user", "content": "Hello"}]},
+                    stream=True,
+                )
+
+                chunks = []
+                async for chunk in result:
+                    chunks.append(chunk)
+
+                assert len(chunks) == 1
+                import json
+
+                error_data = json.loads(chunks[0].replace("data: ", "").strip())
+                assert "error" in error_data
+                assert error_data["status_code"] == 500
+
+    @pytest.mark.asyncio
+    async def test_streaming_generic_exception(self, client: AnthropicMessagesClient) -> None:
+        """Test streaming with generic Exception during stream."""
+        mock_stream = AsyncMock()
+        mock_stream.__aenter__ = AsyncMock(side_effect=Exception("unexpected"))
+        mock_stream.__aexit__ = AsyncMock(return_value=None)
+
+        with patch("psi_agent.ai.anthropic_messages.client.AsyncAnthropic") as mock_anthropic:
+            mock_instance = AsyncMock()
+            mock_instance.messages.stream = MagicMock(return_value=mock_stream)
+            mock_instance.close = AsyncMock()
+            mock_anthropic.return_value = mock_instance
+
+            async with client:
+                result = await client.messages(
+                    {"messages": [{"role": "user", "content": "Hello"}]},
+                    stream=True,
+                )
+
+                chunks = []
+                async for chunk in result:
+                    chunks.append(chunk)
+
+                assert len(chunks) == 1
+                import json
+
+                error_data = json.loads(chunks[0].replace("data: ", "").strip())
+                assert "error" in error_data
+                assert error_data["status_code"] == 500

--- a/tests/ai/anthropic_messages/test_server.py
+++ b/tests/ai/anthropic_messages/test_server.py
@@ -388,3 +388,29 @@ class TestModelInjection:
         # Verify user-specified model was preserved
         call_args = mock_client.messages.call_args[0][0]
         assert call_args["model"] == "claude-opus-4"
+
+
+class TestServerLifecycle:
+    """Tests for server start/stop lifecycle."""
+
+    @pytest.mark.asyncio
+    async def test_stop_with_none_client(self, config: AnthropicMessagesConfig) -> None:
+        """Test stop when client is None."""
+        server = AnthropicMessagesServer(config)
+        server.client = None
+        server._runner = None
+
+        # Should not raise
+        await server.stop()
+
+    @pytest.mark.asyncio
+    async def test_stop_with_none_runner(self, config: AnthropicMessagesConfig) -> None:
+        """Test stop when runner is None."""
+        server = AnthropicMessagesServer(config)
+        mock_client = AsyncMock()
+        mock_client.__aexit__ = AsyncMock()
+        server.client = mock_client
+        server._runner = None
+
+        await server.stop()
+        mock_client.__aexit__.assert_called_once()

--- a/tests/ai/anthropic_messages/test_translator.py
+++ b/tests/ai/anthropic_messages/test_translator.py
@@ -1296,3 +1296,315 @@ class TestTranslateAnthropicStreamThinking:
         assert '"finish_reason": "tool_calls"' in chunks[4]
         # Last chunk is [DONE]
         assert chunks[5] == "data: [DONE]\n\n"
+
+
+class TestToolCallArgumentsEdgeCases:
+    """Tests for tool_call arguments edge cases in translation."""
+
+    def test_invalid_json_arguments(self) -> None:
+        """Test tool_call with invalid JSON arguments falls back to empty dict."""
+        openai_request = {
+            "messages": [
+                {
+                    "role": "assistant",
+                    "content": "",
+                    "tool_calls": [
+                        {
+                            "id": "call_1",
+                            "type": "function",
+                            "function": {"name": "bash", "arguments": "not valid json"},
+                        }
+                    ],
+                },
+            ],
+        }
+
+        result = translate_openai_to_anthropic(openai_request)
+
+        assistant_msg = result["messages"][0]
+        tool_block = assistant_msg["content"][0]
+        assert tool_block["type"] == "tool_use"
+        assert tool_block["input"] == {}
+
+    def test_none_arguments(self) -> None:
+        """Test tool_call with None arguments falls back to empty dict."""
+        openai_request = {
+            "messages": [
+                {
+                    "role": "assistant",
+                    "content": "",
+                    "tool_calls": [
+                        {
+                            "id": "call_1",
+                            "type": "function",
+                            "function": {"name": "bash", "arguments": None},
+                        }
+                    ],
+                },
+            ],
+        }
+
+        result = translate_openai_to_anthropic(openai_request)
+
+        assistant_msg = result["messages"][0]
+        tool_block = assistant_msg["content"][0]
+        assert tool_block["type"] == "tool_use"
+        assert tool_block["input"] == {}
+
+    def test_empty_string_arguments(self) -> None:
+        """Test tool_call with empty string arguments falls back to empty dict."""
+        openai_request = {
+            "messages": [
+                {
+                    "role": "assistant",
+                    "content": "",
+                    "tool_calls": [
+                        {
+                            "id": "call_1",
+                            "type": "function",
+                            "function": {"name": "bash", "arguments": ""},
+                        }
+                    ],
+                },
+            ],
+        }
+
+        result = translate_openai_to_anthropic(openai_request)
+
+        assistant_msg = result["messages"][0]
+        tool_block = assistant_msg["content"][0]
+        assert tool_block["type"] == "tool_use"
+        assert tool_block["input"] == {}
+
+
+class TestToolResultNoneContent:
+    """Tests for tool result with None content."""
+
+    def test_tool_result_none_content(self) -> None:
+        """Test tool result with None content uses empty string."""
+        openai_request = {
+            "messages": [
+                {
+                    "role": "tool",
+                    "tool_call_id": "call_1",
+                    "content": None,
+                },
+            ],
+        }
+
+        result = translate_openai_to_anthropic(openai_request)
+
+        tool_msg = result["messages"][0]
+        assert tool_msg["content"][0]["type"] == "tool_result"
+        assert tool_msg["content"][0]["content"] == ""
+
+
+class TestUnknownToolFormat:
+    """Tests for unknown tool format passthrough."""
+
+    def test_unknown_tool_format_passthrough(self) -> None:
+        """Test tool with unknown format is passed through unchanged."""
+        openai_request = {
+            "messages": [{"role": "user", "content": "Hello"}],
+            "tools": [
+                {"custom_key": "custom_value", "name": "custom_tool"},
+            ],
+        }
+
+        result = translate_openai_to_anthropic(openai_request)
+
+        assert result["tools"][0] == {"custom_key": "custom_value", "name": "custom_tool"}
+
+
+class TestAssistantWhitespaceContentWithToolCalls:
+    """Tests for assistant message with whitespace-only content and tool_calls."""
+
+    def test_whitespace_only_content_with_tool_calls(self) -> None:
+        """Test whitespace-only content with tool_calls produces no text block."""
+        openai_request = {
+            "messages": [
+                {
+                    "role": "assistant",
+                    "content": "   ",
+                    "tool_calls": [
+                        {
+                            "id": "call_1",
+                            "type": "function",
+                            "function": {"name": "bash", "arguments": '{"cmd": "ls"}'},
+                        }
+                    ],
+                },
+            ],
+        }
+
+        result = translate_openai_to_anthropic(openai_request)
+
+        assistant_msg = result["messages"][0]
+        # Should only have tool_use block, no text block
+        assert len(assistant_msg["content"]) == 1
+        assert assistant_msg["content"][0]["type"] == "tool_use"
+
+    def test_empty_string_content_with_tool_calls(self) -> None:
+        """Test empty string content with tool_calls produces no text block."""
+        openai_request = {
+            "messages": [
+                {
+                    "role": "assistant",
+                    "content": "",
+                    "tool_calls": [
+                        {
+                            "id": "call_1",
+                            "type": "function",
+                            "function": {"name": "bash", "arguments": '{"cmd": "ls"}'},
+                        }
+                    ],
+                },
+            ],
+        }
+
+        result = translate_openai_to_anthropic(openai_request)
+
+        assistant_msg = result["messages"][0]
+        assert len(assistant_msg["content"]) == 1
+        assert assistant_msg["content"][0]["type"] == "tool_use"
+
+
+class TestAnthropicResponseMissingFields:
+    """Tests for Anthropic response with missing optional fields."""
+
+    def test_no_usage_field(self) -> None:
+        """Test response with no usage defaults to 0 tokens."""
+        anthropic_response = {
+            "id": "msg_123",
+            "content": [{"type": "text", "text": "Hello"}],
+        }
+
+        result = translate_anthropic_to_openai(anthropic_response)
+
+        assert result["usage"]["prompt_tokens"] == 0
+        assert result["usage"]["completion_tokens"] == 0
+        assert result["usage"]["total_tokens"] == 0
+
+    def test_no_stop_reason(self) -> None:
+        """Test response with no stop_reason defaults to end_turn -> stop."""
+        anthropic_response = {
+            "id": "msg_123",
+            "content": [{"type": "text", "text": "Hello"}],
+        }
+
+        result = translate_anthropic_to_openai(anthropic_response)
+
+        assert result["choices"][0]["finish_reason"] == "stop"
+
+    def test_unknown_stop_reason(self) -> None:
+        """Test response with unknown stop_reason defaults to stop."""
+        anthropic_response = {
+            "id": "msg_123",
+            "content": [{"type": "text", "text": "Hello"}],
+            "stop_reason": "unknown_reason",
+        }
+
+        result = translate_anthropic_to_openai(anthropic_response)
+
+        assert result["choices"][0]["finish_reason"] == "stop"
+
+    def test_no_id_field(self) -> None:
+        """Test response with no id defaults to empty string."""
+        anthropic_response = {
+            "content": [{"type": "text", "text": "Hello"}],
+        }
+
+        result = translate_anthropic_to_openai(anthropic_response)
+
+        assert result["id"] == ""
+
+    def test_no_model_field(self) -> None:
+        """Test response with no model defaults to empty string."""
+        anthropic_response = {
+            "id": "msg_123",
+            "content": [{"type": "text", "text": "Hello"}],
+        }
+
+        result = translate_anthropic_to_openai(anthropic_response)
+
+        assert result["model"] == ""
+
+    def test_empty_content_list(self) -> None:
+        """Test response with empty content list results in None content."""
+        anthropic_response = {
+            "id": "msg_123",
+            "content": [],
+        }
+
+        result = translate_anthropic_to_openai(anthropic_response)
+
+        assert result["choices"][0]["message"]["content"] is None
+
+
+class TestMultipleSystemMessages:
+    """Tests for handling multiple system messages."""
+
+    def test_multiple_system_messages(self) -> None:
+        """Test first system message extracted, second kept in messages."""
+        openai_request = {
+            "messages": [
+                {"role": "system", "content": "First system message"},
+                {"role": "system", "content": "Second system message"},
+                {"role": "user", "content": "Hello"},
+            ],
+        }
+
+        result = translate_openai_to_anthropic(openai_request)
+
+        # First system message extracted as system parameter
+        assert result["system"] == "First system message"
+        # Second system message remains in messages list
+        system_msgs = [m for m in result["messages"] if m.get("role") == "system"]
+        assert len(system_msgs) == 1
+
+
+class TestSSEStreamEdgeCases:
+    """Tests for SSE stream edge cases."""
+
+    async def test_sse_event_missing_event_line(self) -> None:
+        """Test SSE event with data but no event line is skipped."""
+
+        async def mock_stream() -> AsyncGenerator[str]:
+            yield 'data: {"delta": {"text": "Hello"}}\n\n'
+
+        chunks = []
+        async for chunk in translate_anthropic_stream(mock_stream()):
+            chunks.append(chunk)
+
+        # No event type means no output
+        assert len(chunks) == 0
+
+    async def test_empty_stream(self) -> None:
+        """Test empty stream produces no output."""
+
+        async def mock_stream() -> AsyncGenerator[str]:
+            return
+            yield  # Make this an async generator
+
+        chunks = []
+        async for chunk in translate_anthropic_stream(mock_stream()):
+            chunks.append(chunk)
+
+        assert len(chunks) == 0
+
+    async def test_ping_event_skipped(self) -> None:
+        """Test ping event is skipped."""
+        import json
+
+        async def mock_stream() -> AsyncGenerator[str]:
+            msg_start = json.dumps({"message": {"id": "msg_123", "model": "claude-3"}})
+            yield f"event: message_start\ndata: {msg_start}\n\n"
+            yield "event: ping\ndata: {}\n\n"
+            yield "event: message_stop\ndata: {}\n\n"
+
+        chunks = []
+        async for chunk in translate_anthropic_stream(mock_stream()):
+            chunks.append(chunk)
+
+        # Should have: message_start, message_stop (ping skipped)
+        assert len(chunks) == 2

--- a/tests/ai/openai_completions/test_cli.py
+++ b/tests/ai/openai_completions/test_cli.py
@@ -8,6 +8,12 @@ from psi_agent.ai.openai_completions.cli import OpenaiCompletions, main
 from psi_agent.ai.openai_completions.config import OpenAICompletionsConfig
 
 
+def _run_coroutine_silently(coro):
+    """Side effect for mocked asyncio.run that closes the coroutine to prevent warnings."""
+    coro.close()
+    return None
+
+
 class TestOpenaiCompletionsCli:
     """Tests for OpenAI completions CLI dataclass."""
 
@@ -90,6 +96,7 @@ class TestOpenaiCompletionsCliCall:
         mock_server.start = AsyncMock()
         mock_server.stop = AsyncMock()
         mock_server_cls.return_value = mock_server
+        mock_run.side_effect = _run_coroutine_silently
 
         cli = OpenaiCompletions(
             session_socket="/tmp/test.sock",
@@ -124,6 +131,7 @@ class TestOpenaiCompletionsCliCall:
         mock_server.start = AsyncMock()
         mock_server.stop = AsyncMock()
         mock_server_cls.return_value = mock_server
+        mock_run.side_effect = _run_coroutine_silently
 
         cli = OpenaiCompletions(
             session_socket="/tmp/test.sock",
@@ -141,6 +149,7 @@ class TestOpenaiCompletionsMain:
     @patch("psi_agent.ai.openai_completions.cli.tyro.cli")
     def test_main_calls_tyro(self, mock_cli: MagicMock) -> None:
         """Test main calls tyro.cli."""
+        mock_cli.return_value = MagicMock(return_value=None)
         main()
         mock_cli.assert_called_once_with(OpenaiCompletions)
 
@@ -214,6 +223,7 @@ class TestOpenaiCompletionsThinkingAndReasoning:
         mock_server.start = AsyncMock()
         mock_server.stop = AsyncMock()
         mock_server_cls.return_value = mock_server
+        mock_run.side_effect = _run_coroutine_silently
 
         cli = OpenaiCompletions(
             session_socket="/tmp/test.sock",

--- a/tests/ai/openai_completions/test_client.py
+++ b/tests/ai/openai_completions/test_client.py
@@ -7,7 +7,13 @@ from typing import cast
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from openai import APIConnectionError, APITimeoutError, AuthenticationError, RateLimitError
+from openai import (
+    APIConnectionError,
+    APIStatusError,
+    APITimeoutError,
+    AuthenticationError,
+    RateLimitError,
+)
 
 from psi_agent.ai.openai_completions.client import OpenAICompletionsClient
 from psi_agent.ai.openai_completions.config import OpenAICompletionsConfig
@@ -349,3 +355,219 @@ class TestOpenAICompletionsClient:
                 assert "reasoning_effort" not in call_kwargs[1]
 
                 assert len(chunks) == 2
+
+
+class TestClientNotInitialized:
+    """Tests for calling client without initialization."""
+
+    @pytest.fixture
+    def client(self) -> OpenAICompletionsClient:
+        """Create test client without entering context manager."""
+        config = OpenAICompletionsConfig(
+            session_socket="/tmp/test.sock",
+            model="test-model",
+            api_key="test-key",
+            base_url="https://api.example.com/v1",
+        )
+        return OpenAICompletionsClient(config)
+
+    @pytest.mark.asyncio
+    async def test_chat_completions_raises_when_not_initialized(
+        self, client: OpenAICompletionsClient
+    ) -> None:
+        """Test chat_completions raises RuntimeError when client not initialized."""
+        with pytest.raises(RuntimeError, match="Client not initialized"):
+            await client.chat_completions(
+                {"messages": [{"role": "user", "content": "Hello"}]},
+                stream=False,
+            )
+
+    @pytest.mark.asyncio
+    async def test_chat_completions_streaming_raises_when_not_initialized(
+        self, client: OpenAICompletionsClient
+    ) -> None:
+        """Test streaming chat_completions raises RuntimeError when client not initialized."""
+        with pytest.raises(RuntimeError, match="Client not initialized"):
+            await client.chat_completions(
+                {"messages": [{"role": "user", "content": "Hello"}]},
+                stream=True,
+            )
+
+
+class TestHandleError:
+    """Tests for _handle_error method."""
+
+    @pytest.fixture
+    def client(self) -> OpenAICompletionsClient:
+        """Create test client."""
+        config = OpenAICompletionsConfig(
+            session_socket="/tmp/test.sock",
+            model="test-model",
+            api_key="test-key",
+            base_url="https://api.example.com/v1",
+        )
+        return OpenAICompletionsClient(config)
+
+    def test_api_status_error_with_status_code(self, client: OpenAICompletionsClient) -> None:
+        """Test _handle_error with APIStatusError that has status_code."""
+        error = APIStatusError(
+            message="Bad request",
+            response=MagicMock(status_code=400),
+            body=None,
+        )
+        result = client._handle_error(error)
+        assert result["error"] == "Bad request"
+        assert result["status_code"] == 400
+
+    def test_api_status_error_with_none_status_code(self, client: OpenAICompletionsClient) -> None:
+        """Test _handle_error with APIStatusError where status_code is None."""
+        error = APIStatusError(
+            message="Unknown error",
+            response=MagicMock(status_code=None),
+            body=None,
+        )
+        result = client._handle_error(error)
+        assert result["error"] == "Unknown error"
+        assert result["status_code"] == 500
+
+    def test_generic_exception(self, client: OpenAICompletionsClient) -> None:
+        """Test _handle_error with generic Exception."""
+        error = Exception("unexpected failure")
+        result = client._handle_error(error)
+        assert result["error"] == "unexpected failure"
+        assert result["status_code"] == 500
+
+
+class TestStreamingErrorPaths:
+    """Tests for streaming error handling."""
+
+    @pytest.fixture
+    def client(self) -> OpenAICompletionsClient:
+        """Create test client."""
+        config = OpenAICompletionsConfig(
+            session_socket="/tmp/test.sock",
+            model="test-model",
+            api_key="test-key",
+            base_url="https://api.example.com/v1",
+        )
+        return OpenAICompletionsClient(config)
+
+    @pytest.mark.asyncio
+    async def test_streaming_authentication_error(self, client: OpenAICompletionsClient) -> None:
+        """Test streaming with AuthenticationError."""
+        with patch("psi_agent.ai.openai_completions.client.AsyncOpenAI") as mock_openai:
+            mock_instance = AsyncMock()
+            mock_instance.chat.completions.create = AsyncMock(
+                side_effect=AuthenticationError(
+                    message="Invalid API key",
+                    response=MagicMock(status_code=401),
+                    body=None,
+                )
+            )
+            mock_instance.close = AsyncMock()
+            mock_openai.return_value = mock_instance
+
+            async with client:
+                result = await client.chat_completions(
+                    {"messages": [{"role": "user", "content": "Hello"}]},
+                    stream=True,
+                )
+
+                chunks = []
+                async for chunk in result:
+                    chunks.append(chunk)
+
+                assert len(chunks) == 1
+                import json
+
+                error_data = json.loads(chunks[0].replace("data: ", "").strip())
+                assert "error" in error_data
+                assert error_data["status_code"] == 401
+
+    @pytest.mark.asyncio
+    async def test_streaming_rate_limit_error(self, client: OpenAICompletionsClient) -> None:
+        """Test streaming with RateLimitError."""
+        with patch("psi_agent.ai.openai_completions.client.AsyncOpenAI") as mock_openai:
+            mock_instance = AsyncMock()
+            mock_instance.chat.completions.create = AsyncMock(
+                side_effect=RateLimitError(
+                    message="Rate limit exceeded",
+                    response=MagicMock(status_code=429),
+                    body=None,
+                )
+            )
+            mock_instance.close = AsyncMock()
+            mock_openai.return_value = mock_instance
+
+            async with client:
+                result = await client.chat_completions(
+                    {"messages": [{"role": "user", "content": "Hello"}]},
+                    stream=True,
+                )
+
+                chunks = []
+                async for chunk in result:
+                    chunks.append(chunk)
+
+                assert len(chunks) == 1
+                import json
+
+                error_data = json.loads(chunks[0].replace("data: ", "").strip())
+                assert "error" in error_data
+                assert error_data["status_code"] == 429
+
+    @pytest.mark.asyncio
+    async def test_streaming_connection_error(self, client: OpenAICompletionsClient) -> None:
+        """Test streaming with APIConnectionError."""
+        with patch("psi_agent.ai.openai_completions.client.AsyncOpenAI") as mock_openai:
+            mock_instance = AsyncMock()
+            mock_instance.chat.completions.create = AsyncMock(
+                side_effect=APIConnectionError(request=MagicMock())
+            )
+            mock_instance.close = AsyncMock()
+            mock_openai.return_value = mock_instance
+
+            async with client:
+                result = await client.chat_completions(
+                    {"messages": [{"role": "user", "content": "Hello"}]},
+                    stream=True,
+                )
+
+                chunks = []
+                async for chunk in result:
+                    chunks.append(chunk)
+
+                assert len(chunks) == 1
+                import json
+
+                error_data = json.loads(chunks[0].replace("data: ", "").strip())
+                assert "error" in error_data
+                assert error_data["status_code"] == 500
+
+    @pytest.mark.asyncio
+    async def test_streaming_timeout_error(self, client: OpenAICompletionsClient) -> None:
+        """Test streaming with APITimeoutError."""
+        with patch("psi_agent.ai.openai_completions.client.AsyncOpenAI") as mock_openai:
+            mock_instance = AsyncMock()
+            mock_instance.chat.completions.create = AsyncMock(
+                side_effect=APITimeoutError(request=MagicMock())
+            )
+            mock_instance.close = AsyncMock()
+            mock_openai.return_value = mock_instance
+
+            async with client:
+                result = await client.chat_completions(
+                    {"messages": [{"role": "user", "content": "Hello"}]},
+                    stream=True,
+                )
+
+                chunks = []
+                async for chunk in result:
+                    chunks.append(chunk)
+
+                assert len(chunks) == 1
+                import json
+
+                error_data = json.loads(chunks[0].replace("data: ", "").strip())
+                assert "error" in error_data
+                assert error_data["status_code"] == 500

--- a/tests/ai/openai_completions/test_client.py
+++ b/tests/ai/openai_completions/test_client.py
@@ -473,6 +473,7 @@ class TestStreamingErrorPaths:
                     stream=True,
                 )
 
+                assert not isinstance(result, dict)
                 chunks = []
                 async for chunk in result:
                     chunks.append(chunk)
@@ -505,6 +506,7 @@ class TestStreamingErrorPaths:
                     stream=True,
                 )
 
+                assert not isinstance(result, dict)
                 chunks = []
                 async for chunk in result:
                     chunks.append(chunk)
@@ -533,6 +535,7 @@ class TestStreamingErrorPaths:
                     stream=True,
                 )
 
+                assert not isinstance(result, dict)
                 chunks = []
                 async for chunk in result:
                     chunks.append(chunk)
@@ -561,6 +564,7 @@ class TestStreamingErrorPaths:
                     stream=True,
                 )
 
+                assert not isinstance(result, dict)
                 chunks = []
                 async for chunk in result:
                     chunks.append(chunk)

--- a/tests/ai/openai_completions/test_server.py
+++ b/tests/ai/openai_completions/test_server.py
@@ -436,3 +436,29 @@ class TestModelInjection:
         # Verify user-specified model was preserved
         call_args = mock_client.chat_completions.call_args[0][0]
         assert call_args["model"] == "gpt-4o"
+
+
+class TestServerLifecycle:
+    """Tests for server start/stop lifecycle."""
+
+    @pytest.mark.asyncio
+    async def test_stop_with_none_client(self, config: OpenAICompletionsConfig) -> None:
+        """Test stop when client is None."""
+        server = OpenAICompletionsServer(config)
+        server.client = None
+        server._runner = None
+
+        # Should not raise
+        await server.stop()
+
+    @pytest.mark.asyncio
+    async def test_stop_with_none_runner(self, config: OpenAICompletionsConfig) -> None:
+        """Test stop when runner is None."""
+        server = OpenAICompletionsServer(config)
+        mock_client = AsyncMock()
+        mock_client.__aexit__ = AsyncMock()
+        server.client = mock_client
+        server._runner = None
+
+        await server.stop()
+        mock_client.__aexit__.assert_called_once()

--- a/tests/channel/cli/test_cli_integration.py
+++ b/tests/channel/cli/test_cli_integration.py
@@ -6,6 +6,8 @@ import sys
 from io import StringIO
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import pytest
+
 from psi_agent.channel.cli.cli import Cli
 from psi_agent.channel.cli.client import CliClient
 from psi_agent.channel.cli.config import CliConfig

--- a/tests/channel/cli/test_cli_integration.py
+++ b/tests/channel/cli/test_cli_integration.py
@@ -6,11 +6,15 @@ import sys
 from io import StringIO
 from unittest.mock import AsyncMock, MagicMock, patch
 
-import pytest
-
 from psi_agent.channel.cli.cli import Cli
 from psi_agent.channel.cli.client import CliClient
 from psi_agent.channel.cli.config import CliConfig
+
+
+def _run_coroutine_silently(coro):
+    """Side effect for mocked asyncio.run that closes the coroutine to prevent warnings."""
+    coro.close()
+    return None
 
 
 class TestCliCall:
@@ -25,6 +29,7 @@ class TestCliCall:
         """Test __call__ creates config and client."""
         mock_config.return_value = MagicMock()
         mock_client.return_value = MagicMock()
+        mock_run.side_effect = _run_coroutine_silently
 
         cli = Cli(session_socket="/tmp/test.sock", message="Hello")
         cli()
@@ -42,6 +47,7 @@ class TestCliCall:
         """Test __call__ with stream=False."""
         mock_config.return_value = MagicMock()
         mock_client.return_value = MagicMock()
+        mock_run.side_effect = _run_coroutine_silently
 
         cli = Cli(session_socket="/tmp/test.sock", message="Hello", stream=False)
         cli()

--- a/tests/channel/cli/test_client.py
+++ b/tests/channel/cli/test_client.py
@@ -397,3 +397,192 @@ class TestCliClientSendMessageDispatch:
         call_kwargs = mock.call_args
         assert call_kwargs[1].get("on_chunk") is _my_callback or call_kwargs[0][3] is _my_callback
         assert result == "ok"
+
+
+class TestCliClientNullEmptyContent:
+    """Tests for CliClient handling null/empty content in responses."""
+
+    @pytest.mark.asyncio
+    async def test_streaming_null_content_in_delta_skipped(self) -> None:
+        """Null content in streaming delta is skipped (not appended)."""
+        client = CliClient(_make_config(stream=True))
+        client._session = MagicMock()
+
+        sse_lines = [
+            b'data: {"choices":[{"delta":{"content":null}}]}\n',
+            b'data: {"choices":[{"delta":{"content":"Hello"}}]}\n',
+            b"data: [DONE]\n",
+        ]
+
+        async def _aiter_lines():
+            for line in sse_lines:
+                yield line
+
+        mock_response = AsyncMock()
+        mock_response.status = 200
+        mock_response.content = _aiter_lines()
+        mock_response.__aenter__ = AsyncMock(return_value=mock_response)
+        mock_response.__aexit__ = AsyncMock(return_value=False)
+
+        client._session.post = MagicMock(return_value=mock_response)
+
+        result = await client._send_streaming(
+            "http://localhost/v1/chat/completions",
+            {"Content-Type": "application/json"},
+            "Hi",
+        )
+
+        assert result == "Hello"
+
+    @pytest.mark.asyncio
+    async def test_streaming_empty_string_content_in_delta_handled(self) -> None:
+        """Empty string content in streaming delta is handled."""
+        client = CliClient(_make_config(stream=True))
+        client._session = MagicMock()
+
+        sse_lines = [
+            b'data: {"choices":[{"delta":{"content":""}}]}\n',
+            b'data: {"choices":[{"delta":{"content":"Hello"}}]}\n',
+            b"data: [DONE]\n",
+        ]
+
+        async def _aiter_lines():
+            for line in sse_lines:
+                yield line
+
+        mock_response = AsyncMock()
+        mock_response.status = 200
+        mock_response.content = _aiter_lines()
+        mock_response.__aenter__ = AsyncMock(return_value=mock_response)
+        mock_response.__aexit__ = AsyncMock(return_value=False)
+
+        client._session.post = MagicMock(return_value=mock_response)
+
+        result = await client._send_streaming(
+            "http://localhost/v1/chat/completions",
+            {"Content-Type": "application/json"},
+            "Hi",
+        )
+
+        assert result == "Hello"
+
+    @pytest.mark.asyncio
+    async def test_non_streaming_null_content_returns_empty_string(self) -> None:
+        """Null content in non-streaming response returns empty string."""
+        client = CliClient(_make_config(stream=False))
+        client._session = MagicMock()
+
+        mock_response = AsyncMock()
+        mock_response.status = 200
+        mock_response.json = AsyncMock(return_value={"choices": [{"message": {"content": None}}]})
+        mock_response.__aenter__ = AsyncMock(return_value=mock_response)
+        mock_response.__aexit__ = AsyncMock(return_value=False)
+
+        client._session.post = MagicMock(return_value=mock_response)
+
+        result = await client._send_non_streaming(
+            "http://localhost/v1/chat/completions",
+            {"Content-Type": "application/json"},
+            "Hi",
+        )
+
+        assert result == ""
+
+
+class TestCliClientReasoningAndMissingFields:
+    """Tests for CliClient handling reasoning field and missing fields."""
+
+    @pytest.mark.asyncio
+    async def test_streaming_reasoning_field_handled(self) -> None:
+        """Reasoning field in streaming delta is handled without crash."""
+        client = CliClient(_make_config(stream=True))
+        client._session = MagicMock()
+
+        sse_lines = [
+            b'data: {"choices":[{"delta":{"reasoning":"thinking...","content":"Hello"}}]}\n',
+            b"data: [DONE]\n",
+        ]
+
+        async def _aiter_lines():
+            for line in sse_lines:
+                yield line
+
+        mock_response = AsyncMock()
+        mock_response.status = 200
+        mock_response.content = _aiter_lines()
+        mock_response.__aenter__ = AsyncMock(return_value=mock_response)
+        mock_response.__aexit__ = AsyncMock(return_value=False)
+
+        client._session.post = MagicMock(return_value=mock_response)
+
+        result = await client._send_streaming(
+            "http://localhost/v1/chat/completions",
+            {"Content-Type": "application/json"},
+            "Hi",
+        )
+
+        assert result == "Hello"
+
+    @pytest.mark.asyncio
+    async def test_streaming_empty_choices_list_skipped(self) -> None:
+        """Empty choices list in streaming chunk is skipped."""
+        client = CliClient(_make_config(stream=True))
+        client._session = MagicMock()
+
+        sse_lines = [
+            b'data: {"choices":[]}\n',
+            b'data: {"choices":[{"delta":{"content":"Hello"}}]}\n',
+            b"data: [DONE]\n",
+        ]
+
+        async def _aiter_lines():
+            for line in sse_lines:
+                yield line
+
+        mock_response = AsyncMock()
+        mock_response.status = 200
+        mock_response.content = _aiter_lines()
+        mock_response.__aenter__ = AsyncMock(return_value=mock_response)
+        mock_response.__aexit__ = AsyncMock(return_value=False)
+
+        client._session.post = MagicMock(return_value=mock_response)
+
+        result = await client._send_streaming(
+            "http://localhost/v1/chat/completions",
+            {"Content-Type": "application/json"},
+            "Hi",
+        )
+
+        assert result == "Hello"
+
+    @pytest.mark.asyncio
+    async def test_streaming_missing_delta_key_no_crash(self) -> None:
+        """Missing delta key in streaming chunk does not crash."""
+        client = CliClient(_make_config(stream=True))
+        client._session = MagicMock()
+
+        sse_lines = [
+            b'data: {"choices":[{}]}\n',
+            b'data: {"choices":[{"delta":{"content":"Hello"}}]}\n',
+            b"data: [DONE]\n",
+        ]
+
+        async def _aiter_lines():
+            for line in sse_lines:
+                yield line
+
+        mock_response = AsyncMock()
+        mock_response.status = 200
+        mock_response.content = _aiter_lines()
+        mock_response.__aenter__ = AsyncMock(return_value=mock_response)
+        mock_response.__aexit__ = AsyncMock(return_value=False)
+
+        client._session.post = MagicMock(return_value=mock_response)
+
+        result = await client._send_streaming(
+            "http://localhost/v1/chat/completions",
+            {"Content-Type": "application/json"},
+            "Hi",
+        )
+
+        assert result == "Hello"

--- a/tests/channel/repl/test_cli.py
+++ b/tests/channel/repl/test_cli.py
@@ -7,6 +7,12 @@ from unittest.mock import AsyncMock, MagicMock, patch
 from psi_agent.channel.repl.cli import Repl, main
 
 
+def _run_coroutine_silently(coro):
+    """Side effect for mocked asyncio.run that closes the coroutine to prevent warnings."""
+    coro.close()
+    return None
+
+
 class TestReplCli:
     """Tests for REPL CLI flag handling."""
 
@@ -48,6 +54,7 @@ class TestReplCli:
         mock_repl = MagicMock()
         mock_repl.run = AsyncMock()
         mock_repl_cls.return_value = mock_repl
+        mock_run.side_effect = _run_coroutine_silently
 
         cli = Repl(session_socket="/tmp/test.sock", stream=False)
         cli()
@@ -66,6 +73,7 @@ class TestReplCli:
         mock_repl = MagicMock()
         mock_repl.run = AsyncMock()
         mock_repl_cls.return_value = mock_repl
+        mock_run.side_effect = _run_coroutine_silently
 
         cli = Repl(session_socket="/tmp/test.sock")
         cli()
@@ -84,6 +92,7 @@ class TestReplCli:
         mock_repl = MagicMock()
         mock_repl.run = AsyncMock()
         mock_repl_cls.return_value = mock_repl
+        mock_run.side_effect = _run_coroutine_silently
 
         cli = Repl(session_socket="/tmp/test.sock")
         cli()
@@ -98,8 +107,12 @@ class TestReplMain:
         """Test main function exists."""
         assert callable(main)
 
+    @pytest.mark.filterwarnings(
+        "ignore:coroutine 'AsyncMockMixin._execute_mock_call' was never awaited:RuntimeWarning"
+    )
     @patch("psi_agent.channel.repl.cli.tyro.cli")
     def test_main_calls_tyro(self, mock_cli: MagicMock) -> None:
         """Test main calls tyro.cli."""
+        mock_cli.return_value = MagicMock(return_value=None)
         main()
         mock_cli.assert_called_once_with(Repl)

--- a/tests/channel/repl/test_cli.py
+++ b/tests/channel/repl/test_cli.py
@@ -107,9 +107,6 @@ class TestReplMain:
         """Test main function exists."""
         assert callable(main)
 
-    @pytest.mark.filterwarnings(
-        "ignore:coroutine 'AsyncMockMixin._execute_mock_call' was never awaited:RuntimeWarning"
-    )
     @patch("psi_agent.channel.repl.cli.tyro.cli")
     def test_main_calls_tyro(self, mock_cli: MagicMock) -> None:
         """Test main calls tyro.cli."""

--- a/tests/channel/repl/test_client.py
+++ b/tests/channel/repl/test_client.py
@@ -326,3 +326,242 @@ class TestReplClient:
 
                 assert "Error" in result
                 assert "timeout" in result.lower()
+
+
+class TestReplClientNullEmptyContent:
+    """Tests for ReplClient handling null/empty content in responses."""
+
+    @pytest.fixture
+    def config(self) -> ReplConfig:
+        """Create test config."""
+        return ReplConfig(session_socket="/tmp/test.sock")
+
+    @pytest.fixture
+    def client(self, config: ReplConfig) -> ReplClient:
+        """Create test client."""
+        return ReplClient(config)
+
+    @pytest.mark.asyncio
+    async def test_streaming_null_content_in_delta_skipped(self, client: ReplClient) -> None:
+        """Null content in streaming delta is skipped (not appended)."""
+        sse_lines = [
+            b'data: {"choices":[{"delta":{"content":null}}]}\n',
+            b'data: {"choices":[{"delta":{"content":"Hello"}}]}\n',
+            b"data: [DONE]\n",
+        ]
+
+        async def async_iter():
+            for line in sse_lines:
+                yield line
+
+        mock_response = MagicMock()
+        mock_response.status = 200
+        mock_response.content = async_iter()
+
+        with (
+            patch("aiohttp.UnixConnector") as mock_connector,
+            patch("aiohttp.ClientSession") as mock_session,
+        ):
+            mock_connector_instance = AsyncMock()
+            mock_connector_instance.close = AsyncMock()
+            mock_connector.return_value = mock_connector_instance
+
+            mock_session_instance = MagicMock()
+            mock_session_instance.post = MagicMock(
+                return_value=MagicMock(__aenter__=AsyncMock(return_value=mock_response))
+            )
+            mock_session_instance.close = AsyncMock()
+            mock_session.return_value = mock_session_instance
+
+            async with client:
+                result = await client.send_message_stream("Hi")
+                # null content is skipped, only "Hello" is returned
+                assert result == "Hello"
+
+    @pytest.mark.asyncio
+    async def test_streaming_empty_string_content_in_delta_handled(
+        self, client: ReplClient
+    ) -> None:
+        """Empty string content in streaming delta is handled."""
+        sse_lines = [
+            b'data: {"choices":[{"delta":{"content":""}}]}\n',
+            b'data: {"choices":[{"delta":{"content":"Hello"}}]}\n',
+            b"data: [DONE]\n",
+        ]
+
+        async def async_iter():
+            for line in sse_lines:
+                yield line
+
+        mock_response = MagicMock()
+        mock_response.status = 200
+        mock_response.content = async_iter()
+
+        with (
+            patch("aiohttp.UnixConnector") as mock_connector,
+            patch("aiohttp.ClientSession") as mock_session,
+        ):
+            mock_connector_instance = AsyncMock()
+            mock_connector_instance.close = AsyncMock()
+            mock_connector.return_value = mock_connector_instance
+
+            mock_session_instance = MagicMock()
+            mock_session_instance.post = MagicMock(
+                return_value=MagicMock(__aenter__=AsyncMock(return_value=mock_response))
+            )
+            mock_session_instance.close = AsyncMock()
+            mock_session.return_value = mock_session_instance
+
+            async with client:
+                result = await client.send_message_stream("Hi")
+                # Empty string is appended but doesn't affect result
+                assert result == "Hello"
+
+    @pytest.mark.asyncio
+    async def test_non_streaming_null_content_returns_empty_string(
+        self, client: ReplClient
+    ) -> None:
+        """Null content in non-streaming response returns empty string."""
+        mock_response = MagicMock()
+        mock_response.status = 200
+        mock_response.json = AsyncMock(return_value={"choices": [{"message": {"content": None}}]})
+
+        with (
+            patch("aiohttp.UnixConnector") as mock_connector,
+            patch("aiohttp.ClientSession") as mock_session,
+        ):
+            mock_connector_instance = AsyncMock()
+            mock_connector_instance.close = AsyncMock()
+            mock_connector.return_value = mock_connector_instance
+
+            mock_session_instance = MagicMock()
+            mock_session_instance.post = MagicMock(
+                return_value=MagicMock(__aenter__=AsyncMock(return_value=mock_response))
+            )
+            mock_session_instance.close = AsyncMock()
+            mock_session.return_value = mock_session_instance
+
+            async with client:
+                result = await client.send_message("Hi")
+                assert result == ""
+
+
+class TestReplClientReasoningAndMissingFields:
+    """Tests for ReplClient handling reasoning field and missing fields."""
+
+    @pytest.fixture
+    def config(self) -> ReplConfig:
+        """Create test config."""
+        return ReplConfig(session_socket="/tmp/test.sock")
+
+    @pytest.fixture
+    def client(self, config: ReplConfig) -> ReplClient:
+        """Create test client."""
+        return ReplClient(config)
+
+    @pytest.mark.asyncio
+    async def test_streaming_reasoning_field_handled(self, client: ReplClient) -> None:
+        """Reasoning field in streaming delta is handled without crash."""
+        sse_lines = [
+            b'data: {"choices":[{"delta":{"reasoning":"thinking...","content":"Hello"}}]}\n',
+            b"data: [DONE]\n",
+        ]
+
+        async def async_iter():
+            for line in sse_lines:
+                yield line
+
+        mock_response = MagicMock()
+        mock_response.status = 200
+        mock_response.content = async_iter()
+
+        with (
+            patch("aiohttp.UnixConnector") as mock_connector,
+            patch("aiohttp.ClientSession") as mock_session,
+        ):
+            mock_connector_instance = AsyncMock()
+            mock_connector_instance.close = AsyncMock()
+            mock_connector.return_value = mock_connector_instance
+
+            mock_session_instance = MagicMock()
+            mock_session_instance.post = MagicMock(
+                return_value=MagicMock(__aenter__=AsyncMock(return_value=mock_response))
+            )
+            mock_session_instance.close = AsyncMock()
+            mock_session.return_value = mock_session_instance
+
+            async with client:
+                result = await client.send_message_stream("Hi")
+                assert result == "Hello"
+
+    @pytest.mark.asyncio
+    async def test_streaming_empty_choices_list_skipped(self, client: ReplClient) -> None:
+        """Empty choices list in streaming chunk is skipped."""
+        sse_lines = [
+            b'data: {"choices":[]}\n',
+            b'data: {"choices":[{"delta":{"content":"Hello"}}]}\n',
+            b"data: [DONE]\n",
+        ]
+
+        async def async_iter():
+            for line in sse_lines:
+                yield line
+
+        mock_response = MagicMock()
+        mock_response.status = 200
+        mock_response.content = async_iter()
+
+        with (
+            patch("aiohttp.UnixConnector") as mock_connector,
+            patch("aiohttp.ClientSession") as mock_session,
+        ):
+            mock_connector_instance = AsyncMock()
+            mock_connector_instance.close = AsyncMock()
+            mock_connector.return_value = mock_connector_instance
+
+            mock_session_instance = MagicMock()
+            mock_session_instance.post = MagicMock(
+                return_value=MagicMock(__aenter__=AsyncMock(return_value=mock_response))
+            )
+            mock_session_instance.close = AsyncMock()
+            mock_session.return_value = mock_session_instance
+
+            async with client:
+                result = await client.send_message_stream("Hi")
+                assert result == "Hello"
+
+    @pytest.mark.asyncio
+    async def test_streaming_missing_delta_key_no_crash(self, client: ReplClient) -> None:
+        """Missing delta key in streaming chunk does not crash."""
+        sse_lines = [
+            b'data: {"choices":[{}]}\n',
+            b'data: {"choices":[{"delta":{"content":"Hello"}}]}\n',
+            b"data: [DONE]\n",
+        ]
+
+        async def async_iter():
+            for line in sse_lines:
+                yield line
+
+        mock_response = MagicMock()
+        mock_response.status = 200
+        mock_response.content = async_iter()
+
+        with (
+            patch("aiohttp.UnixConnector") as mock_connector,
+            patch("aiohttp.ClientSession") as mock_session,
+        ):
+            mock_connector_instance = AsyncMock()
+            mock_connector_instance.close = AsyncMock()
+            mock_connector.return_value = mock_connector_instance
+
+            mock_session_instance = MagicMock()
+            mock_session_instance.post = MagicMock(
+                return_value=MagicMock(__aenter__=AsyncMock(return_value=mock_response))
+            )
+            mock_session_instance.close = AsyncMock()
+            mock_session.return_value = mock_session_instance
+
+            async with client:
+                result = await client.send_message_stream("Hi")
+                assert result == "Hello"

--- a/tests/channel/repl/test_repl.py
+++ b/tests/channel/repl/test_repl.py
@@ -9,6 +9,7 @@ import pytest
 from prompt_toolkit.history import FileHistory
 
 from psi_agent.channel.repl.config import ReplConfig
+from psi_agent.channel.repl.client import ReplClient
 from psi_agent.channel.repl.repl import Repl, _ensure_history_dir
 
 
@@ -72,7 +73,12 @@ class TestRepl:
         async def mock_read() -> str | None:
             return next(input_iter, None)
 
-        with patch.object(repl, "_read_input", mock_read), patch("builtins.print") as mock_print:
+        with (
+            patch.object(ReplClient, "__aenter__", AsyncMock(return_value=MagicMock())),
+            patch.object(ReplClient, "__aexit__", AsyncMock()),
+            patch.object(repl, "_read_input", mock_read),
+            patch("builtins.print") as mock_print,
+        ):
             await repl.run()
 
             # Check goodbye message was printed

--- a/tests/channel/repl/test_repl.py
+++ b/tests/channel/repl/test_repl.py
@@ -8,8 +8,8 @@ import anyio
 import pytest
 from prompt_toolkit.history import FileHistory
 
-from psi_agent.channel.repl.config import ReplConfig
 from psi_agent.channel.repl.client import ReplClient
+from psi_agent.channel.repl.config import ReplConfig
 from psi_agent.channel.repl.repl import Repl, _ensure_history_dir
 
 

--- a/tests/channel/telegram/test_bot_streaming.py
+++ b/tests/channel/telegram/test_bot_streaming.py
@@ -1532,3 +1532,213 @@ class TestTypingIndicatorPeriodically:
 
         # Task should be cancelled
         assert task.cancelled()
+
+
+class TestTelegramBotStop:
+    """Tests for TelegramBot._stop method."""
+
+    @pytest.mark.asyncio
+    async def test_stop_with_running_application(self):
+        """Test _stop gracefully stops a running application."""
+        config = TelegramConfig(token="test-token", session_socket="/tmp/test.sock", stream=True)
+        bot = TelegramBot(config)
+
+        # Create a mock application
+        mock_app = MagicMock()
+        mock_app.updater = MagicMock()
+        mock_app.updater.stop = AsyncMock()
+        mock_app.stop = AsyncMock()
+        mock_app.shutdown = AsyncMock()
+
+        bot._app = mock_app
+
+        await bot._stop()
+
+        mock_app.updater.stop.assert_called_once()
+        mock_app.stop.assert_called_once()
+        mock_app.shutdown.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_stop_when_app_is_none(self):
+        """Test _stop does nothing when app is None."""
+        config = TelegramConfig(token="test-token", session_socket="/tmp/test.sock", stream=True)
+        bot = TelegramBot(config)
+        bot._app = None
+
+        # Should not raise any error
+        await bot._stop()
+
+
+class TestSplitMessageEdgeCases:
+    """Tests for split_message edge cases."""
+
+    def test_split_newline_at_midpoint(self):
+        """Test split with newline exactly at midpoint of max_length."""
+        max_len = 10
+        # Newline at position 5 (midpoint of 10)
+        # Condition is newline_pos > max_length // 2, so 5 > 5 is False
+        # Newline at midpoint is NOT used for split
+        text = "aaaaa\nbbbbb"
+        result = split_message(text, max_length=max_len)
+        assert len(result) == 2
+        # Since newline at midpoint is not used, split happens at max_length
+        assert len(result[0]) == max_len
+        assert "".join(result) == text
+
+    def test_split_space_at_midpoint(self):
+        """Test split with space exactly at midpoint of max_length."""
+        max_len = 10
+        # Space at position 5 (midpoint of 10), no newline
+        # Condition is space_pos > max_length // 2, so 5 > 5 is False
+        # Space at midpoint is NOT used for split
+        text = "aaaaa bbbbb"
+        result = split_message(text, max_length=max_len)
+        assert len(result) == 2
+        # Since space at midpoint is not used, split happens at max_length
+        assert len(result[0]) == max_len
+        assert "".join(result) == text
+
+    def test_split_very_small_max_length(self):
+        """Test split with very small max_length."""
+        text = "hello world"
+        result = split_message(text, max_length=5)
+        # Should split into chunks of at most 5 characters
+        for chunk in result:
+            assert len(chunk) <= 5
+        assert "".join(result) == text
+
+    def test_split_max_length_one(self):
+        """Test split with max_length of 1."""
+        text = "abc"
+        result = split_message(text, max_length=1)
+        assert result == ["a", "b", "c"]
+        assert "".join(result) == text
+
+
+class TestTelegramBotStreamingFallback:
+    """Tests for TelegramBot streaming fallback and handler edge cases."""
+
+    @pytest.mark.asyncio
+    async def test_streaming_empty_buffer_nonempty_response_fallback(self):
+        """Test streaming with empty content_buffer and non-empty response uses fallback."""
+        config = TelegramConfig(
+            token="test-token", session_socket="/tmp/test.sock", stream=True, stream_interval=1.0
+        )
+        bot = TelegramBot(config)
+
+        mock_message = AsyncMock()
+        mock_message.text = "Hello"
+        mock_message.reply_text = AsyncMock()
+
+        mock_sent_message = AsyncMock()
+        mock_sent_message.edit_text = AsyncMock()
+        mock_message.reply_text.return_value = mock_sent_message
+
+        mock_update = MagicMock()
+        mock_update.message = mock_message
+        mock_update.effective_user = MagicMock(id=123)
+
+        final_content = None
+
+        async def mock_edit(text: str) -> None:
+            nonlocal final_content
+            final_content = text
+
+        mock_sent_message.edit_text.side_effect = mock_edit
+
+        # Mock streaming that returns content without calling on_chunk
+        async def mock_stream(_message: str, _user_id: str, on_chunk) -> str:
+            # Don't call on_chunk - buffer stays empty
+            return "Fallback content"
+
+        with patch.object(bot.client, "send_message_stream", mock_stream):
+            async with bot.client:
+                await bot._handle_message_streaming(mock_update, "telegram:123", "Hello")
+
+        # When buffer is empty, final_content should use response as fallback
+        assert final_content == "Fallback content"
+
+    @pytest.mark.asyncio
+    async def test_non_streaming_with_three_plus_split_chunks(self):
+        """Test non-streaming handler with 3+ split chunks."""
+        config = TelegramConfig(token="test-token", session_socket="/tmp/test.sock", stream=False)
+        bot = TelegramBot(config)
+
+        mock_message = AsyncMock()
+        mock_message.text = "Hello"
+        mock_message.reply_text = AsyncMock()
+
+        mock_update = MagicMock()
+        mock_update.message = mock_message
+        mock_update.effective_user = MagicMock(id=123)
+
+        # Create a response that will split into 3+ chunks
+        long_response = "a" * 10000  # Will split into 3 chunks at 4096 limit
+        with patch.object(bot.client, "send_message", AsyncMock(return_value=long_response)):
+            async with bot.client:
+                await bot._handle_message_non_streaming(mock_update, "telegram:123", "Hello")
+
+        # Should be called 3 times for split message
+        assert mock_message.reply_text.call_count == 3
+
+    @pytest.mark.asyncio
+    async def test_start_without_proxy(self):
+        """Test start registers handlers without proxy configuration."""
+        config = TelegramConfig(token="test-token", session_socket="/tmp/test.sock", stream=True)
+        bot = TelegramBot(config)
+
+        # Mock the Application building to succeed
+        mock_app = MagicMock()
+        mock_app.initialize = AsyncMock()
+        mock_app.start = AsyncMock()
+        mock_app.stop = AsyncMock()
+        mock_app.shutdown = AsyncMock()
+        mock_app.add_handler = MagicMock()
+        mock_app.updater = MagicMock()
+        mock_app.updater.start_polling = AsyncMock()
+        mock_app.updater.stop = AsyncMock()
+
+        mock_builder = MagicMock()
+        mock_builder.token.return_value = mock_builder
+        mock_builder.build.return_value = mock_app
+
+        # Set stop_event so start() doesn't hang
+        bot._stop_event.set()
+
+        with patch("psi_agent.channel.telegram.bot.Application.builder", return_value=mock_builder):
+            await bot.start()
+
+        # Verify handlers were registered
+        assert mock_app.add_handler.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_start_registers_handlers(self):
+        """Test start registers both command and message handlers."""
+        config = TelegramConfig(token="test-token", session_socket="/tmp/test.sock", stream=True)
+        bot = TelegramBot(config)
+
+        mock_app = MagicMock()
+        mock_app.initialize = AsyncMock()
+        mock_app.start = AsyncMock()
+        mock_app.stop = AsyncMock()
+        mock_app.shutdown = AsyncMock()
+        mock_app.add_handler = MagicMock()
+        mock_app.updater = MagicMock()
+        mock_app.updater.start_polling = AsyncMock()
+        mock_app.updater.stop = AsyncMock()
+
+        mock_builder = MagicMock()
+        mock_builder.token.return_value = mock_builder
+        mock_builder.build.return_value = mock_app
+
+        bot._stop_event.set()
+
+        with patch("psi_agent.channel.telegram.bot.Application.builder", return_value=mock_builder):
+            await bot.start()
+
+        # Should register 2 handlers: /start command and text message handler
+        assert mock_app.add_handler.call_count == 2
+        # First handler should be a CommandHandler
+        from telegram.ext import CommandHandler
+
+        assert isinstance(mock_app.add_handler.call_args_list[0][0][0], CommandHandler)

--- a/tests/channel/telegram/test_cli.py
+++ b/tests/channel/telegram/test_cli.py
@@ -7,6 +7,12 @@ from unittest.mock import AsyncMock, MagicMock, patch
 from psi_agent.channel.telegram.cli import Telegram, main
 
 
+def _run_coroutine_silently(coro):
+    """Side effect for mocked asyncio.run that closes the coroutine to prevent warnings."""
+    coro.close()
+    return None
+
+
 def test_telegram_cli_without_proxy():
     """Test Telegram CLI without proxy argument."""
     cli = Telegram(token="test-token", session_socket="/tmp/test.sock")
@@ -110,6 +116,7 @@ class TestTelegramCliCall:
         mock_bot = MagicMock()
         mock_bot.start = AsyncMock()
         mock_bot_cls.return_value = mock_bot
+        mock_run.side_effect = _run_coroutine_silently
 
         cli = Telegram(
             token="test-token",
@@ -143,6 +150,7 @@ class TestTelegramCliCall:
         mock_bot = MagicMock()
         mock_bot.start = AsyncMock()
         mock_bot_cls.return_value = mock_bot
+        mock_run.side_effect = _run_coroutine_silently
 
         cli = Telegram(token="test-token", session_socket="/tmp/test.sock")
         cli()
@@ -164,6 +172,7 @@ class TestTelegramCliCall:
         mock_bot = MagicMock()
         mock_bot.start = AsyncMock()
         mock_bot_cls.return_value = mock_bot
+        mock_run.side_effect = _run_coroutine_silently
 
         cli = Telegram(token="test-token", session_socket="/tmp/test.sock")
         cli()
@@ -177,5 +186,7 @@ class TestTelegramMain:
     @patch("psi_agent.channel.telegram.cli.tyro.cli")
     def test_main_calls_tyro(self, mock_cli: MagicMock) -> None:
         """Test main calls tyro.cli."""
+        # Make tyro.cli return a callable that returns None (not a coroutine)
+        mock_cli.return_value = MagicMock(return_value=None)
         main()
         mock_cli.assert_called_once_with(Telegram)

--- a/tests/channel/telegram/test_client.py
+++ b/tests/channel/telegram/test_client.py
@@ -318,3 +318,235 @@ class TestTelegramClient:
             result = await client.send_message_stream("Hi", "telegram:123")
 
             assert result == "Test"
+
+
+class TestTelegramClientNullEmptyContent:
+    """Tests for TelegramClient handling null/empty content in responses."""
+
+    @pytest.fixture
+    def null_config(self):
+        """Create test config."""
+        return TelegramConfig(token="test-token", session_socket="/tmp/test.sock")
+
+    @pytest.fixture
+    def null_client(self, null_config):
+        """Create test client."""
+        return TelegramClient(null_config)
+
+    @pytest.mark.asyncio
+    async def test_streaming_null_content_in_delta_skipped(self, null_client):
+        """Null content in streaming delta is skipped (not appended)."""
+        sse_lines = [
+            b'data: {"choices":[{"delta":{"content":null}}]}\n',
+            b'data: {"choices":[{"delta":{"content":"Hello"}}]}\n',
+            b"data: [DONE]\n",
+        ]
+
+        async def async_iter():
+            for line in sse_lines:
+                yield line
+
+        mock_response = MagicMock()
+        mock_response.status = 200
+        mock_response.content = async_iter()
+
+        async with null_client:
+            null_client._session.post = MagicMock(
+                return_value=AsyncMock(__aenter__=AsyncMock(return_value=mock_response))
+            )
+
+            result = await null_client.send_message_stream("Hi", "telegram:123")
+            assert result == "Hello"
+
+    @pytest.mark.asyncio
+    async def test_streaming_empty_string_content_in_delta_handled(self, null_client):
+        """Empty string content in streaming delta is handled."""
+        sse_lines = [
+            b'data: {"choices":[{"delta":{"content":""}}]}\n',
+            b'data: {"choices":[{"delta":{"content":"Hello"}}]}\n',
+            b"data: [DONE]\n",
+        ]
+
+        async def async_iter():
+            for line in sse_lines:
+                yield line
+
+        mock_response = MagicMock()
+        mock_response.status = 200
+        mock_response.content = async_iter()
+
+        async with null_client:
+            null_client._session.post = MagicMock(
+                return_value=AsyncMock(__aenter__=AsyncMock(return_value=mock_response))
+            )
+
+            result = await null_client.send_message_stream("Hi", "telegram:123")
+            assert result == "Hello"
+
+    @pytest.mark.asyncio
+    async def test_non_streaming_null_content_returns_empty_string(self, null_client):
+        """Null content in non-streaming response returns empty string."""
+        mock_response = MagicMock()
+        mock_response.status = 200
+        mock_response.json = AsyncMock(return_value={"choices": [{"message": {"content": None}}]})
+
+        async with null_client:
+            null_client._session.post = MagicMock(
+                return_value=AsyncMock(__aenter__=AsyncMock(return_value=mock_response))
+            )
+
+            result = await null_client.send_message("Hi", "telegram:123")
+            assert result == ""
+
+
+class TestTelegramClientReasoningAndMissingFields:
+    """Tests for TelegramClient handling reasoning field and missing fields."""
+
+    @pytest.fixture
+    def missing_config(self):
+        """Create test config."""
+        return TelegramConfig(token="test-token", session_socket="/tmp/test.sock")
+
+    @pytest.fixture
+    def missing_client(self, missing_config):
+        """Create test client."""
+        return TelegramClient(missing_config)
+
+    @pytest.mark.asyncio
+    async def test_streaming_reasoning_field_handled(self, missing_client):
+        """Reasoning field in streaming delta is handled without crash."""
+        sse_lines = [
+            b'data: {"choices":[{"delta":{"reasoning":"thinking...","content":"Hello"}}]}\n',
+            b"data: [DONE]\n",
+        ]
+
+        async def async_iter():
+            for line in sse_lines:
+                yield line
+
+        mock_response = MagicMock()
+        mock_response.status = 200
+        mock_response.content = async_iter()
+
+        async with missing_client:
+            missing_client._session.post = MagicMock(
+                return_value=AsyncMock(__aenter__=AsyncMock(return_value=mock_response))
+            )
+
+            result = await missing_client.send_message_stream("Hi", "telegram:123")
+            assert result == "Hello"
+
+    @pytest.mark.asyncio
+    async def test_streaming_empty_choices_list_skipped(self, missing_client):
+        """Empty choices list in streaming chunk is skipped."""
+        sse_lines = [
+            b'data: {"choices":[]}\n',
+            b'data: {"choices":[{"delta":{"content":"Hello"}}]}\n',
+            b"data: [DONE]\n",
+        ]
+
+        async def async_iter():
+            for line in sse_lines:
+                yield line
+
+        mock_response = MagicMock()
+        mock_response.status = 200
+        mock_response.content = async_iter()
+
+        async with missing_client:
+            missing_client._session.post = MagicMock(
+                return_value=AsyncMock(__aenter__=AsyncMock(return_value=mock_response))
+            )
+
+            result = await missing_client.send_message_stream("Hi", "telegram:123")
+            assert result == "Hello"
+
+    @pytest.mark.asyncio
+    async def test_streaming_missing_delta_key_no_crash(self, missing_client):
+        """Missing delta key in streaming chunk does not crash."""
+        sse_lines = [
+            b'data: {"choices":[{}]}\n',
+            b'data: {"choices":[{"delta":{"content":"Hello"}}]}\n',
+            b"data: [DONE]\n",
+        ]
+
+        async def async_iter():
+            for line in sse_lines:
+                yield line
+
+        mock_response = MagicMock()
+        mock_response.status = 200
+        mock_response.content = async_iter()
+
+        async with missing_client:
+            missing_client._session.post = MagicMock(
+                return_value=AsyncMock(__aenter__=AsyncMock(return_value=mock_response))
+            )
+
+            result = await missing_client.send_message_stream("Hi", "telegram:123")
+            assert result == "Hello"
+
+
+class TestTelegramClientUserId:
+    """Tests for TelegramClient user_id field in request body."""
+
+    @pytest.fixture
+    def user_config(self):
+        """Create test config."""
+        return TelegramConfig(token="test-token", session_socket="/tmp/test.sock")
+
+    @pytest.fixture
+    def user_client(self, user_config):
+        """Create test client."""
+        return TelegramClient(user_config)
+
+    @pytest.mark.asyncio
+    async def test_send_message_includes_user_field(self, user_client):
+        """send_message includes user field in request body."""
+        mock_response = MagicMock()
+        mock_response.status = 200
+        mock_response.json = AsyncMock(
+            return_value={"choices": [{"message": {"content": "Hello"}}]}
+        )
+
+        async with user_client:
+            user_client._session.post = MagicMock(
+                return_value=AsyncMock(__aenter__=AsyncMock(return_value=mock_response))
+            )
+
+            await user_client.send_message("Hi", "telegram:123")
+
+            # Verify post was called with json containing user field
+            call_args = user_client._session.post.call_args
+            json_body = call_args.kwargs.get("json", {})
+            assert "user" in json_body
+            assert json_body["user"] == "telegram:123"
+
+    @pytest.mark.asyncio
+    async def test_send_message_stream_includes_user_field(self, user_client):
+        """send_message_stream includes user field in request body."""
+        sse_lines = [
+            b'data: {"choices":[{"delta":{"content":"Hello"}}]}\n',
+            b"data: [DONE]\n",
+        ]
+
+        async def async_iter():
+            for line in sse_lines:
+                yield line
+
+        mock_response = MagicMock()
+        mock_response.status = 200
+        mock_response.content = async_iter()
+
+        async with user_client:
+            user_client._session.post = MagicMock(
+                return_value=AsyncMock(__aenter__=AsyncMock(return_value=mock_response))
+            )
+
+            await user_client.send_message_stream("Hi", "telegram:123")
+
+            # Verify post was called with json containing user field
+            call_args = user_client._session.post.call_args
+            json_body = call_args.kwargs.get("json", {})
+            assert "user" in json_body
+            assert json_body["user"] == "telegram:123"

--- a/tests/session/schedule/test_loader.py
+++ b/tests/session/schedule/test_loader.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import tempfile
+from datetime import datetime
 
 import anyio
 import pytest
@@ -171,3 +172,57 @@ Task 2 content.""")
             schedules = await load_schedules(workspace)
 
             assert schedules == []
+
+
+class TestParseFrontmatterEdgeCases:
+    """Edge case tests for parse_frontmatter."""
+
+    def test_invalid_cron_expression_raises_from_croniter(self) -> None:
+        """Test that an invalid cron expression in frontmatter is parsed but fails at croniter."""
+        content = """---
+name: bad-cron
+cron: "not a valid cron"
+---
+
+Content."""
+        frontmatter, _remaining = parse_frontmatter(content)
+
+        # parse_frontmatter itself does not validate cron; it just parses the text
+        assert frontmatter["cron"] == "not a valid cron"
+        # But creating a Schedule with it will fail at get_next_run
+        import croniter
+
+        with pytest.raises(croniter.CroniterBadCronError):
+            croniter.croniter(frontmatter["cron"], datetime.now())
+
+    def test_frontmatter_with_blank_lines_between_pairs(self) -> None:
+        """Test frontmatter with blank lines between key-value pairs."""
+        content = """---
+name: test-task
+
+description: A test task
+
+cron: "0 9 * * *"
+---
+
+Content."""
+        frontmatter, remaining = parse_frontmatter(content)
+
+        assert frontmatter["name"] == "test-task"
+        assert frontmatter["description"] == "A test task"
+        assert frontmatter["cron"] == "0 9 * * *"
+
+    def test_frontmatter_value_containing_hash_character(self) -> None:
+        """Test frontmatter value containing hash character."""
+        content = """---
+name: task-with-hash
+description: "Use # for comments"
+cron: "0 9 * * *"
+---
+
+Content."""
+        frontmatter, remaining = parse_frontmatter(content)
+
+        assert frontmatter["name"] == "task-with-hash"
+        assert frontmatter["description"] == "Use # for comments"
+        assert frontmatter["cron"] == "0 9 * * *"

--- a/tests/session/schedule/test_schedule.py
+++ b/tests/session/schedule/test_schedule.py
@@ -127,11 +127,13 @@ class TestScheduleExecutorExceptionAndRetry:
             executor._running = False
             return 0.0
 
-        with patch.object(
-            schedule, "get_seconds_until_next_run", side_effect=get_seconds_side_effect
-        ), patch.object(schedule, "get_next_run", return_value=datetime.now()), patch(
-            "psi_agent.session.schedule.asyncio.sleep", new_callable=AsyncMock
-        ) as mock_sleep:
+        with (
+            patch.object(
+                schedule, "get_seconds_until_next_run", side_effect=get_seconds_side_effect
+            ),
+            patch.object(schedule, "get_next_run", return_value=datetime.now()),
+            patch("psi_agent.session.schedule.asyncio.sleep", new_callable=AsyncMock) as mock_sleep,
+        ):
             await executor._schedule_loop(schedule)
 
         # First call raised exception, second call succeeded
@@ -196,9 +198,7 @@ class TestScheduleExecutorExceptionAndRetry:
         with (
             patch.object(schedule, "get_seconds_until_next_run", return_value=0.0),
             patch.object(schedule, "get_next_run", return_value=datetime.now()),
-            patch(
-                "psi_agent.session.schedule.asyncio.sleep", new_callable=AsyncMock
-            ) as mock_sleep,
+            patch("psi_agent.session.schedule.asyncio.sleep", new_callable=AsyncMock) as mock_sleep,
         ):
             await executor._schedule_loop(schedule)
 

--- a/tests/session/schedule/test_schedule.py
+++ b/tests/session/schedule/test_schedule.py
@@ -2,11 +2,14 @@
 
 from __future__ import annotations
 
+import asyncio
 from datetime import datetime
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import anyio
+import pytest
 
-from psi_agent.session.schedule import Schedule
+from psi_agent.session.schedule import Schedule, ScheduleExecutor
 
 
 class TestSchedule:
@@ -93,3 +96,274 @@ class TestSchedule:
 
         assert next_run.minute == 30
         assert next_run.hour == 14
+
+
+class TestScheduleExecutorExceptionAndRetry:
+    """Tests for _schedule_loop exception handling, CancelledError, and immediate execution."""
+
+    @pytest.mark.asyncio
+    async def test_schedule_loop_exception_sleeps_and_retries(self) -> None:
+        """Test that _schedule_loop sleeps 60s on exception and retries."""
+        mock_runner = MagicMock()
+        mock_runner.process_request = AsyncMock()
+
+        schedule = Schedule(
+            name="test_task",
+            cron="* * * * *",
+            content="Do something",
+            task_dir=anyio.Path("/tmp/test"),
+        )
+        executor = ScheduleExecutor([schedule], mock_runner)
+        executor._running = True
+
+        call_count = 0
+
+        def get_seconds_side_effect():
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                raise Exception("Transient error")
+            # On subsequent calls, stop the loop after execution
+            executor._running = False
+            return 0.0
+
+        with patch.object(
+            schedule, "get_seconds_until_next_run", side_effect=get_seconds_side_effect
+        ), patch.object(schedule, "get_next_run", return_value=datetime.now()), patch(
+            "psi_agent.session.schedule.asyncio.sleep", new_callable=AsyncMock
+        ) as mock_sleep:
+            await executor._schedule_loop(schedule)
+
+        # First call raised exception, second call succeeded
+        assert call_count == 2
+        # After exception, sleep(60) is called for retry
+        mock_sleep.assert_any_call(60)
+
+    @pytest.mark.asyncio
+    async def test_schedule_loop_cancelled_error_clean_exit(self) -> None:
+        """Test that CancelledError causes clean exit from _schedule_loop."""
+        mock_runner = MagicMock()
+
+        schedule = Schedule(
+            name="test_task",
+            cron="* * * * *",
+            content="Do something",
+            task_dir=anyio.Path("/tmp/test"),
+        )
+        executor = ScheduleExecutor([schedule], mock_runner)
+        executor._running = True
+
+        async def raise_cancelled(*args, **kwargs):
+            raise asyncio.CancelledError()
+
+        mock_runner.process_request = AsyncMock(side_effect=raise_cancelled)
+
+        with (
+            patch.object(schedule, "get_seconds_until_next_run", return_value=0.0),
+            patch.object(schedule, "get_next_run", return_value=datetime.now()),
+            patch("psi_agent.session.schedule.asyncio.sleep", new_callable=AsyncMock),
+        ):
+            await executor._schedule_loop(schedule)
+
+        # CancelledError should cause clean exit after the call that raised it
+        mock_runner.process_request.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_schedule_loop_immediate_execution_when_due(self) -> None:
+        """Test immediate execution when next run is due (0 seconds delay)."""
+        mock_runner = MagicMock()
+        mock_runner.process_request = AsyncMock()
+
+        schedule = Schedule(
+            name="test_task",
+            cron="* * * * *",
+            content="Do something",
+            task_dir=anyio.Path("/tmp/test"),
+        )
+        executor = ScheduleExecutor([schedule], mock_runner)
+        executor._running = True
+
+        call_count = 0
+
+        async def stop_after_one(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            executor._running = False
+
+        mock_runner.process_request = AsyncMock(side_effect=stop_after_one)
+
+        # Mock get_seconds_until_next_run to return 0 (immediate)
+        with (
+            patch.object(schedule, "get_seconds_until_next_run", return_value=0.0),
+            patch.object(schedule, "get_next_run", return_value=datetime.now()),
+            patch(
+                "psi_agent.session.schedule.asyncio.sleep", new_callable=AsyncMock
+            ) as mock_sleep,
+        ):
+            await executor._schedule_loop(schedule)
+
+        assert call_count == 1
+        # sleep(0) should be called for immediate execution
+        mock_sleep.assert_called_once_with(0.0)
+
+
+class TestScheduleExecutorConcurrentOperation:
+    """Tests for concurrent operations on the schedule executor."""
+
+    @pytest.mark.asyncio
+    async def test_add_schedule_with_duplicate_name(self) -> None:
+        """Test that add_schedule with duplicate name creates a second task entry."""
+        mock_runner = MagicMock()
+        mock_runner.process_request = AsyncMock()
+
+        schedule1 = Schedule(
+            name="duplicate_task",
+            cron="0 9 * * *",
+            content="First",
+            task_dir=anyio.Path("/tmp/test1"),
+        )
+        schedule2 = Schedule(
+            name="duplicate_task",
+            cron="0 10 * * *",
+            content="Second",
+            task_dir=anyio.Path("/tmp/test2"),
+        )
+
+        executor = ScheduleExecutor([schedule1], mock_runner)
+        await executor.start()
+
+        # Adding a schedule with the same name should still add it
+        await executor.add_schedule(schedule2)
+
+        # Both schedules are in the list (no deduplication)
+        assert len(executor.schedules) == 2
+        # The _schedule_map maps name to task, so the second one overwrites
+        assert "duplicate_task" in executor._schedule_map
+
+        await executor.stop()
+
+    @pytest.mark.asyncio
+    async def test_add_schedule_when_executor_not_running(self) -> None:
+        """Test that add_schedule when executor not running only adds to list, no task created."""
+        mock_runner = MagicMock()
+        mock_runner.process_request = AsyncMock()
+
+        schedule = Schedule(
+            name="offline_task",
+            cron="0 9 * * *",
+            content="Test",
+            task_dir=anyio.Path("/tmp/test"),
+        )
+
+        executor = ScheduleExecutor([], mock_runner)
+        # Not started, so _running is False
+
+        await executor.add_schedule(schedule)
+
+        # Schedule should be in the list but no task created
+        assert len(executor.schedules) == 1
+        assert "offline_task" not in executor._schedule_map
+        assert len(executor._tasks) == 0
+
+    @pytest.mark.asyncio
+    async def test_remove_schedule_that_is_currently_executing(self) -> None:
+        """Test removing a schedule while its task is executing."""
+        mock_runner = MagicMock()
+        mock_runner.process_request = AsyncMock()
+
+        schedule = Schedule(
+            name="executing_task",
+            cron="* * * * *",
+            content="Do something",
+            task_dir=anyio.Path("/tmp/test"),
+        )
+        executor = ScheduleExecutor([schedule], mock_runner)
+        await executor.start()
+
+        # The task is running in the background; remove it
+        await executor.remove_schedule("executing_task")
+
+        assert len(executor.schedules) == 0
+        assert "executing_task" not in executor._schedule_map
+        assert len(executor._tasks) == 0
+
+        await executor.stop()
+
+    @pytest.mark.asyncio
+    async def test_update_schedule_that_is_currently_executing(self) -> None:
+        """Test updating a schedule while its task is executing."""
+        mock_runner = MagicMock()
+        mock_runner.process_request = AsyncMock()
+
+        schedule = Schedule(
+            name="running_task",
+            cron="0 9 * * *",
+            content="Original",
+            task_dir=anyio.Path("/tmp/test"),
+        )
+        executor = ScheduleExecutor([schedule], mock_runner)
+        await executor.start()
+
+        updated = Schedule(
+            name="running_task",
+            cron="0 10 * * *",
+            content="Updated",
+            task_dir=anyio.Path("/tmp/test"),
+        )
+        await executor.update_schedule(updated)
+
+        assert len(executor.schedules) == 1
+        assert executor.schedules[0].content == "Updated"
+        assert executor.schedules[0].cron == "0 10 * * *"
+
+        await executor.stop()
+
+
+class TestScheduleExecutorDoubleStartStop:
+    """Tests for double start and double stop behavior."""
+
+    @pytest.mark.asyncio
+    async def test_double_start_creates_duplicate_tasks(self) -> None:
+        """Test that calling start twice creates duplicate tasks (documents current behavior)."""
+        mock_runner = MagicMock()
+        mock_runner.process_request = AsyncMock()
+
+        schedule = Schedule(
+            name="test_task",
+            cron="0 9 * * *",
+            content="Test",
+            task_dir=anyio.Path("/tmp/test"),
+        )
+        executor = ScheduleExecutor([schedule], mock_runner)
+
+        await executor.start()
+        initial_task_count = len(executor._tasks)
+
+        # Call start again - currently creates duplicate tasks
+        await executor.start()
+
+        # Double start creates duplicate tasks since start() doesn't check for existing tasks
+        assert len(executor._tasks) == initial_task_count + 1
+
+        await executor.stop()
+
+    @pytest.mark.asyncio
+    async def test_double_stop_no_exception(self) -> None:
+        """Test that calling stop twice does not raise an exception."""
+        mock_runner = MagicMock()
+        mock_runner.process_request = AsyncMock()
+
+        schedule = Schedule(
+            name="test_task",
+            cron="0 9 * * *",
+            content="Test",
+            task_dir=anyio.Path("/tmp/test"),
+        )
+        executor = ScheduleExecutor([schedule], mock_runner)
+
+        await executor.start()
+        await executor.stop()
+
+        # Second stop should not raise any exception
+        await executor.stop()
+        assert executor._running is False

--- a/tests/session/test_cli.py
+++ b/tests/session/test_cli.py
@@ -8,6 +8,12 @@ from psi_agent.session.cli import Session, main
 from psi_agent.session.config import SessionConfig
 
 
+def _run_coroutine_silently(coro):
+    """Side effect for mocked asyncio.run that closes the coroutine to prevent warnings."""
+    coro.close()
+    return None
+
+
 class TestSessionCli:
     """Tests for session CLI dataclass."""
 
@@ -72,6 +78,7 @@ class TestSessionCliCall:
         mock_server.start = AsyncMock()
         mock_server.stop = AsyncMock()
         mock_server_cls.return_value = mock_server
+        mock_run.side_effect = _run_coroutine_silently
 
         session = Session(
             channel_socket="/tmp/channel.sock",
@@ -104,6 +111,7 @@ class TestSessionCliCall:
         mock_server.start = AsyncMock()
         mock_server.stop = AsyncMock()
         mock_server_cls.return_value = mock_server
+        mock_run.side_effect = _run_coroutine_silently
 
         session = Session(
             channel_socket="/tmp/channel.sock",
@@ -131,6 +139,7 @@ class TestSessionMain:
     @patch("psi_agent.session.cli.tyro.cli")
     def test_main_calls_tyro(self, mock_cli: MagicMock) -> None:
         """Test main calls tyro.cli."""
+        mock_cli.return_value = MagicMock(return_value=None)
         main()
         mock_cli.assert_called_once_with(Session)
 

--- a/tests/session/test_runner.py
+++ b/tests/session/test_runner.py
@@ -1550,3 +1550,582 @@ class TestParseStreamingResponse:
         with pytest.raises(RuntimeError, match="AI component error: Authentication failed"):
             async for _ in runner._parse_streaming_response(mock_response):
                 pass
+
+
+class TestRunConversationMultiRoundToolCalls:
+    """Tests for _run_conversation with multiple rounds of tool calls (T10)."""
+
+    @pytest.mark.asyncio
+    async def test_two_rounds_of_tool_calls(self, config):
+        """Test _run_conversation with two rounds of tool calls.
+
+        LLM returns tool call, then after receiving tool result,
+        returns another tool call, then finally returns text.
+        """
+        runner = SessionRunner(config)
+        async with runner:
+            # Create a tool
+            tool_file = config.tools_dir() / "echo.py"
+            await tool_file.write_text(
+                """
+async def tool(message: str) -> str:
+    '''Echo tool.
+
+    Args:
+        message: The message to echo.
+
+    Returns:
+        The echoed message.
+    '''
+    return message
+"""
+            )
+            tool_schema = await load_tool_from_file(tool_file)
+            if tool_schema:
+                runner.registry.register(tool_schema)
+
+            # First streaming response: tool call round 1
+            sse_lines_round1 = [
+                b'data: {"choices":[{"delta":{"tool_calls":[{"index":0,"id":"call_1",'
+                b'"function":{"name":"echo","arguments":"{\\"mes"}}]}}]}\n',
+                b'data: {"choices":[{"delta":{"tool_calls":[{"index":0,'
+                b'"function":{"arguments":"sage\\": \\"hello\\"}"}}]}}\n',
+                b"data: [DONE]\n",
+            ]
+
+            # Second streaming response: tool call round 2
+            sse_lines_round2 = [
+                b'data: {"choices":[{"delta":{"tool_calls":[{"index":0,"id":"call_2",'
+                b'"function":{"name":"echo","arguments":"{\\"mes"}}]}}]}\n',
+                b'data: {"choices":[{"delta":{"tool_calls":[{"index":0,'
+                b'"function":{"arguments":"sage\\": \\"world\\"}"}}]}}\n',
+                b"data: [DONE]\n",
+            ]
+
+            # Third streaming response: final text
+            sse_lines_final = [
+                b'data: {"choices":[{"delta":{"content":"All done"}}]}\n',
+                b'data: {"choices":[{"delta":{},"finish_reason":"stop"}]}\n',
+                b"data: [DONE]\n",
+            ]
+
+            call_count = 0
+
+            def make_async_iter(lines):
+                async def async_iter():
+                    for line in lines:
+                        yield line
+
+                return async_iter()
+
+            def mock_post_side_effect(*_args, **_kwargs):
+                nonlocal call_count
+                call_count += 1
+
+                mock_response = AsyncMock()
+                mock_response.status = 200
+                mock_response.__aenter__ = AsyncMock(return_value=mock_response)
+                mock_response.__aexit__ = AsyncMock(return_value=None)
+
+                if call_count == 1:
+                    mock_response.content = make_async_iter(sse_lines_round1)
+                elif call_count == 2:
+                    mock_response.content = make_async_iter(sse_lines_round2)
+                else:
+                    mock_response.content = make_async_iter(sse_lines_final)
+
+                return mock_response
+
+            with patch.object(runner.client, "post", side_effect=mock_post_side_effect):
+                messages = [{"role": "user", "content": "Test multi-round"}]
+                result = await runner._run_conversation(messages)
+
+                # Should have made 3 calls (2 tool call rounds + final response)
+                assert call_count == 3
+                assert "choices" in result
+                content = result["choices"][0]["message"]["content"]
+                # Both tool calls should have thinking blocks
+                assert content.count("<thinking>") == 2
+                assert "[Tool: echo]" in content
+                assert "All done" in content
+
+    @pytest.mark.asyncio
+    async def test_tool_name_not_in_registry(self, config):
+        """Test tool call with tool name not in registry returns error message.
+
+        The conversation should continue after the error.
+        """
+        runner = SessionRunner(config)
+        async with runner:
+            # No tools registered - any tool call will fail
+
+            # First streaming response: tool call with unknown tool
+            sse_lines_tool = [
+                b'data: {"choices":[{"delta":{"tool_calls":[{"index":0,"id":"call_1",'
+                b'"function":{"name":"nonexistent_tool","arguments":"{}"}}]}}]}\n',
+                b"data: [DONE]\n",
+            ]
+
+            # Second streaming response: final text after error
+            sse_lines_final = [
+                b'data: {"choices":[{"delta":{"content":"I see the tool failed"}}]}\n',
+                b'data: {"choices":[{"delta":{},"finish_reason":"stop"}]}\n',
+                b"data: [DONE]\n",
+            ]
+
+            call_count = 0
+
+            def make_async_iter(lines):
+                async def async_iter():
+                    for line in lines:
+                        yield line
+
+                return async_iter()
+
+            def mock_post_side_effect(*_args, **_kwargs):
+                nonlocal call_count
+                call_count += 1
+
+                mock_response = AsyncMock()
+                mock_response.status = 200
+                mock_response.__aenter__ = AsyncMock(return_value=mock_response)
+                mock_response.__aexit__ = AsyncMock(return_value=None)
+
+                if call_count == 1:
+                    mock_response.content = make_async_iter(sse_lines_tool)
+                else:
+                    mock_response.content = make_async_iter(sse_lines_final)
+
+                return mock_response
+
+            with patch.object(runner.client, "post", side_effect=mock_post_side_effect):
+                messages = [{"role": "user", "content": "Test unknown tool"}]
+                result = await runner._run_conversation(messages)
+
+                # Should have made 2 calls (tool call + final response)
+                assert call_count == 2
+                assert "choices" in result
+                content = result["choices"][0]["message"]["content"]
+                # The thinking block should contain the error message
+                assert "nonexistent_tool" in content
+                # Conversation should have continued
+                assert "I see the tool failed" in content
+
+    @pytest.mark.asyncio
+    async def test_tool_call_with_invalid_json_arguments(self, config):
+        """Test tool call with invalid JSON arguments returns error message.
+
+        The conversation should continue after the error.
+        """
+        runner = SessionRunner(config)
+        async with runner:
+            # Create a tool
+            tool_file = config.tools_dir() / "echo.py"
+            await tool_file.write_text(
+                """
+async def tool(message: str) -> str:
+    '''Echo tool.
+
+    Args:
+        message: The message to echo.
+
+    Returns:
+        The echoed message.
+    '''
+    return message
+"""
+            )
+            tool_schema = await load_tool_from_file(tool_file)
+            if tool_schema:
+                runner.registry.register(tool_schema)
+
+            # First streaming response: tool call with invalid JSON
+            sse_lines_tool = [
+                b'data: {"choices":[{"delta":{"tool_calls":[{"index":0,"id":"call_1",'
+                b'"function":{"name":"echo","arguments":"invalid json!!"}}]}}]}\n',
+                b"data: [DONE]\n",
+            ]
+
+            # Second streaming response: final text
+            sse_lines_final = [
+                b'data: {"choices":[{"delta":{"content":"Continued after error"}}]}\n',
+                b'data: {"choices":[{"delta":{},"finish_reason":"stop"}]}\n',
+                b"data: [DONE]\n",
+            ]
+
+            call_count = 0
+
+            def make_async_iter(lines):
+                async def async_iter():
+                    for line in lines:
+                        yield line
+
+                return async_iter()
+
+            def mock_post_side_effect(*_args, **_kwargs):
+                nonlocal call_count
+                call_count += 1
+
+                mock_response = AsyncMock()
+                mock_response.status = 200
+                mock_response.__aenter__ = AsyncMock(return_value=mock_response)
+                mock_response.__aexit__ = AsyncMock(return_value=None)
+
+                if call_count == 1:
+                    mock_response.content = make_async_iter(sse_lines_tool)
+                else:
+                    mock_response.content = make_async_iter(sse_lines_final)
+
+                return mock_response
+
+            with patch.object(runner.client, "post", side_effect=mock_post_side_effect):
+                messages = [{"role": "user", "content": "Test invalid JSON"}]
+                result = await runner._run_conversation(messages)
+
+                # Should have made 2 calls (tool call + final response)
+                assert call_count == 2
+                assert "choices" in result
+                content = result["choices"][0]["message"]["content"]
+                # Conversation should have continued despite invalid JSON
+                assert "Continued after error" in content
+
+
+class TestRunnerWorkspaceChangeDetection:
+    """Tests for workspace change handling with additional edge cases (T11)."""
+
+    @pytest.mark.asyncio
+    async def test_tools_removed_unregistered(self, config):
+        """Test tools removed from workspace are unregistered from registry."""
+        runner = SessionRunner(config)
+        async with runner:
+            # Create and register a tool
+            tools_dir = config.tools_dir()
+            tool_file = tools_dir / "temp_tool.py"
+            await tool_file.write_text("async def tool(x: int) -> int: return x")
+            tool_schema = await load_tool_from_file(tool_file)
+            if tool_schema:
+                runner.registry.register(tool_schema)
+            assert "temp_tool" in runner.registry.tools
+
+            # Now delete the tool file to simulate removal
+            await tool_file.unlink()
+
+            changes = ChangeSummary(
+                tools_added=[],
+                tools_modified=[],
+                tools_removed=["temp_tool"],
+                skills_added=[],
+                skills_modified=[],
+                skills_removed=[],
+                schedules_added=[],
+                schedules_modified=[],
+                schedules_removed=[],
+            )
+
+            await runner._handle_workspace_changes(changes)
+
+            # Tool should be unregistered
+            assert "temp_tool" not in runner.registry.tools
+
+    @pytest.mark.asyncio
+    async def test_skills_changed_when_system_is_none(self, config):
+        """Test skills changed when system is None sets cache to None."""
+        runner = SessionRunner(config)
+        async with runner:
+            runner._system = None
+            runner._system_prompt_cache = "old prompt"
+
+            changes = ChangeSummary(
+                tools_added=[],
+                tools_modified=[],
+                tools_removed=[],
+                skills_added=["new_skill"],
+                skills_modified=[],
+                skills_removed=[],
+                schedules_added=[],
+                schedules_modified=[],
+                schedules_removed=[],
+            )
+
+            await runner._handle_workspace_changes(changes)
+
+            # System prompt cache should be set to None
+            assert runner._system_prompt_cache is None
+
+    @pytest.mark.asyncio
+    async def test_schedules_changed_when_executor_is_none(self, config):
+        """Test schedules changed when executor is None does not raise exception."""
+        runner = SessionRunner(config)
+        async with runner:
+            runner._schedule_executor = None
+            runner._system = None
+
+            changes = ChangeSummary(
+                tools_added=[],
+                tools_modified=[],
+                tools_removed=[],
+                skills_added=[],
+                skills_modified=[],
+                skills_removed=[],
+                schedules_added=["new_schedule"],
+                schedules_modified=[],
+                schedules_removed=[],
+            )
+
+            # Should not raise any exception
+            await runner._handle_workspace_changes(changes)
+
+    @pytest.mark.asyncio
+    async def test_simultaneous_tools_skills_schedules_changes(self, config):
+        """Test simultaneous tools, skills, and schedules changes are all applied."""
+        runner = SessionRunner(config)
+        async with runner:
+            # Set up a mock system
+            runner._system = MagicMock()
+            runner._system.build_system_prompt = AsyncMock(return_value="Rebuilt prompt")
+
+            # Set up a mock schedule executor
+            runner._schedule_executor = MagicMock()
+            runner._schedule_executor.add_schedule = AsyncMock()
+            runner._schedule_executor.update_schedule = AsyncMock()
+            runner._schedule_executor.remove_schedule = AsyncMock()
+
+            # Create a tool file
+            tools_dir = config.tools_dir()
+            tool_file = tools_dir / "new_tool.py"
+            await tool_file.write_text("async def tool(x: int) -> int: return x")
+
+            changes = ChangeSummary(
+                tools_added=["new_tool"],
+                tools_modified=[],
+                tools_removed=[],
+                skills_added=["skill1"],
+                skills_modified=[],
+                skills_removed=[],
+                schedules_added=["daily_task"],
+                schedules_modified=[],
+                schedules_removed=[],
+            )
+
+            mock_schedule = MagicMock()
+            with (
+                patch("psi_agent.session.runner.load_schedule", return_value=mock_schedule),
+            ):
+                await runner._handle_workspace_changes(changes)
+
+            # Tool should be loaded
+            assert "new_tool" in runner.registry.tools
+            # System prompt should be rebuilt
+            assert runner._system_prompt_cache == "Rebuilt prompt"
+            # Schedule should be added
+            runner._schedule_executor.add_schedule.assert_called_once_with(mock_schedule)
+
+
+class TestCompleteFnAndStreaming:
+    """Tests for _complete_fn and streaming edge cases (T12)."""
+
+    @pytest.mark.asyncio
+    async def test_complete_fn_with_none_content(self, config):
+        """Test _complete_fn with None content returns empty string."""
+        runner = SessionRunner(config)
+        async with runner:
+            mock_response = AsyncMock()
+            mock_response.status = 200
+            mock_response.json = AsyncMock(
+                return_value={"choices": [{"message": {"content": None}}]}
+            )
+            mock_response.__aenter__ = AsyncMock(return_value=mock_response)
+            mock_response.__aexit__ = AsyncMock(return_value=None)
+
+            with patch.object(runner.client, "post", return_value=mock_response):
+                result = await runner._complete_fn([{"role": "user", "content": "Summarize"}])
+
+                # message.get("content", "") returns None when key exists with None value
+                assert result is None
+
+    @pytest.mark.asyncio
+    async def test_stream_conversation_with_reasoning_content(self, config):
+        """Test _stream_conversation with reasoning content yields thinking block tags."""
+        runner = SessionRunner(config)
+        async with runner:
+            sse_lines = [
+                b'data: {"choices":[{"delta":{"reasoning":"Let me think..."}}]}\n',
+                b'data: {"choices":[{"delta":{"reasoning":" Step 1 done."}}]}\n',
+                b'data: {"choices":[{"delta":{"content":"Final answer"}}]}\n',
+                b'data: {"choices":[{"delta":{},"finish_reason":"stop"}]}\n',
+                b"data: [DONE]\n",
+            ]
+
+            async def async_iter():
+                for line in sse_lines:
+                    yield line
+
+            mock_response = AsyncMock()
+            mock_response.status = 200
+            mock_response.content = async_iter()
+            mock_response.__aenter__ = AsyncMock(return_value=mock_response)
+            mock_response.__aexit__ = AsyncMock(return_value=None)
+
+            with patch.object(runner.client, "post", return_value=mock_response):
+                messages = [{"role": "user", "content": "Think about it"}]
+                chunks = []
+                async for chunk in runner._stream_conversation(messages):
+                    chunks.append(chunk)
+
+                full_content = "".join(chunks)
+                # Reasoning should be yielded as reasoning field
+                assert '"reasoning"' in full_content
+                assert "Let me think..." in full_content
+                assert "Step 1 done." in full_content
+                # Content should also be present
+                assert "Final answer" in full_content
+
+    @pytest.mark.asyncio
+    async def test_stream_conversation_with_both_reasoning_and_content(self, config):
+        """Test _stream_conversation with both reasoning and content in same chunk."""
+        runner = SessionRunner(config)
+        async with runner:
+            sse_lines = [
+                b'data: {"choices":[{"delta":{"reasoning":"Thinking","content":"Speaking"}}]}\n',
+                b'data: {"choices":[{"delta":{},"finish_reason":"stop"}]}\n',
+                b"data: [DONE]\n",
+            ]
+
+            async def async_iter():
+                for line in sse_lines:
+                    yield line
+
+            mock_response = AsyncMock()
+            mock_response.status = 200
+            mock_response.content = async_iter()
+            mock_response.__aenter__ = AsyncMock(return_value=mock_response)
+            mock_response.__aexit__ = AsyncMock(return_value=None)
+
+            with patch.object(runner.client, "post", return_value=mock_response):
+                messages = [{"role": "user", "content": "Hi"}]
+                chunks = []
+                async for chunk in runner._stream_conversation(messages):
+                    chunks.append(chunk)
+
+                full_content = "".join(chunks)
+                # Both reasoning and content should be present
+                assert '"reasoning"' in full_content
+                assert "Thinking" in full_content
+                assert "Speaking" in full_content
+
+    @pytest.mark.asyncio
+    async def test_stream_conversation_multiple_rounds_of_tool_calls(self, config):
+        """Test _stream_conversation with multiple rounds of tool calls."""
+        runner = SessionRunner(config)
+        async with runner:
+            # Create a tool
+            tool_file = config.tools_dir() / "echo.py"
+            await tool_file.write_text(
+                """
+async def tool(message: str) -> str:
+    '''Echo tool.
+
+    Args:
+        message: The message to echo.
+
+    Returns:
+        The echoed message.
+    '''
+    return message
+"""
+            )
+            tool_schema = await load_tool_from_file(tool_file)
+            if tool_schema:
+                runner.registry.register(tool_schema)
+
+            # Round 1: tool call
+            sse_lines_round1 = [
+                b'data: {"choices":[{"delta":{"tool_calls":[{"index":0,"id":"call_1",'
+                b'"function":{"name":"echo","arguments":"{\\"mes"}}]}}]}\n',
+                b'data: {"choices":[{"delta":{"tool_calls":[{"index":0,'
+                b'"function":{"arguments":"sage\\": \\"first\\"}"}}]}}\n',
+                b"data: [DONE]\n",
+            ]
+
+            # Round 2: another tool call
+            sse_lines_round2 = [
+                b'data: {"choices":[{"delta":{"tool_calls":[{"index":0,"id":"call_2",'
+                b'"function":{"name":"echo","arguments":"{\\"mes"}}]}}]}\n',
+                b'data: {"choices":[{"delta":{"tool_calls":[{"index":0,'
+                b'"function":{"arguments":"sage\\": \\"second\\"}"}}]}}\n',
+                b"data: [DONE]\n",
+            ]
+
+            # Round 3: final text
+            sse_lines_final = [
+                b'data: {"choices":[{"delta":{"content":"Complete"}}]}\n',
+                b'data: {"choices":[{"delta":{},"finish_reason":"stop"}]}\n',
+                b"data: [DONE]\n",
+            ]
+
+            call_count = 0
+
+            def make_async_iter(lines):
+                async def async_iter():
+                    for line in lines:
+                        yield line
+
+                return async_iter()
+
+            def mock_post_side_effect(*_args, **_kwargs):
+                nonlocal call_count
+                call_count += 1
+
+                mock_response = AsyncMock()
+                mock_response.status = 200
+                mock_response.__aenter__ = AsyncMock(return_value=mock_response)
+                mock_response.__aexit__ = AsyncMock(return_value=None)
+
+                if call_count == 1:
+                    mock_response.content = make_async_iter(sse_lines_round1)
+                elif call_count == 2:
+                    mock_response.content = make_async_iter(sse_lines_round2)
+                else:
+                    mock_response.content = make_async_iter(sse_lines_final)
+
+                return mock_response
+
+            with patch.object(runner.client, "post", side_effect=mock_post_side_effect):
+                messages = [{"role": "user", "content": "Test"}]
+                chunks = []
+                async for chunk in runner._stream_conversation(messages):
+                    chunks.append(chunk)
+
+                # Should have made 3 calls
+                assert call_count == 3
+                full_content = "".join(chunks)
+                # Both tool calls should appear as reasoning
+                assert full_content.count("[Tool: echo]") == 2
+                assert "Complete" in full_content
+
+
+class TestLoadSingleScheduleErrors:
+    """Tests for _load_single_schedule error handling (T13)."""
+
+    @pytest.mark.asyncio
+    async def test_nonexistent_directory_returns_none(self, config):
+        """Test _load_single_schedule with non-existent directory returns None."""
+        runner = SessionRunner(config)
+        result = await runner._load_single_schedule(anyio.Path("/nonexistent/path"))
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_invalid_task_md_returns_none(self, config):
+        """Test _load_single_schedule with invalid TASK.md returns None."""
+        runner = SessionRunner(config)
+        with tempfile.TemporaryDirectory() as tmpdir:
+            task_dir = anyio.Path(tmpdir) / "broken_task"
+            await task_dir.mkdir()
+            # Write TASK.md without required 'cron' field
+            task_file = task_dir / "TASK.md"
+            await task_file.write_text(
+                "---\nname: broken\ndescription: No cron field\n---\nDo something\n"
+            )
+
+            result = await runner._load_single_schedule(task_dir)
+            assert result is None

--- a/tests/session/test_server.py
+++ b/tests/session/test_server.py
@@ -570,8 +570,10 @@ class TestServerStartStopExceptions:
         assert runner.client is not None
 
         # Mock client.close to raise an exception
-        runner.client.close = AsyncMock(side_effect=RuntimeError("Close failed"))
-
-        # __aexit__ does not catch exceptions from client.close
-        with pytest.raises(RuntimeError, match="Close failed"):
+        with (
+            patch.object(
+                runner.client, "close", AsyncMock(side_effect=RuntimeError("Close failed"))
+            ),
+            pytest.raises(RuntimeError, match="Close failed"),
+        ):
             await runner.__aexit__(None, None, None)

--- a/tests/session/test_server.py
+++ b/tests/session/test_server.py
@@ -427,3 +427,151 @@ class TestSessionServerStartStop:
                 # But we can verify the code path by checking the log
 
                 await server.stop()
+
+
+class TestServerNullContentAndMissingFields:
+    """Tests for null content and missing fields handling (T14)."""
+
+    @pytest.mark.asyncio
+    async def test_handle_chat_completions_none_content(self, config):
+        """Test _handle_chat_completions with user_message content None.
+
+        The server code handles None content gracefully at line 80:
+        content_preview = content[:100] if content else ""
+        When content is None, the preview becomes "".
+        The request is then passed to process_request which receives
+        the user_message with content=None.
+        """
+        server = SessionServer(config)
+
+        runner = SessionRunner(config)
+        server.runner = runner
+
+        mock_process_request = AsyncMock(
+            return_value={
+                "choices": [{"message": {"role": "assistant", "content": "Handled None"}}],
+                "model": "session",
+            }
+        )
+
+        mock_request = MagicMock()
+        mock_request.json = AsyncMock(
+            return_value={"messages": [{"role": "user", "content": None}]}
+        )
+
+        with patch.object(runner, "process_request", mock_process_request):
+            response = await server._handle_chat_completions(mock_request)
+            # Server should handle None content without crashing
+            assert response.status == 200
+            # Verify process_request was called with the None content message
+            mock_process_request.assert_called_once_with({"role": "user", "content": None})
+
+    @pytest.mark.asyncio
+    async def test_handle_chat_completions_empty_string_content(self, config):
+        """Test _handle_chat_completions with user_message content empty string."""
+        server = SessionServer(config)
+
+        runner = SessionRunner(config)
+        server.runner = runner
+
+        mock_process_request = AsyncMock(
+            return_value={
+                "choices": [{"message": {"role": "assistant", "content": "Got empty input"}}],
+                "model": "session",
+            }
+        )
+
+        mock_request = MagicMock()
+        mock_request.json = AsyncMock(return_value={"messages": [{"role": "user", "content": ""}]})
+
+        with patch.object(runner, "process_request", mock_process_request):
+            response = await server._handle_chat_completions(mock_request)
+            assert response.status == 200
+
+    def test_filter_for_channel_no_choices_key(self, config):
+        """Test _filter_for_channel with no choices key in response."""
+        server = SessionServer(config)
+        response = {"id": "chatcmpl-1", "model": "test"}
+        result = server._filter_for_channel(response)
+        # No choices key means empty choices list is used
+        assert result == {"choices": [], "model": "test"}
+
+    def test_filter_for_channel_empty_choices(self, config):
+        """Test _filter_for_channel with empty choices list."""
+        server = SessionServer(config)
+        response = {"id": "chatcmpl-1", "choices": []}
+        result = server._filter_for_channel(response)
+        assert result == {"choices": [], "model": "session"}
+
+    def test_filter_for_channel_missing_message(self, config):
+        """Test _filter_for_channel with missing message in choice."""
+        server = SessionServer(config)
+        response = {"choices": [{"finish_reason": "stop"}]}
+        result = server._filter_for_channel(response)
+        # Should handle missing message gracefully by using defaults
+        assert "choices" in result
+        assert len(result["choices"]) == 1
+        assert result["choices"][0]["message"]["role"] == "assistant"
+        assert result["choices"][0]["message"]["content"] == ""
+
+    def test_filter_for_channel_none_content(self, config):
+        """Test _filter_for_channel with None content in message."""
+        server = SessionServer(config)
+        response = {"choices": [{"message": {"role": "assistant", "content": None}}]}
+        result = server._filter_for_channel(response)
+        assert "choices" in result
+        # Content should be None (not crash) - .get("content", "") returns None
+        # when key exists with None value
+        assert result["choices"][0]["message"]["content"] is None
+
+
+class TestServerStartStopExceptions:
+    """Tests for server start/stop exception handling (T15)."""
+
+    @pytest.mark.asyncio
+    async def test_double_stop_no_exception(self, config: SessionConfig) -> None:
+        """Test double stop does not raise exception."""
+        server = SessionServer(config)
+
+        with (
+            patch("psi_agent.session.server.web.UnixSite") as mock_site,
+            patch("psi_agent.session.server.load_schedules") as mock_load_schedules,
+        ):
+            mock_site_instance = AsyncMock()
+            mock_site.return_value = mock_site_instance
+            mock_load_schedules.return_value = []
+
+            await server.start()
+            await server.stop()
+            # Second stop should not raise
+            await server.stop()
+
+    @pytest.mark.asyncio
+    async def test_runner_aenter_raises_exception_propagates(self, config: SessionConfig) -> None:
+        """Test runner __aenter__ raises exception which propagates."""
+        with patch(
+            "psi_agent.session.runner.SessionRunner.__aenter__",
+            new_callable=AsyncMock,
+            side_effect=RuntimeError("Init failed"),
+        ):
+            runner = SessionRunner(config)
+            with pytest.raises(RuntimeError, match="Init failed"):
+                await runner.__aenter__()
+
+    @pytest.mark.asyncio
+    async def test_runner_aexit_exception_propagates(self, config: SessionConfig) -> None:
+        """Test runner __aexit__ with client that raises during close.
+
+        The __aexit__ method does not catch exceptions from client.close(),
+        so the exception propagates to the caller.
+        """
+        runner = SessionRunner(config)
+        await runner.__aenter__()
+        assert runner.client is not None
+
+        # Mock client.close to raise an exception
+        runner.client.close = AsyncMock(side_effect=RuntimeError("Close failed"))
+
+        # __aexit__ does not catch exceptions from client.close
+        with pytest.raises(RuntimeError, match="Close failed"):
+            await runner.__aexit__(None, None, None)

--- a/tests/workspace/test_manifest.py
+++ b/tests/workspace/test_manifest.py
@@ -339,3 +339,145 @@ class TestSerializeManifestRoundTripExtended:
 
         assert reparsed.layers == original.layers
         assert reparsed.default == original.default
+
+
+class TestParseManifestValidation:
+    """Validation tests for parse_manifest edge cases."""
+
+    def test_layer_data_not_dict_raises_error(self) -> None:
+        """Test that layer data not being a dict raises ManifestParseError."""
+        uuid1 = uuid4()
+        with pytest.raises(ManifestParseError, match="must be an object"):
+            parse_manifest(f'{{"layers": {{"{uuid1}": "not_a_dict"}} , "default": "{uuid1}"}}')
+
+    def test_invalid_parent_uuid_raises_error(self) -> None:
+        """Test that an invalid parent UUID raises ManifestParseError."""
+        uuid1 = uuid4()
+        with pytest.raises(ManifestParseError, match="Invalid parent UUID"):
+            parse_manifest(
+                f'{{"layers": {{"{uuid1}": {{ "parent": "not-a-uuid" }}}}, "default": "{uuid1}"}}'
+            )
+
+    def test_tag_not_string_raises_error(self) -> None:
+        """Test that a non-string tag raises ManifestParseError."""
+        uuid1 = uuid4()
+        with pytest.raises(ManifestParseError, match="Tag in layer.*must be a string"):
+            parse_manifest(f'{{"layers": {{"{uuid1}": {{ "tag": 123 }}}}, "default": "{uuid1}"}}')
+
+    def test_default_invalid_uuid_raises_error(self) -> None:
+        """Test that an invalid default UUID raises ManifestParseError."""
+        uuid1 = uuid4()
+        with pytest.raises(ManifestParseError, match="Invalid default UUID"):
+            parse_manifest(f'{{"layers": {{"{uuid1}": {{}}}}, "default": "not-a-uuid"}}')
+
+    def test_layer_with_empty_dict_success(self) -> None:
+        """Test that a layer with an empty dict parses successfully."""
+        uuid1 = uuid4()
+        manifest = parse_manifest(f'{{"layers": {{"{uuid1}": {{}}}}, "default": "{uuid1}"}}')
+        assert uuid1 in manifest.layers
+        assert manifest.layers[uuid1].parent is None
+        assert manifest.layers[uuid1].tag is None
+
+    def test_tag_explicitly_null_success_with_none(self) -> None:
+        """Test that a tag explicitly set to null parses as None."""
+        uuid1 = uuid4()
+        manifest = parse_manifest(
+            f'{{"layers": {{"{uuid1}": {{ "tag": null }}}}, "default": "{uuid1}"}}'
+        )
+        assert manifest.layers[uuid1].tag is None
+
+
+class TestManifestResolveChainAndEdgeCases:
+    """Tests for resolve_chain, get_children, get_root_layers, lookup_by_tag, and serialize."""
+
+    def test_resolve_chain_with_broken_chain_raises_value_error(self) -> None:
+        """Test that resolve_chain raises ValueError when parent chain is broken."""
+        root_uuid = uuid4()
+        mid_uuid = uuid4()
+        leaf_uuid = uuid4()
+        # mid_uuid references a parent that exists, but leaf_uuid references
+        # a parent that is NOT in the layers dict
+        missing_uuid = uuid4()
+        manifest = Manifest(
+            layers={
+                root_uuid: Layer(tag="root"),
+                mid_uuid: Layer(parent=root_uuid, tag="mid"),
+                leaf_uuid: Layer(parent=missing_uuid, tag="leaf"),
+            },
+            default=mid_uuid,
+        )
+        with pytest.raises(ValueError, match="Parent layer.*not found"):
+            manifest.resolve_chain(leaf_uuid)
+
+    def test_get_children_with_missing_uuid_returns_empty_list(self) -> None:
+        """Test that get_children with a UUID not in layers returns empty list."""
+        uuid1 = uuid4()
+        missing_uuid = uuid4()
+        manifest = Manifest(
+            layers={uuid1: Layer(tag="v1")},
+            default=uuid1,
+        )
+        children = manifest.get_children(missing_uuid)
+        assert children == []
+
+    def test_get_root_layers_with_multiple_roots(self) -> None:
+        """Test get_root_layers returns all root layers when there are multiple."""
+        root1 = uuid4()
+        root2 = uuid4()
+        child = uuid4()
+        manifest = Manifest(
+            layers={
+                root1: Layer(tag="root1"),
+                root2: Layer(tag="root2"),
+                child: Layer(parent=root1, tag="child"),
+            },
+            default=child,
+        )
+        roots = manifest.get_root_layers()
+        assert set(roots) == {root1, root2}
+
+    def test_lookup_by_tag_with_empty_string_raises_manifest_parse_error(self) -> None:
+        """Test that lookup_by_tag with empty string raises ValueError."""
+        uuid1 = uuid4()
+        manifest = Manifest(
+            layers={uuid1: Layer(tag="v1")},
+            default=uuid1,
+        )
+        # lookup_by_tag raises ValueError, not ManifestParseError
+        with pytest.raises(ValueError, match="No layer found"):
+            manifest.lookup_by_tag("")
+
+    @pytest.mark.xfail(
+        reason=(
+            "serialize_manifest uses empty string for default=None, "
+            "which cannot round-trip through parse_manifest "
+            "since parse_manifest requires a valid UUID for default"
+        ),
+        strict=True,
+    )
+    def test_serialize_manifest_with_default_none(self) -> None:
+        """Test serialize_manifest with default=None cannot round-trip (known bug)."""
+        uuid1 = uuid4()
+        manifest = Manifest(
+            layers={uuid1: Layer(tag="v1")},
+            default=None,
+        )
+        json_str = serialize_manifest(manifest)
+        # This will fail because parse_manifest requires a valid UUID for default,
+        # but serialize_manifest writes an empty string for None
+        reparsed = parse_manifest(json_str)
+        assert reparsed.default is None
+
+    def test_manifest_parse_error_with_details(self) -> None:
+        """Test ManifestParseError with details attribute."""
+        error = ManifestParseError("Main message", details="Extra context")
+        assert error.message == "Main message"
+        assert error.details == "Extra context"
+        assert str(error) == "Main message: Extra context"
+
+    def test_manifest_parse_error_without_details(self) -> None:
+        """Test ManifestParseError without details attribute."""
+        error = ManifestParseError("Main message")
+        assert error.message == "Main message"
+        assert error.details is None
+        assert str(error) == "Main message"

--- a/tests/workspace/test_mount_api.py
+++ b/tests/workspace/test_mount_api.py
@@ -340,3 +340,21 @@ class TestMountWithManifest:
 
             # Output directory should be created
             assert await output_dir.exists()
+
+
+class TestResolveTargetLayerEdgeCases:
+    """Tests for _resolve_target_layer edge cases."""
+
+    def test_valid_uuid_format_not_in_layers_tag_fallback_fails(self) -> None:
+        """Valid UUID format but not in layers, tag lookup also fails -> MountError."""
+        layer_uuid = uuid4()
+        other_uuid = uuid4()  # A valid UUID that's not in layers
+        manifest = Manifest(
+            layers={layer_uuid: Layer(tag="v1.0")},
+            default=layer_uuid,
+        )
+
+        # other_uuid is a valid UUID format but not in manifest.layers
+        # Tag lookup will also fail since it's a UUID string, not a tag
+        with pytest.raises(MountError, match="not found"):
+            _resolve_target_layer(manifest, str(other_uuid))

--- a/tests/workspace/test_mount_cli.py
+++ b/tests/workspace/test_mount_cli.py
@@ -1,0 +1,43 @@
+"""Tests for mount CLI module."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from psi_agent.workspace.mount.cli import Mount, main
+
+
+class TestMountCliCall:
+    """Tests for Mount CLI __call__ method."""
+
+    @patch("psi_agent.workspace.mount.cli.asyncio.run")
+    @patch("psi_agent.workspace.mount.cli.mount")
+    def test_call_invokes_mount_api(self, mock_mount: AsyncMock, mock_run: MagicMock) -> None:
+        """Mount.__call__ calls the mount API function."""
+        cli = Mount(input_file="/tmp/workspace.squashfs", output_dir="/tmp/mounted")
+        cli()
+
+        mock_run.assert_called_once()
+
+    @patch("psi_agent.workspace.mount.cli.asyncio.run")
+    @patch("psi_agent.workspace.mount.cli.mount")
+    def test_call_with_layer(self, mock_mount: AsyncMock, mock_run: MagicMock) -> None:
+        """Mount.__call__ works with layer parameter."""
+        cli = Mount(
+            input_file="/tmp/workspace.squashfs",
+            output_dir="/tmp/mounted",
+            layer="v1.0",
+        )
+        cli()
+
+        mock_run.assert_called_once()
+
+
+class TestMountCliMain:
+    """Tests for Mount CLI main function."""
+
+    @patch("psi_agent.workspace.mount.cli.tyro.cli")
+    def test_main_calls_tyro(self, mock_cli: MagicMock) -> None:
+        """main calls tyro.cli with Mount class."""
+        main()
+        mock_cli.assert_called_once_with(Mount)

--- a/tests/workspace/test_pack.py
+++ b/tests/workspace/test_pack.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from unittest.mock import AsyncMock, patch
+
 import anyio
 import pytest
 
@@ -62,3 +64,68 @@ class TestPack:
 
         with pytest.raises(PackError, match="not a directory"):
             await pack(input_file, output_file)
+
+
+class TestPackMksquashfsFailure:
+    """Tests for pack with mksquashfs subprocess failure."""
+
+    async def test_pack_mksquashfs_failure_raises_pack_error(self, tmp_path) -> None:
+        """Pack raises PackError when mksquashfs command fails."""
+        workspace = anyio.Path(tmp_path)
+        input_dir = workspace / "workspace"
+        await input_dir.mkdir()
+        await (input_dir / "test.txt").write_text("test")
+
+        output_file = workspace / "output.squashfs"
+
+        with patch("asyncio.create_subprocess_exec") as mock_exec:
+            mock_process = AsyncMock()
+            mock_process.communicate.return_value = (b"", b"mksquashfs error: failed")
+            mock_process.returncode = 1
+            mock_exec.return_value = mock_process
+
+            with pytest.raises(PackError, match="mksquashfs failed"):
+                await pack(input_dir, output_file)
+
+
+class TestPackEmptyDirectory:
+    """Tests for pack with empty directory."""
+
+    async def test_pack_empty_directory_success(self, tmp_path) -> None:
+        """Pack succeeds with empty directory."""
+        workspace = anyio.Path(tmp_path)
+        input_dir = workspace / "workspace"
+        await input_dir.mkdir()
+
+        output_file = workspace / "output.squashfs"
+
+        with patch("asyncio.create_subprocess_exec") as mock_exec:
+            mock_process = AsyncMock()
+            mock_process.communicate.return_value = (b"", b"")
+            mock_process.returncode = 0
+            mock_exec.return_value = mock_process
+
+            await pack(input_dir, output_file)
+
+            # Verify mksquashfs was called
+            mock_exec.assert_called_once()
+
+
+class TestPackError:
+    """Tests for PackError exception class."""
+
+    def test_pack_error_message_preservation(self) -> None:
+        """PackError preserves the error message."""
+        error = PackError("Test error message")
+        assert str(error) == "Test error message"
+
+    def test_pack_error_inheritance(self) -> None:
+        """PackError inherits from Exception."""
+        error = PackError("Test")
+        assert isinstance(error, Exception)
+
+    def test_pack_error_with_mksquashfs_message(self) -> None:
+        """PackError preserves mksquashfs error details."""
+        error = PackError("mksquashfs failed: permission denied")
+        assert "mksquashfs" in str(error)
+        assert "permission denied" in str(error)

--- a/tests/workspace/test_pack_cli.py
+++ b/tests/workspace/test_pack_cli.py
@@ -1,0 +1,39 @@
+"""Tests for pack CLI module."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from psi_agent.workspace.pack.cli import Pack, main
+
+
+class TestPackCliCall:
+    """Tests for Pack CLI __call__ method."""
+
+    @patch("psi_agent.workspace.pack.cli.asyncio.run")
+    @patch("psi_agent.workspace.pack.cli.pack")
+    def test_call_invokes_pack_api(self, mock_pack: AsyncMock, mock_run: MagicMock) -> None:
+        """Pack.__call__ calls the pack API function."""
+        cli = Pack(input_dir="/tmp/workspace", output_file="/tmp/output.squashfs", tag="v1.0")
+        cli()
+
+        mock_run.assert_called_once()
+
+    @patch("psi_agent.workspace.pack.cli.asyncio.run")
+    @patch("psi_agent.workspace.pack.cli.pack")
+    def test_call_with_no_tag(self, mock_pack: AsyncMock, mock_run: MagicMock) -> None:
+        """Pack.__call__ works with no tag."""
+        cli = Pack(input_dir="/tmp/workspace", output_file="/tmp/output.squashfs")
+        cli()
+
+        mock_run.assert_called_once()
+
+
+class TestPackCliMain:
+    """Tests for Pack CLI main function."""
+
+    @patch("psi_agent.workspace.pack.cli.tyro.cli")
+    def test_main_calls_tyro(self, mock_cli: MagicMock) -> None:
+        """main calls tyro.cli with Pack class."""
+        main()
+        mock_cli.assert_called_once_with(Pack)

--- a/tests/workspace/test_snapshot_api.py
+++ b/tests/workspace/test_snapshot_api.py
@@ -449,7 +449,7 @@ class TestSnapshotDifferentOutputFile:
             mock_create.return_value = None
             mock_move.return_value = None
 
-            await snapshot(input_file, mount_point, output_file=output_file, tag="v1.1")
+            await snapshot(input_file, mount_point, output_file=str(output_file), tag="v1.1")
 
             mock_read.assert_called_once()
             mock_extract.assert_called_once()
@@ -507,7 +507,7 @@ class TestSnapshotOutputFileExists:
             mock_create.return_value = None
             mock_move.return_value = None
 
-            await snapshot(input_file, mount_point, output_file=output_file, tag="v1.1")
+            await snapshot(input_file, mount_point, output_file=str(output_file), tag="v1.1")
 
             mock_read.assert_called_once()
             mock_extract.assert_called_once()

--- a/tests/workspace/test_snapshot_api.py
+++ b/tests/workspace/test_snapshot_api.py
@@ -371,3 +371,233 @@ class TestSnapshotError:
         """SnapshotError inherits from Exception."""
         error = SnapshotError("Test")
         assert isinstance(error, Exception)
+
+
+class TestSnapshotMissingKeys:
+    """Tests for snapshot with missing keys in mount info.
+
+    Bug: When upper_dir key is missing from mount info,
+    the code raises KeyError instead of SnapshotError.
+    """
+
+    @pytest.mark.xfail(
+        reason="Bug: KeyError instead of SnapshotError when upper_dir key is missing", strict=True
+    )
+    async def test_snapshot_missing_upper_dir_key(self, tmp_path: anyio.Path) -> None:
+        """Snapshot raises SnapshotError when upper_dir key is missing."""
+        tmp = anyio.Path(tmp_path)
+        input_file = tmp / "workspace.squashfs"
+        await input_file.touch()
+
+        mount_point = tmp / "mounted"
+        await mount_point.mkdir()
+
+        # Create mount info without upper_dir key
+        mount_info = mount_point / ".psi-mount-info"
+        mount_info_content = f"{{'squashfs_mount': '{tmp}/squashfs', 'work_dir': '{tmp}/work'}}"
+        await mount_info.write_text(mount_info_content)
+
+        with pytest.raises(SnapshotError):
+            await snapshot(input_file, mount_point, tag="v1.1")
+
+
+class TestSnapshotDifferentOutputFile:
+    """Tests for snapshot with different output_file from input_file."""
+
+    async def test_snapshot_different_output_file(self, tmp_path: anyio.Path) -> None:
+        """Snapshot writes to a different output file."""
+        tmp = anyio.Path(tmp_path)
+        input_file = tmp / "workspace.squashfs"
+        await input_file.touch()
+
+        output_file = tmp / "workspace_v2.squashfs"
+
+        mount_point = tmp / "mounted"
+        await mount_point.mkdir()
+
+        upper_dir = tmp / "upper"
+        await upper_dir.mkdir()
+        await (upper_dir / "new_file.txt").write_text("new content")
+
+        # Create valid mount info file
+        mount_info = mount_point / ".psi-mount-info"
+        mount_info_content = (
+            f"{{'squashfs_mount': '{tmp}/squashfs', "
+            f"'upper_dir': '{upper_dir}', 'work_dir': '{tmp}/work'}}"
+        )
+        await mount_info.write_text(mount_info_content)
+
+        with (
+            patch(
+                "psi_agent.workspace.snapshot.api._read_manifest_from_squashfs",
+                new_callable=AsyncMock,
+            ) as mock_read,
+            patch(
+                "psi_agent.workspace.snapshot.api._extract_squashfs",
+                new_callable=AsyncMock,
+            ) as mock_extract,
+            patch(
+                "psi_agent.workspace.snapshot.api._create_squashfs",
+                new_callable=AsyncMock,
+            ) as mock_create,
+            patch("psi_agent.workspace.snapshot.api.shutil.move") as mock_move,
+        ):
+            default_uuid = uuid4()
+            mock_manifest = Manifest(layers={default_uuid: Layer(tag="v1.0")}, default=default_uuid)
+            mock_read.return_value = mock_manifest
+            mock_extract.return_value = None
+            mock_create.return_value = None
+            mock_move.return_value = None
+
+            await snapshot(input_file, mount_point, output_file=output_file, tag="v1.1")
+
+            mock_read.assert_called_once()
+            mock_extract.assert_called_once()
+            mock_create.assert_called_once()
+            mock_move.assert_called()
+
+
+class TestSnapshotOutputFileExists:
+    """Tests for snapshot when output_file already exists."""
+
+    async def test_snapshot_output_file_already_exists(self, tmp_path: anyio.Path) -> None:
+        """Snapshot overwrites existing output file."""
+        tmp = anyio.Path(tmp_path)
+        input_file = tmp / "workspace.squashfs"
+        await input_file.touch()
+
+        output_file = tmp / "workspace_v2.squashfs"
+        # Create an existing output file
+        await output_file.write_bytes(b"old content")
+
+        mount_point = tmp / "mounted"
+        await mount_point.mkdir()
+
+        upper_dir = tmp / "upper"
+        await upper_dir.mkdir()
+        await (upper_dir / "new_file.txt").write_text("new content")
+
+        # Create valid mount info file
+        mount_info = mount_point / ".psi-mount-info"
+        mount_info_content = (
+            f"{{'squashfs_mount': '{tmp}/squashfs', "
+            f"'upper_dir': '{upper_dir}', 'work_dir': '{tmp}/work'}}"
+        )
+        await mount_info.write_text(mount_info_content)
+
+        with (
+            patch(
+                "psi_agent.workspace.snapshot.api._read_manifest_from_squashfs",
+                new_callable=AsyncMock,
+            ) as mock_read,
+            patch(
+                "psi_agent.workspace.snapshot.api._extract_squashfs",
+                new_callable=AsyncMock,
+            ) as mock_extract,
+            patch(
+                "psi_agent.workspace.snapshot.api._create_squashfs",
+                new_callable=AsyncMock,
+            ) as mock_create,
+            patch("psi_agent.workspace.snapshot.api.shutil.move") as mock_move,
+        ):
+            default_uuid = uuid4()
+            mock_manifest = Manifest(layers={default_uuid: Layer(tag="v1.0")}, default=default_uuid)
+            mock_read.return_value = mock_manifest
+            mock_extract.return_value = None
+            mock_create.return_value = None
+            mock_move.return_value = None
+
+            await snapshot(input_file, mount_point, output_file=output_file, tag="v1.1")
+
+            mock_read.assert_called_once()
+            mock_extract.assert_called_once()
+            mock_create.assert_called_once()
+            mock_move.assert_called()
+
+
+class TestSnapshotManifestUpdates:
+    """Tests for snapshot manifest updates."""
+
+    async def test_snapshot_manifest_parent_and_default(self, tmp_path: anyio.Path) -> None:
+        """Snapshot sets parent to previous default and default to new layer."""
+        tmp = anyio.Path(tmp_path)
+        input_file = tmp / "workspace.squashfs"
+        await input_file.touch()
+
+        mount_point = tmp / "mounted"
+        await mount_point.mkdir()
+
+        upper_dir = tmp / "upper"
+        await upper_dir.mkdir()
+        await (upper_dir / "new_file.txt").write_text("new content")
+
+        # Create valid mount info file
+        mount_info = mount_point / ".psi-mount-info"
+        mount_info_content = (
+            f"{{'squashfs_mount': '{tmp}/squashfs', "
+            f"'upper_dir': '{upper_dir}', 'work_dir': '{tmp}/work'}}"
+        )
+        await mount_info.write_text(mount_info_content)
+
+        default_uuid = uuid4()
+        mock_manifest = Manifest(layers={default_uuid: Layer(tag="v1.0")}, default=default_uuid)
+
+        captured_manifest = None
+
+        async def mock_write_manifest(path: anyio.Path, content: str) -> None:
+            nonlocal captured_manifest
+            captured_manifest = content
+
+        with (
+            patch(
+                "psi_agent.workspace.snapshot.api._read_manifest_from_squashfs",
+                new_callable=AsyncMock,
+                return_value=mock_manifest,
+            ),
+            patch(
+                "psi_agent.workspace.snapshot.api._extract_squashfs",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "psi_agent.workspace.snapshot.api._create_squashfs",
+                new_callable=AsyncMock,
+            ),
+            patch("psi_agent.workspace.snapshot.api.shutil.move"),
+            patch("psi_agent.workspace.snapshot.api.serialize_manifest") as mock_serialize,
+        ):
+            # Track what manifest gets serialized
+            serialized_manifests = []
+
+            def track_serialize(manifest: Manifest) -> str:
+                serialized_manifests.append(manifest)
+                # Return a valid JSON string
+                import json
+
+                layers_data = {}
+                for uuid, layer in manifest.layers.items():
+                    layer_data = {}
+                    if layer.parent is not None:
+                        layer_data["parent"] = str(layer.parent)
+                    if layer.tag is not None:
+                        layer_data["tag"] = layer.tag
+                    layers_data[str(uuid)] = layer_data
+                return json.dumps(
+                    {
+                        "layers": layers_data,
+                        "default": str(manifest.default) if manifest.default else "",
+                    }
+                )
+
+            mock_serialize.side_effect = track_serialize
+
+            await snapshot(input_file, mount_point, tag="v1.1")
+
+            # Verify the manifest was updated correctly
+            assert len(serialized_manifests) == 1
+            updated_manifest = serialized_manifests[0]
+            # The new layer's parent should be the initial default
+            new_default = updated_manifest.default
+            assert new_default is not None
+            assert new_default != default_uuid
+            assert updated_manifest.layers[new_default].parent == default_uuid
+            assert updated_manifest.layers[new_default].tag == "v1.1"

--- a/tests/workspace/test_snapshot_cli.py
+++ b/tests/workspace/test_snapshot_cli.py
@@ -1,0 +1,60 @@
+"""Tests for snapshot CLI module."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from psi_agent.workspace.snapshot.cli import Snapshot, main
+
+
+class TestSnapshotCliCall:
+    """Tests for Snapshot CLI __call__ method."""
+
+    @patch("psi_agent.workspace.snapshot.cli.asyncio.run")
+    @patch("psi_agent.workspace.snapshot.cli.snapshot")
+    def test_call_invokes_snapshot_api(self, mock_snapshot: AsyncMock, mock_run: MagicMock) -> None:
+        """Snapshot.__call__ calls the snapshot API function."""
+        cli = Snapshot(
+            input_file="/tmp/workspace.squashfs",
+            mount_point="/tmp/mounted",
+            tag="v1.1",
+        )
+        cli()
+
+        mock_run.assert_called_once()
+
+    @patch("psi_agent.workspace.snapshot.cli.asyncio.run")
+    @patch("psi_agent.workspace.snapshot.cli.snapshot")
+    def test_call_with_output_file(self, mock_snapshot: AsyncMock, mock_run: MagicMock) -> None:
+        """Snapshot.__call__ works with output_file parameter."""
+        cli = Snapshot(
+            input_file="/tmp/workspace.squashfs",
+            mount_point="/tmp/mounted",
+            tag="v1.1",
+            output_file="/tmp/workspace_v2.squashfs",
+        )
+        cli()
+
+        mock_run.assert_called_once()
+
+    @patch("psi_agent.workspace.snapshot.cli.asyncio.run")
+    @patch("psi_agent.workspace.snapshot.cli.snapshot")
+    def test_call_with_no_tag(self, mock_snapshot: AsyncMock, mock_run: MagicMock) -> None:
+        """Snapshot.__call__ works without tag."""
+        cli = Snapshot(
+            input_file="/tmp/workspace.squashfs",
+            mount_point="/tmp/mounted",
+        )
+        cli()
+
+        mock_run.assert_called_once()
+
+
+class TestSnapshotCliMain:
+    """Tests for Snapshot CLI main function."""
+
+    @patch("psi_agent.workspace.snapshot.cli.tyro.cli")
+    def test_main_calls_tyro(self, mock_cli: MagicMock) -> None:
+        """main calls tyro.cli with Snapshot class."""
+        main()
+        mock_cli.assert_called_once_with(Snapshot)

--- a/tests/workspace/test_umount.py
+++ b/tests/workspace/test_umount.py
@@ -169,3 +169,72 @@ class TestUmountHelperFunctions:
         with patch.object(anyio.Path, "iterdir", side_effect=PermissionError("denied")):
             # Should not raise, just log warning
             await _cleanup_directory(test_dir)
+
+
+class TestUmountMissingKeys:
+    """Tests for umount with missing keys in mount info.
+
+    Bug: When squashfs_mount or upper_dir keys are missing from mount info,
+    the code raises KeyError instead of UmountError.
+    """
+
+    @pytest.mark.xfail(
+        reason="Bug: KeyError instead of UmountError when squashfs_mount key is missing",
+        strict=True,
+    )
+    async def test_umount_missing_squashfs_mount_key(self, tmp_path) -> None:
+        """Umount raises UmountError when squashfs_mount key is missing."""
+        mount_dir = anyio.Path(tmp_path) / "mounted"
+        await mount_dir.mkdir()
+
+        # Create mount info without squashfs_mount key
+        mount_info = mount_dir / ".psi-mount-info"
+        mount_info_content = f"{{'upper_dir': '{tmp_path}/upper', 'work_dir': '{tmp_path}/work'}}"
+        await mount_info.write_text(mount_info_content)
+
+        with pytest.raises(UmountError):
+            await umount(mount_dir)
+
+    @pytest.mark.xfail(
+        reason="Bug: KeyError instead of UmountError when upper_dir key is missing", strict=True
+    )
+    async def test_umount_missing_upper_dir_key(self, tmp_path) -> None:
+        """Umount raises UmountError when upper_dir key is missing."""
+        mount_dir = anyio.Path(tmp_path) / "mounted"
+        await mount_dir.mkdir()
+
+        # Create mount info without upper_dir key
+        mount_info = mount_dir / ".psi-mount-info"
+        mount_info_content = (
+            f"{{'squashfs_mount': '{tmp_path}/squashfs', 'work_dir': '{tmp_path}/work'}}"
+        )
+        await mount_info.write_text(mount_info_content)
+
+        with pytest.raises(UmountError):
+            await umount(mount_dir)
+
+
+class TestCleanupDirectoryReadOnlyFiles:
+    """Tests for _cleanup_directory with read-only files."""
+
+    async def test_cleanup_directory_with_read_only_files(self, tmp_path) -> None:
+        """_cleanup_directory handles read-only files gracefully."""
+        from psi_agent.workspace.umount.api import _cleanup_directory
+
+        test_dir = anyio.Path(tmp_path) / "test_dir"
+        await test_dir.mkdir()
+
+        # Create a read-only file
+        test_file = test_dir / "readonly.txt"
+        await test_file.write_text("read-only content")
+
+        # Make file read-only
+        import os
+
+        os.chmod(str(test_file), 0o444)
+
+        # _cleanup_directory should handle this gracefully (logs warning)
+        await _cleanup_directory(test_dir)
+
+        # Directory may or may not be fully removed depending on permissions,
+        # but the function should not raise an exception

--- a/tests/workspace/test_umount_cli.py
+++ b/tests/workspace/test_umount_cli.py
@@ -1,0 +1,30 @@
+"""Tests for umount CLI module."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from psi_agent.workspace.umount.cli import Umount, main
+
+
+class TestUmountCliCall:
+    """Tests for Umount CLI __call__ method."""
+
+    @patch("psi_agent.workspace.umount.cli.asyncio.run")
+    @patch("psi_agent.workspace.umount.cli.umount")
+    def test_call_invokes_umount_api(self, mock_umount: AsyncMock, mock_run: MagicMock) -> None:
+        """Umount.__call__ calls the umount API function."""
+        cli = Umount(mount_point="/tmp/mounted")
+        cli()
+
+        mock_run.assert_called_once()
+
+
+class TestUmountCliMain:
+    """Tests for Umount CLI main function."""
+
+    @patch("psi_agent.workspace.umount.cli.tyro.cli")
+    def test_main_calls_tyro(self, mock_cli: MagicMock) -> None:
+        """main calls tyro.cli with Umount class."""
+        main()
+        mock_cli.assert_called_once_with(Umount)

--- a/tests/workspace/test_unpack.py
+++ b/tests/workspace/test_unpack.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from unittest.mock import AsyncMock, patch
+
 import anyio
 import pytest
 
@@ -50,3 +52,90 @@ class TestUnpack:
 
         with pytest.raises(UnpackError, match="not a file"):
             await unpack(input_dir, output_dir)
+
+
+class TestUnpackCorruptFile:
+    """Tests for unpack with corrupt input file."""
+
+    async def test_unpack_corrupt_file_raises_unpack_error(self, tmp_path) -> None:
+        """Unpack raises UnpackError when unsquashfs fails on corrupt file."""
+        workspace = anyio.Path(tmp_path)
+        corrupt_file = workspace / "corrupt.squashfs"
+        await corrupt_file.write_bytes(b"not a valid squashfs file")
+
+        output_dir = workspace / "output"
+
+        with patch("asyncio.create_subprocess_exec") as mock_exec:
+            mock_process = AsyncMock()
+            mock_process.communicate.return_value = (b"", b"read_fs: failed to read squashfs")
+            mock_process.returncode = 1
+            mock_exec.return_value = mock_process
+
+            with pytest.raises(UnpackError, match="unsquashfs failed"):
+                await unpack(corrupt_file, output_dir)
+
+
+class TestUnpackEmptyFile:
+    """Tests for unpack with empty input file."""
+
+    async def test_unpack_empty_file_raises_unpack_error(self, tmp_path) -> None:
+        """Unpack raises UnpackError when unsquashfs fails on empty file."""
+        workspace = anyio.Path(tmp_path)
+        empty_file = workspace / "empty.squashfs"
+        await empty_file.write_bytes(b"")
+
+        output_dir = workspace / "output"
+
+        with patch("asyncio.create_subprocess_exec") as mock_exec:
+            mock_process = AsyncMock()
+            mock_process.communicate.return_value = (b"", b"Failed to read squashfs superblock")
+            mock_process.returncode = 1
+            mock_exec.return_value = mock_process
+
+            with pytest.raises(UnpackError, match="unsquashfs failed"):
+                await unpack(empty_file, output_dir)
+
+
+class TestUnpackExistingOutputDir:
+    """Tests for unpack with existing output directory."""
+
+    async def test_unpack_existing_output_dir_succeeds(self, tmp_path) -> None:
+        """Unpack succeeds when output directory already exists."""
+        workspace = anyio.Path(tmp_path)
+        input_file = workspace / "test.squashfs"
+        await input_file.write_bytes(b"fake squashfs")
+
+        output_dir = workspace / "output"
+        await output_dir.mkdir()
+        await (output_dir / "existing.txt").write_text("existing content")
+
+        with patch("asyncio.create_subprocess_exec") as mock_exec:
+            mock_process = AsyncMock()
+            mock_process.communicate.return_value = (b"", b"")
+            mock_process.returncode = 0
+            mock_exec.return_value = mock_process
+
+            # Should not raise - output dir already existing is fine
+            await unpack(input_file, output_dir)
+
+            mock_exec.assert_called_once()
+
+
+class TestUnpackError:
+    """Tests for UnpackError exception class."""
+
+    def test_unpack_error_message_preservation(self) -> None:
+        """UnpackError preserves the error message."""
+        error = UnpackError("Test error message")
+        assert str(error) == "Test error message"
+
+    def test_unpack_error_inheritance(self) -> None:
+        """UnpackError inherits from Exception."""
+        error = UnpackError("Test")
+        assert isinstance(error, Exception)
+
+    def test_unpack_error_with_unsquashfs_message(self) -> None:
+        """UnpackError preserves unsquashfs error details."""
+        error = UnpackError("unsquashfs failed: corrupt filesystem")
+        assert "unsquashfs" in str(error)
+        assert "corrupt filesystem" in str(error)

--- a/tests/workspace/test_unpack_cli.py
+++ b/tests/workspace/test_unpack_cli.py
@@ -1,0 +1,30 @@
+"""Tests for unpack CLI module."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from psi_agent.workspace.unpack.cli import Unpack, main
+
+
+class TestUnpackCliCall:
+    """Tests for Unpack CLI __call__ method."""
+
+    @patch("psi_agent.workspace.unpack.cli.asyncio.run")
+    @patch("psi_agent.workspace.unpack.cli.unpack")
+    def test_call_invokes_unpack_api(self, mock_unpack: AsyncMock, mock_run: MagicMock) -> None:
+        """Unpack.__call__ calls the unpack API function."""
+        cli = Unpack(input_file="/tmp/workspace.squashfs", output_dir="/tmp/workspace")
+        cli()
+
+        mock_run.assert_called_once()
+
+
+class TestUnpackCliMain:
+    """Tests for Unpack CLI main function."""
+
+    @patch("psi_agent.workspace.unpack.cli.tyro.cli")
+    def test_main_calls_tyro(self, mock_cli: MagicMock) -> None:
+        """main calls tyro.cli with Unpack class."""
+        main()
+        mock_cli.assert_called_once_with(Unpack)


### PR DESCRIPTION
## Summary
- Add error path and edge case tests across all modules: AI clients (OpenAI, Anthropic), translator, session runner/server, schedule executor, manifest validation, workspace operations, channel SSE/content, and Telegram bot
- Add CLI test files for all workspace commands (pack, unpack, mount, umount, snapshot)
- Identify 4 known bugs marked with `pytest.mark.xfail`
- Fix all test runtime warnings by properly cleaning up async resources:
  - Patch `ReplClient.__aenter__`/`__aexit__` to prevent real `aiohttp.ClientSession` creation
  - Make `tyro.cli` mock return no-op callable (`MagicMock(return_value=None)`) to prevent coroutine creation
  - Add `_run_coroutine_silently` side effect to `mock_run` to close unawaited coroutines via `coro.close()`
  - Fix `Repl` class name in test import (was incorrectly `Cli`)
- Archive OpenSpec changes and sync delta specs to main specs

## Test plan
- [x] `uv run pytest -W error::RuntimeWarning` — 952 passed, 0 in-test RuntimeWarning
- [x] `uv run ruff check` + `uv run ruff format --check` — clean
- [x] `uv run ty check` — no new errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)