### PR TITLE
Update Python dependencies to latest versions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,11 +9,11 @@ authors = [{ name = "Hao Zhang", email = "hzhangxyz@outlook.com" }]
 urls = { Repository = "https://github.com/psi-agent/psi-agent", Homepage = "https://github.com/psi-agent/psi-agent", Documentation = "https://github.com/psi-agent/psi-agent#readme" }
 dependencies = [
     "aiohttp>=3.13.5",
-    "anthropic>=0.97.0",
+    "anthropic>=0.100.0",
     "anyio>=4.13.0",
     "croniter>=6.2.2",
     "loguru>=0.7.3",
-    "openai>=2.33.0",
+    "openai>=2.36.0",
     "platformdirs>=4.9.6",
     "prompt-toolkit>=3.0.52",
     "python-telegram-bot>=22.7",

--- a/uv.lock
+++ b/uv.lock
@@ -85,7 +85,7 @@ wheels = [
 
 [[package]]
 name = "anthropic"
-version = "0.98.1"
+version = "0.100.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -97,9 +97,9 @@ dependencies = [
     { name = "sniffio" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/24/60/a9e4426dfe594e5eec8a9757d48e3d8dcf529a0a35a4fc8aefa352bd95fe/anthropic-0.98.1.tar.gz", hash = "sha256:62205edec42f5877df63d58be8e9443843d3e032215836e228fba1f59514a433", size = 725085, upload-time = "2026-05-04T21:40:39.496Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9c/2d/24caf0ff727cba2ed863925017c8f93463a2ea6224a0efe5626e672bc3d2/anthropic-0.100.0.tar.gz", hash = "sha256:650dee9e023afb16395939ee4104bbc21f966b380210119fb91122c12099c79a", size = 758255, upload-time = "2026-05-06T15:07:13.578Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9b/6f/7f7f80f714e6de0784518f1999f71fd632076aefd3e22fe0ccd27ca9571f/anthropic-0.98.1-py3-none-any.whl", hash = "sha256:107ebf954415382fdcea6a94f9cf334a53199ad64794403590dc55366cefcc28", size = 699604, upload-time = "2026-05-04T21:40:41.311Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/a0/c775c59ab9445ecabb57ef3d5c24027de060139189a9e312ef9ef889a665/anthropic-0.100.0-py3-none-any.whl", hash = "sha256:1c15769efa15d8fd5c1ebf900e25c57e3ee540f8554a29aa56e4edefffe2951d", size = 753596, upload-time = "2026-05-06T15:07:12.106Z" },
 ]
 
 [[package]]
@@ -401,7 +401,7 @@ wheels = [
 
 [[package]]
 name = "openai"
-version = "2.34.0"
+version = "2.36.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -413,9 +413,9 @@ dependencies = [
     { name = "tqdm" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/7b/89/f1e78f5f828f4e97a6ebca8f45c6b35667da12b074ac490dc8362b882279/openai-2.34.0.tar.gz", hash = "sha256:828b4efcbb126352c2b5eb97d33ae890c92a71ab72511aefc1b7fe64aeccb07b", size = 759556, upload-time = "2026-05-04T17:34:08.721Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f4/a1/4d5e84cf51720fc1526cc49e10ac1961abcccb55b0efb3d970db1e9a2728/openai-2.36.0.tar.gz", hash = "sha256:139dea0edd2f1b30c33d46ae1a6929e03906254140318e4608e98fe8c566f2e7", size = 753003, upload-time = "2026-05-07T17:33:17.075Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f2/40/f090499f10514515081d09cb9da09f25b821eb20497e9423afe4f07b4ecf/openai-2.34.0-py3-none-any.whl", hash = "sha256:c996a71b1a210f3569844572ad4c609307e978515fb76877cf449b72596e549e", size = 1316535, upload-time = "2026-05-04T17:34:06.773Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/1c/5d43735b2553baae2a5e899dcbcd0670a86930d993184d72ca909bf11c9b/openai-2.36.0-py3-none-any.whl", hash = "sha256:143f6194b548dbc2c921af1f1b03b9f14c85fed8a75b5b516f5bcc11a2a50c63", size = 1302361, upload-time = "2026-05-07T17:33:15.063Z" },
 ]
 
 [[package]]
@@ -529,11 +529,11 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "aiohttp", specifier = ">=3.13.5" },
-    { name = "anthropic", specifier = ">=0.97.0" },
+    { name = "anthropic", specifier = ">=0.100.0" },
     { name = "anyio", specifier = ">=4.13.0" },
     { name = "croniter", specifier = ">=6.2.2" },
     { name = "loguru", specifier = ">=0.7.3" },
-    { name = "openai", specifier = ">=2.33.0" },
+    { name = "openai", specifier = ">=2.36.0" },
     { name = "platformdirs", specifier = ">=4.9.6" },
     { name = "prompt-toolkit", specifier = ">=3.0.52" },
     { name = "python-telegram-bot", specifier = ">=22.7" },


### PR DESCRIPTION
This PR updates the python dependencies in pyproject.toml to their latest versions on PyPI.

Changes:
- Updated `anthropic>=0.97.0` to `anthropic>=0.100.0`
- Updated `openai>=2.33.0` to `openai>=2.36.0`
- Synchronized `uv.lock` using `uv sync`

Verification:
- Ran `uv run pytest`. All tests passed except for 4 pre-existing failures related to missing `mksquashfs` on the system, which are unrelated to these changes.

---
*PR created automatically by Jules for task [2982093093938232701](https://jules.google.com/task/2982093093938232701) started by @hzhangxyz*